### PR TITLE
fixes issue with ubuntu build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OCID_INSTANCE := ocid_dev
 SYSTEM_GOPATH := ${GOPATH}
 PREFIX ?= ${DESTDIR}/usr
 INSTALLDIR=${PREFIX}/bin
-GO_MD2MAN ?= $(shell command -v go-md2man)
+GO_MD2MAN ?= $(shell which go-md2man)
 export GOPATH := ${CURDIR}/vendor
 
 default: help


### PR DESCRIPTION
When doing make install on ubuntu I'm getting the following error..
mike@mike-VirtualBox:~/go/src/github.com/kubernetes-incubator/cri-o$ sudo make docs
make: command: Command not found
/bin/sh: 1: Syntax error: "in" unexpected
Makefile:80: recipe for target 'docs/ocid.8' failed
make: [docs/ocid.8] Error 2 (ignored)

So I'd like to change from using `command -v` to `which` to identify the path to go-md2man.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>