### PR TITLE
removing mount from container_redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ sudo make install
 ```
 # ocid --debug
 ```
-If the default --runtime value does not point to your runtime:   
+If the default `--runtime` value does not point to your runtime:   
 ```
 # ocid --runtime $(which runc)
 ```

--- a/test/testdata/container_redis.json
+++ b/test/testdata/container_redis.json
@@ -32,15 +32,6 @@
 			"value": "92d6d93ef2efc91e595c8bf578bf72baff397507"
 		}
 	],
-	"mounts": [
-		{
-			"name": "redis_data",
-			"container_path": "/data",
-			"host_path": "/test/redis-data",
-			"readonly": false,
-			"selinux_relabel": true
-		}
-	],
 	"labels": {
 		"tier": "backend"
 	},


### PR DESCRIPTION
Container will fail to load correctly if you don't have the directory specified by the mount in the config.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>