### PR TITLE
README.md: Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ It is currently in active development in the Kubernetes community through the [d
 
 ### Build
 
-`glib2-devel` package on Fedora or ` libglib2.0-dev` on Ubuntu or equivalent is required.
+`glib2-devel` and `glibc-static` packages on Fedora or ` libglib2.0-dev` on Ubuntu or equivalent is required.
 
 
 ```


### PR DESCRIPTION
The 'make binaries' command requires the existence of ibc.a.  On Fedora this file is included in the glibc-static package.  If this is not installed the user will get the error '/usr/bin/ld: cannot find -lc'.  On Ubuntu this is not an issue.  The README was updated to reflect this dependency.