### PR TITLE
Makefile: fix remove docs in make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ clean:
 	rm -f ocid.conf
 	rm -f ocic ocid
 	rm -f ${OCID_LINK}
-	rm -f docs/*.1 docs/*.5{,.gz} docs/*.8{,.gz}
+	rm -f docs/*.5 docs/*.5.gz docs/*.8 docs/*.8.gz
 	find . -name \*~ -delete
 	find . -name \#\* -delete
 	make -C conmon clean


### PR DESCRIPTION
On Ubuntu, /bin/sh is used in Makefile by default, so
a.{1,2,3} isn't evaluated to a.1 a.2 a.3, another solution
is to use `SHELL=/bin/bash` in Makefile, but I don't think
we should bind to bash this early, at least not for this
case.

This also remove the removal of docs/*.1 which doesn't
exist for now.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>