### PR TITLE
Setup proper labeling for runnin test with selinux

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -22,6 +22,11 @@ RUNC_PATH=$(command -v runc || true)
 RUNC_BINARY=${RUNC_PATH:-/usr/local/sbin/runc}
 
 TESTDIR=$(mktemp -d)
+if selinuxenabled; then
+    . /etc/selinux/config
+    filelabel=$(awk -F'"' '/^file.*=.*/ {print $2}' /etc/selinux/${SELINUXTYPE}/contexts/lxc_contexts)
+    chcon -R ${filelabel} $TESTDIR
+fi
 OCID_SOCKET="$TESTDIR/ocid.sock"
 OCID_CONFIG="$TESTDIR/ocid.conf"
 


### PR DESCRIPTION
The rootfs that gets created needs to have an SELinux label that containers
can write to.  Until they get native storage support, this patch will
force the entire storage pool to be labeled in such a way that confined
containers can read/write/execute the content.

Signed-off-by: Dan Walsh <dwalsh@redhat.com>