### PR TITLE
Can't use SELinux separation when sharing the host pid or ipc namespace

### DIFF
--- a/server/sandbox.go
+++ b/server/sandbox.go
@@ -166,9 +166,12 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, err
 	}
 
-	processLabel, mountLabel, err = getSELinuxLabels(nil)
-	if err != nil {
-		return nil, err
+	// Don't use SELinux separation with Host Pid or IPC Namespace,
+	if !req.GetConfig().GetLinux().GetNamespaceOptions().GetHostPid() && !req.GetConfig().GetLinux().GetNamespaceOptions().GetHostIpc() {
+		processLabel, mountLabel, err = getSELinuxLabels(nil)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	containerID, containerName, err := s.generateContainerIDandName(name, "infra", 0)


### PR DESCRIPTION
SELinux will cause breakage when sharing these namespaces.  For example it
will block processes inside of the container from looking at the hosts /proc
in hosts Pid Namespace.  It will also block all access to semaphores and
shared memory defined outside of the pod.

Signed-off-by: Dan Walsh <dwalsh@redhat.com>