### PR TITLE
(WIP) Remove redundant build steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,11 @@ sudo: required
 services:
   - docker
 
+install:
+  - make install.tools
+
 before_script:
   - export PATH=$HOME/gopath/bin:$PATH
-
-before_install:
-  - make install.tools
-  - go get -u github.com/alecthomas/gometalinter
-  - gometalinter --install --update
-
-install: true
 
 script:
   - make .gitvalidation


### PR DESCRIPTION
`make install.tools` already installs `gometalinter` (as can be seen in
the logs), so the subsequent `go get` steps are unnecessary.

This change also reorders the build directives according to execution
order: https://docs.travis-ci.com/user/customizing-the-build#The-Build-Lifecycle
and replaces the "before_install" step with an override of the default
"install" procedure (which we were suppressing anyway with install: true)

Signed-off-by: Jonathan Yu <jawnsy@redhat.com>