### PR TITLE
Use container ID as the directory name

### DIFF
--- a/server/container.go
+++ b/server/container.go
@@ -74,7 +74,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 	}
 
 	// containerDir is the dir for the container bundle.
-	containerDir := filepath.Join(s.runtime.ContainerDir(), name)
+	containerDir := filepath.Join(s.runtime.ContainerDir(), containerID)
 
 	if _, err = os.Stat(containerDir); err == nil {
 		return nil, fmt.Errorf("container (%s) already exists", containerDir)


### PR DESCRIPTION
@runcom Bug from the refactor. Remove already uses the container ID.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>