### PR TITLE
server: containers restore

### DIFF
--- a/server/container.go
+++ b/server/container.go
@@ -422,9 +422,10 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 		cState := s.runtime.ContainerStatus(ctr)
 		created := cState.Created.Unix()
 		rState := pb.ContainerState_UNKNOWN
+		cID := ctr.ID()
 
 		c := &pb.Container{
-			Id:           &cState.ID,
+			Id:           &cID,
 			PodSandboxId: &podSandboxID,
 			CreatedAt:    int64Ptr(created),
 		}

--- a/server/container.go
+++ b/server/container.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -204,7 +205,6 @@ func (s *Server) createSandboxContainer(containerID string, containerName string
 			specgen.AddAnnotation(k, v)
 		}
 	}
-
 	if containerConfig.GetPrivileged() {
 		specgen.SetupPrivileged(true)
 	}
@@ -305,7 +305,18 @@ func (s *Server) createSandboxContainer(containerID string, containerName string
 		}
 	}
 
-	if err := specgen.SaveToFile(filepath.Join(containerDir, "config.json")); err != nil {
+	specgen.AddAnnotation("ocid/name", containerName)
+	specgen.AddAnnotation("ocid/sandbox_id", sb.id)
+	specgen.AddAnnotation("ocid/log_path", logPath)
+	specgen.AddAnnotation("ocid/tty", fmt.Sprintf("%v", containerConfig.GetTty()))
+	labelsJSON, err := json.Marshal(labels)
+	if err != nil {
+		return nil, err
+	}
+
+	specgen.AddAnnotation("ocid/labels", string(labelsJSON))
+
+	if err = specgen.SaveToFile(filepath.Join(containerDir, "config.json")); err != nil {
 		return nil, err
 	}
 
@@ -321,7 +332,7 @@ func (s *Server) createSandboxContainer(containerID string, containerName string
 
 	// TODO: copy the rootfs into the bundle.
 	// Currently, utils.CreateFakeRootfs is used to populate the rootfs.
-	if err := utils.CreateFakeRootfs(containerDir, image); err != nil {
+	if err = utils.CreateFakeRootfs(containerDir, image); err != nil {
 		return nil, err
 	}
 

--- a/server/sandbox.go
+++ b/server/sandbox.go
@@ -173,6 +173,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		if err != nil {
 			return nil, err
 		}
+		g.SetProcessSelinuxLabel(processLabel)
 	}
 
 	containerID, containerName, err := s.generateContainerIDandName(name, "infra", 0)
@@ -353,6 +354,10 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 
 		s.releaseContainerName(c.Name())
 		s.removeContainer(c)
+	}
+
+	if err := label.UnreserveLabel(sb.processLabel); err != nil {
+		return nil, err
 	}
 
 	// Remove the files related to the sandbox

--- a/server/server.go
+++ b/server/server.go
@@ -142,7 +142,7 @@ func (s *Server) loadSandbox(id string) error {
 
 func (s *Server) restore() {
 	sandboxDir, err := ioutil.ReadDir(s.sandboxDir)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		logrus.Warnf("could not read sandbox directory %s: %v", sandboxDir, err)
 	}
 	for _, v := range sandboxDir {
@@ -154,7 +154,7 @@ func (s *Server) restore() {
 		}
 	}
 	containerDir, err := ioutil.ReadDir(s.runtime.ContainerDir())
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		logrus.Warnf("could not read container directory %s: %v", s.runtime.ContainerDir(), err)
 	}
 	for _, v := range containerDir {

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -33,6 +33,7 @@ function teardown() {
 	run ocic pod remove --id "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
+	cleanup_ctrs
 	cleanup_pods
 	stop_ocid
 }
@@ -103,6 +104,7 @@ function teardown() {
 	run ocic ctr list
 	echo "$output"
 	[ "$status" -eq 0 ]
+	cleanup_ctrs
 	cleanup_pods
 	stop_ocid
 }

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -33,8 +33,8 @@ function teardown() {
 	run ocic pod remove --id "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	stop_ocid
 	cleanup_pods
+	stop_ocid
 }
 
 @test "ctr lifecycle" {
@@ -103,6 +103,6 @@ function teardown() {
 	run ocic ctr list
 	echo "$output"
 	[ "$status" -eq 0 ]
-	stop_ocid
 	cleanup_pods
+	stop_ocid
 }

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -76,6 +76,19 @@ function start_ocid() {
 	wait_until_reachable
 }
 
+function cleanup_ctrs() {
+	run ocic ctr list --quiet
+	if [ "$status" -eq 0 ]; then
+		if [ "$output" != "" ]; then
+			printf '%s\n' "$output" | while IFS= read -r line
+			do
+			   ocic ctr stop --id "$line"
+			   ocic ctr remove --id "$line"
+			done
+		fi
+	fi
+}
+
 function cleanup_pods() {
 	run ocic pod list --quiet
 	if [ "$status" -eq 0 ]; then
@@ -92,7 +105,7 @@ function cleanup_pods() {
 # Stop ocid.
 function stop_ocid() {
 	if [ "$OCID_PID" != "" ]; then
-		kill -9 "$OCID_PID" >/dev/null 2>&1
+		kill "$OCID_PID" >/dev/null 2>&1
 	fi
 }
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -77,21 +77,22 @@ function start_ocid() {
 }
 
 function cleanup_pods() {
-	run ocic pod list
+	run ocic pod list --quiet
 	if [ "$status" -eq 0 ]; then
-		printf '%s\n' "$output" | while IFS= read -r line
-		do
-		   pod=$(echo "$line" | sed -e 's/ID: //g')
-		   ocic pod stop --id "$pod"
-		   ocic pod remove --id "$pod"
-		done
+		if [ "$output" != "" ]; then
+			printf '%s\n' "$output" | while IFS= read -r line
+			do
+			   ocic pod stop --id "$line"
+			   ocic pod remove --id "$line"
+			done
+		fi
 	fi
 }
 
 # Stop ocid.
 function stop_ocid() {
 	if [ "$OCID_PID" != "" ]; then
-		kill "$OCID_PID" >/dev/null 2>&1
+		kill -9 "$OCID_PID" >/dev/null 2>&1
 	fi
 }
 

--- a/test/pod.bats
+++ b/test/pod.bats
@@ -35,6 +35,7 @@ function teardown() {
 	run ocic pod remove --id "$id"
 	echo "$output"
 	[ "$status" -eq 0 ]
+	cleanup_ctrs
 	cleanup_pods
 	stop_ocid
 }
@@ -60,6 +61,7 @@ function teardown() {
 	run ocic pod remove --id "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
+	cleanup_ctrs
 	cleanup_pods
 	stop_ocid
 }

--- a/test/pod.bats
+++ b/test/pod.bats
@@ -35,8 +35,8 @@ function teardown() {
 	run ocic pod remove --id "$id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	stop_ocid
 	cleanup_pods
+	stop_ocid
 }
 
 @test "pod remove" {
@@ -60,6 +60,6 @@ function teardown() {
 	run ocic pod remove --id "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	stop_ocid
 	cleanup_pods
+	stop_ocid
 }

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function teardown() {
+	cleanup_test
+}
+
+@test "ocid restore" {
+	# this test requires docker, thus it can't yet be run in a container
+	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
+		skip "cannot yet run this test in a container, use sudo make localintegration"
+	fi
+
+	start_ocid
+	run ocic pod create --config "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	run ocic ctr create --config "$TESTDATA"/container_config.json --pod "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+
+	stop_ocid
+
+	start_ocid
+	run ocic pod list
+	echo "$output"
+	[ "$status" -eq 0 ]
+	#[[ "${output}" == *'${pod_id}'*  ]]
+
+	run ocic ctr list
+	echo "$output"
+	[ "$status" -eq 0 ]
+	#[[ "${output}" == *'${pod_id}'*  ]]
+
+	cleanup_pods
+	stop_ocid
+}

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -29,13 +29,16 @@ function teardown() {
 	run ocic pod list
 	echo "$output"
 	[ "$status" -eq 0 ]
-	#[[ "${output}" == *'${pod_id}'*  ]]
+	[[ "${output}" != "" ]]
+	[[ "${output}" =~ "${pod_id}"  ]]
 
 	run ocic ctr list
 	echo "$output"
 	[ "$status" -eq 0 ]
-	#[[ "${output}" == *'${pod_id}'*  ]]
+	[[ "${output}" != "" ]]
+	[[ "${output}" =~ "${pod_id}"  ]]
 
+	cleanup_ctrs
 	cleanup_pods
 	stop_ocid
 }


### PR DESCRIPTION
Close https://github.com/kubernetes-incubator/cri-o/issues/17
Close #111

Keep in mind this comment https://github.com/kubernetes-incubator/cri-o/issues/17#issuecomment-252249629 meaning we don't have any way right now to fully restore if someone plays with runc directly (we'll address that ofc).

@rhatdan this is also fixing https://github.com/kubernetes-incubator/cri-o/issues/102#issuecomment-252259251 by storing the process label in the sandbox's config.json.

@mrunalp PTAL - I'm writing some tests but won't likely finish soon (this weekend at least), I'll open another PR shortly.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>