### PR TITLE
Fixes Makefile so CFLAGS/LIBS are accepted as a make parameter

### DIFF
--- a/conmon/Makefile
+++ b/conmon/Makefile
@@ -1,8 +1,8 @@
 src = $(wildcard *.c)
 obj = $(src:.c=.o)
 
-LIBS = $(shell pkg-config --libs glib-2.0)
-CFLAGS = -Wall -Wextra $(shell pkg-config --cflags glib-2.0)
+override LIBS += $(shell pkg-config --libs glib-2.0)
+override CFLAGS += -Wall -Wextra $(shell pkg-config --cflags glib-2.0)
 
 conmon: $(obj)
 	$(CC) -o $@ $^ $(LIBS)


### PR DESCRIPTION
It should be possible to run make with compilation CFLAGS / LIBS
paramaters. For instance, 'make CFLAGS="-g3 -O0"'. Fixes #87

Signed-off-by: Alvaro Lopez Ortega <alvaro@gnu.org>