### PR TITLE
Refactor to separate container IDs from container names

### DIFF
--- a/.tool/lint
+++ b/.tool/lint
@@ -14,6 +14,7 @@ for d in $(find . -type d -not -iwholename '*.git*' -a -not -iname '.tool' -a -n
 		--disable=gotype \
 		--disable=gas \
 		--cyclo-over=50 \
+		--dupl-threshold=100 \
 		--tests \
 		--deadline=30s "${d}"
 done

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -208,6 +208,7 @@ func (r *Runtime) ContainerStatus(c *Container) *ContainerState {
 
 // Container respresents a runtime container.
 type Container struct {
+	id         string
 	name       string
 	bundlePath string
 	logPath    string
@@ -243,6 +244,11 @@ func NewContainer(name string, bundlePath string, logPath string, labels map[str
 // Name returns the name of the container.
 func (c *Container) Name() string {
 	return c.name
+}
+
+// ID returns the id of the container.
+func (c *Container) ID() string {
+	return c.id
 }
 
 // BundlePath returns the bundlePath of the container.

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -229,8 +229,9 @@ type ContainerState struct {
 }
 
 // NewContainer creates a container object.
-func NewContainer(name string, bundlePath string, logPath string, labels map[string]string, sandbox string, terminal bool) (*Container, error) {
+func NewContainer(id string, name string, bundlePath string, logPath string, labels map[string]string, sandbox string, terminal bool) (*Container, error) {
 	c := &Container{
+		id:         id,
 		name:       name,
 		bundlePath: bundlePath,
 		logPath:    logPath,

--- a/server/container.go
+++ b/server/container.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/kubernetes-incubator/cri-o/oci"
 	"github.com/kubernetes-incubator/cri-o/utils"
 	"github.com/opencontainers/runtime-tools/generate"
@@ -22,6 +23,21 @@ const (
 	// ContainerStateStopped represents the stopped state of a container
 	ContainerStateStopped = "stopped"
 )
+
+func (s *Server) generateContainerIDandName(podName string, name string, attempt uint32) (string, string, error) {
+	var (
+		err error
+		id  = stringid.GenerateNonCryptoID()
+	)
+	nameStr = fmt.Sprintf("%s-%s-%v", podName, name, attempt)
+	if name == "infra" {
+		nameStr := fmt.Sprintf("%s-%s", podName, name)
+	}
+	if name, err = s.reserveContainerName(id, nameStr); err != nil {
+		return "", "", err
+	}
+	return id, name, err
+}
 
 // CreateContainer creates a new container in specified PodSandbox
 func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*pb.CreateContainerResponse, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -63,7 +63,7 @@ func (s *Server) loadSandbox(id string) error {
 		containers: oci.NewMemoryStore(),
 	})
 	sandboxPath := filepath.Join(s.sandboxDir, id)
-	scontainer, err := oci.NewContainer(m.Annotations["ocid/container_name"], sandboxPath, sandboxPath, labels, id, false)
+	scontainer, err := oci.NewContainer(m.Annotations["ocid/container_id"], m.Annotations["ocid/container_name"], sandboxPath, sandboxPath, labels, id, false)
 	if err != nil {
 		return err
 	}
@@ -217,13 +217,13 @@ func (s *Server) addContainer(c *oci.Container) {
 	sandbox := s.state.sandboxes[c.Sandbox()]
 	// TODO(runcom): handle !ok above!!! otherwise it panics!
 	sandbox.addContainer(c)
-	s.state.containers.Add(c.Name(), c)
+	s.state.containers.Add(c.ID(), c)
 	s.stateLock.Unlock()
 }
 
-func (s *Server) getContainer(name string) *oci.Container {
+func (s *Server) getContainer(id string) *oci.Container {
 	s.stateLock.Lock()
-	c := s.state.containers.Get(name)
+	c := s.state.containers.Get(id)
 	s.stateLock.Unlock()
 	return c
 }
@@ -232,6 +232,6 @@ func (s *Server) removeContainer(c *oci.Container) {
 	s.stateLock.Lock()
 	sandbox := s.state.sandboxes[c.Sandbox()]
 	sandbox.removeContainer(c)
-	s.state.containers.Delete(c.Name())
+	s.state.containers.Delete(c.ID())
 	s.stateLock.Unlock()
 }


### PR DESCRIPTION
This PR introduces IDs for containers separating them from container names similar to what we have for pods. I will add support for short IDs in a follow on PR.

@runcom PTAL