### PR TITLE
Makefile: suggests install.tools

### DIFF
--- a/.tool/lint
+++ b/.tool/lint
@@ -4,11 +4,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ ! $(command -v gometalinter) ]; then
-	go get -u github.com/alecthomas/gometalinter
-	gometalinter --update --install
-fi
-
 for d in $(find . -type d -not -iwholename '*.git*' -a -not -iname '.tool' -a -not -iwholename '*vendor*'); do
 	gometalinter \
 		--exclude='error return value not checked.*(Close|Log|Print).*\(errcheck\)$' \

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ help:
 	@echo " * 'lint' - Execute the source code linter"
 
 lint: ${OCID_LINK}
+	@which gometalinter > /dev/null 2>/dev/null || (echo "ERROR: gometalinter not found. Consider 'make install.tools' target" && false)
 	@echo "checking lint"
 	@./.tool/lint
 


### PR DESCRIPTION
Close #68 

@rhatdan we can't install automatically because it will pollute the project's GOPATH - I'm providing an hint to run `make install.tools` instead

Signed-off-by: Antonio Murdaca <runcom@redhat.com>