### PR TITLE
server/server: skip f no sandbox when restoring containers

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -59,6 +59,7 @@ func (s *Server) loadContainer(id string) error {
 	sb := s.getSandbox(m.Annotations["ocid/sandbox_id"])
 	if sb == nil {
 		logrus.Warnf("could not get sandbox with id %s, skipping", m.Annotations["ocid/sandbox_id"])
+		return nil
 	}
 
 	var tty bool


### PR DESCRIPTION
@mrunalp PTAL fixing the panic you have into https://github.com/kubernetes-incubator/cri-o/pull/115

Signed-off-by: Antonio Murdaca <runcom@redhat.com>