### PR TITLE
pod/container name should be released when create failed

### DIFF
--- a/server/container.go
+++ b/server/container.go
@@ -93,6 +93,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 	containerDir := filepath.Join(s.runtime.ContainerDir(), containerID)
 	defer func() {
 		if err != nil {
+			s.releaseContainerName(containerName)
 			err1 := os.RemoveAll(containerDir)
 			if err1 != nil {
 				logrus.Warnf("Failed to cleanup container directory: %v")

--- a/server/sandbox.go
+++ b/server/sandbox.go
@@ -104,17 +104,18 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, fmt.Errorf("pod sandbox (%s) already exists", podSandboxDir)
 	}
 
-	if err = os.MkdirAll(podSandboxDir, 0755); err != nil {
-		return nil, err
-	}
-
 	defer func() {
 		if err != nil {
+			s.releasePodName(name)
 			if err2 := os.RemoveAll(podSandboxDir); err2 != nil {
 				logrus.Warnf("couldn't cleanup podSandboxDir %s: %v", podSandboxDir, err2)
 			}
 		}
 	}()
+
+	if err = os.MkdirAll(podSandboxDir, 0755); err != nil {
+		return nil, err
+	}
 
 	// creates a spec Generator with the default spec.
 	g := generate.New()

--- a/server/server.go
+++ b/server/server.go
@@ -192,10 +192,10 @@ func (s *Server) reserveContainerName(id, name string) (string, error) {
 		if err == registrar.ErrNameReserved {
 			id, err := s.ctrNameIndex.Get(name)
 			if err != nil {
-				logrus.Warnf("name %s already reserved for %s", name, id)
+				logrus.Warnf("get reserved name %s failed", name)
 				return "", err
 			}
-			return "", fmt.Errorf("conflict, name %s already reserved", name)
+			return "", fmt.Errorf("conflict, name %s already reserved for %s", name, id)
 		}
 		return "", fmt.Errorf("error reserving name %s", name)
 	}


### PR DESCRIPTION
After container name is reserved, if create failed, name should be released. Neither is podsandbox. 
fix it.

Signed-off-by: Crazykev <crazykev@zju.edu.cn>