### PR TITLE
Container state fixes

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -20,6 +20,15 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const (
+	// ContainerStateCreated represents the created state of a container
+	ContainerStateCreated = "created"
+	// ContainerStateRunning represents the running state of a container
+	ContainerStateRunning = "running"
+	// ContainerStateStopped represents the stopped state of a container
+	ContainerStateStopped = "stopped"
+)
+
 // New creates a new Runtime with options provided
 func New(runtimePath string, containerDir string, conmonPath string) (*Runtime, error) {
 	r := &Runtime{
@@ -176,7 +185,7 @@ func (r *Runtime) UpdateStatus(c *Container) error {
 		return fmt.Errorf("failed to decode container status for %s: %s", c.name, err)
 	}
 
-	if c.state.Status == "stopped" {
+	if c.state.Status == ContainerStateStopped {
 		exitFilePath := filepath.Join(c.bundlePath, "exit")
 		fi, err := os.Stat(exitFilePath)
 		if err != nil {

--- a/server/container.go
+++ b/server/container.go
@@ -17,15 +17,6 @@ import (
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
 
-const (
-	// ContainerStateCreated represents the created state of a container
-	ContainerStateCreated = "created"
-	// ContainerStateRunning represents the running state of a container
-	ContainerStateRunning = "running"
-	// ContainerStateStopped represents the stopped state of a container
-	ContainerStateStopped = "stopped"
-)
-
 func (s *Server) generateContainerIDandName(podName string, name string, attempt uint32) (string, string, error) {
 	var (
 		err error
@@ -383,7 +374,7 @@ func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerReq
 	}
 
 	cState := s.runtime.ContainerStatus(c)
-	if cState.Status == ContainerStateCreated || cState.Status == ContainerStateRunning {
+	if cState.Status == oci.ContainerStateCreated || cState.Status == oci.ContainerStateRunning {
 		if err := s.runtime.StopContainer(c); err != nil {
 			return nil, fmt.Errorf("failed to stop container %s: %v", c.ID(), err)
 		}
@@ -428,11 +419,11 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 		}
 
 		switch cState.Status {
-		case ContainerStateCreated:
+		case oci.ContainerStateCreated:
 			rState = pb.ContainerState_CREATED
-		case ContainerStateRunning:
+		case oci.ContainerStateRunning:
 			rState = pb.ContainerState_RUNNING
-		case ContainerStateStopped:
+		case oci.ContainerStateStopped:
 			rState = pb.ContainerState_EXITED
 		}
 		c.State = &rState
@@ -467,17 +458,17 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 	rStatus := pb.ContainerState_UNKNOWN
 
 	switch cState.Status {
-	case ContainerStateCreated:
+	case oci.ContainerStateCreated:
 		rStatus = pb.ContainerState_CREATED
 		created := cState.Created.Unix()
 		csr.Status.CreatedAt = int64Ptr(created)
-	case ContainerStateRunning:
+	case oci.ContainerStateRunning:
 		rStatus = pb.ContainerState_RUNNING
 		created := cState.Created.Unix()
 		csr.Status.CreatedAt = int64Ptr(created)
 		started := cState.Started.Unix()
 		csr.Status.StartedAt = int64Ptr(started)
-	case ContainerStateStopped:
+	case oci.ContainerStateStopped:
 		rStatus = pb.ContainerState_EXITED
 		created := cState.Created.Unix()
 		csr.Status.CreatedAt = int64Ptr(created)

--- a/server/sandbox.go
+++ b/server/sandbox.go
@@ -286,7 +286,7 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 			}
 		}
 		cStatus := s.runtime.ContainerStatus(c)
-		if cStatus.Status != "stopped" {
+		if cStatus.Status != oci.ContainerStateStopped {
 			if err := s.runtime.StopContainer(c); err != nil {
 				return nil, fmt.Errorf("failed to stop container %s in sandbox %s: %v", c.Name(), sandboxID, err)
 			}
@@ -324,7 +324,7 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 		}
 
 		cState := s.runtime.ContainerStatus(c)
-		if cState.Status == ContainerStateCreated || cState.Status == ContainerStateRunning {
+		if cState.Status == oci.ContainerStateCreated || cState.Status == oci.ContainerStateRunning {
 			if err := s.runtime.StopContainer(c); err != nil {
 				return nil, fmt.Errorf("failed to stop container %s: %v", c.Name(), err)
 			}
@@ -400,7 +400,7 @@ func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusR
 	}
 
 	rStatus := pb.PodSandBoxState_NOTREADY
-	if cState.Status == ContainerStateRunning {
+	if cState.Status == oci.ContainerStateRunning {
 		rStatus = pb.PodSandBoxState_READY
 	}
 
@@ -436,7 +436,7 @@ func (s *Server) ListPodSandbox(context.Context, *pb.ListPodSandboxRequest) (*pb
 		cState := s.runtime.ContainerStatus(podInfraContainer)
 		created := cState.Created.Unix()
 		rStatus := pb.PodSandBoxState_NOTREADY
-		if cState.Status == ContainerStateRunning {
+		if cState.Status == oci.ContainerStateRunning {
 			rStatus = pb.PodSandBoxState_READY
 		}
 


### PR DESCRIPTION
Move Container State constants to oci package
and fixup where strings were used instead of
the state constants

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>