### PR TITLE
test: add more debugging output

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -14,8 +14,8 @@ function teardown() {
 
 	start_ocid
 	run ocic pod create --config "$TESTDATA"/sandbox_config.json
-	[ "$status" -eq 0 ]
 	echo "$output"
+	[ "$status" -eq 0 ]
 	pod_id="$output"
 	run ocic ctr create --config "$TESTDATA"/container_redis.json --pod "$pod_id"
 	echo "$output"
@@ -45,8 +45,8 @@ function teardown() {
 
 	start_ocid
 	run ocic pod create --config "$TESTDATA"/sandbox_config.json
-	[ "$status" -eq 0 ]
 	echo "$output"
+	[ "$status" -eq 0 ]
 	pod_id="$output"
 	run ocic pod list
 	echo "$output"

--- a/test/pod.bats
+++ b/test/pod.bats
@@ -15,20 +15,25 @@ function teardown() {
 
 	start_ocid
 	run ocic pod create --config "$TESTDATA"/sandbox_config.json
-	[ "$status" -eq 0 ]
 	echo "$output"
+	[ "$status" -eq 0 ]
 	id="$output"
 	run ocic pod stop --id "$id"
+	echo "$output"
 	[ "$status" -eq 0 ]
+	echo "$output"
 	run ocic pod remove --id "$id"
+	echo "$output"
 	[ "$status" -eq 0 ]
 	run ocic pod create --config "$TESTDATA"/sandbox_config.json
-	[ "$status" -eq 0 ]
 	echo "$output"
+	[ "$status" -eq 0 ]
 	id="$output"
 	run ocic pod stop --id "$id"
+	echo "$output"
 	[ "$status" -eq 0 ]
 	run ocic pod remove --id "$id"
+	echo "$output"
 	[ "$status" -eq 0 ]
 	stop_ocid
 	cleanup_pods
@@ -42,8 +47,8 @@ function teardown() {
 
 	start_ocid
 	run ocic pod create --config "$TESTDATA"/sandbox_config.json
-	[ "$status" -eq 0 ]
 	echo "$output"
+	[ "$status" -eq 0 ]
 	pod_id="$output"
 	run ocic ctr create --config "$TESTDATA"/container_redis.json --pod "$pod_id"
 	echo "$output"

--- a/test/runtimeversion.bats
+++ b/test/runtimeversion.bats
@@ -9,6 +9,7 @@ function teardown() {
 @test "ocic runtimeversion" {
 	start_ocid
 	ocic runtimeversion
+	echo "$output"
 	[ "$status" -eq 0 ]
 	stop_ocid
 }


### PR DESCRIPTION
In several places, we previously didn't output the $output of the
failing command, leading to confusion when debugging. A proper fix is to
alias oci{c,d} in helpers.sh like runC does, but that can come later.

Signed-off-by: Aleksa Sarai <asarai@suse.de>