### PR TITLE
conmon: implement logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /ocic
 /ocid
 /ocid.conf
+*.o
 *.orig
 /pause/pause
 /pause/pause.o

--- a/.tool/lint
+++ b/.tool/lint
@@ -15,7 +15,7 @@ for d in $(find . -type d -not -iwholename '*.git*' -a -not -iname '.tool' -a -n
 		 --disable=aligncheck \
 		 --disable=gotype \
 		 --disable=gas \
-		 --cyclo-over=60 \
+		 --cyclo-over=80 \
 		 --dupl-threshold=100 \
 		 --tests \
 		 --deadline=60s "${d}"

--- a/.tool/lint
+++ b/.tool/lint
@@ -6,7 +6,8 @@ set -o pipefail
 
 for d in $(find . -type d -not -iwholename '*.git*' -a -not -iname '.tool' -a -not -iwholename '*vendor*'); do
 	${GOPATH}/bin/gometalinter \
-		 --exclude='error return value not checked.*(Close|Log|Print).*\(errcheck\)$' \
+		 --exclude='error return value not checked.*(Close|Log|Print|RemoveAll).*\(errcheck\)$' \
+		 --exclude='declaration of.*err.*shadows declaration.*\(vetshadow\)$' \
 		 --exclude='.*_test\.go:.*error return value not checked.*\(errcheck\)$' \
 		 --exclude='duplicate of.*_test.go.*\(dupl\)$' \
 		 --exclude='cmd\/client\/.*\.go.*\(dupl\)$' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,9 @@ RUN mkdir -p /usr/src/criu \
     && rm -rf /usr/src/criu
 
 # Install runc
-ENV RUNC_COMMIT cc29e3dded8e27ba8f65738f40d251c885030a28
+# TODO: This should actually be v1.0.0-rc3 but we first need to switch to
+#       v1.0.0-rc5 runtime config generation.
+ENV RUNC_COMMIT 31980a53ae7887b2c8f8715d13c3eb486c27b6cf
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/conmon/cmsg.c
+++ b/conmon/cmsg.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2016 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* NOTE: This code comes directly from runc/libcontainer/utils/cmsg.c. */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "cmsg.h"
+
+#define error(fmt, ...)							\
+	({								\
+		fprintf(stderr, "nsenter: " fmt ": %m\n", ##__VA_ARGS__); \
+		errno = ECOMM;						\
+		goto err; /* return value */				\
+	})
+
+/*
+ * Sends a file descriptor along the sockfd provided. Returns the return
+ * value of sendmsg(2). Any synchronisation and preparation of state
+ * should be done external to this (we expect the other side to be in
+ * recvfd() in the code).
+ */
+ssize_t sendfd(int sockfd, struct file_t file)
+{
+	struct msghdr msg = {0};
+	struct iovec iov[1] = {0};
+	struct cmsghdr *cmsg;
+	int *fdptr;
+
+	union {
+		char buf[CMSG_SPACE(sizeof(file.fd))];
+		struct cmsghdr align;
+	} u;
+
+	/*
+	 * We need to send some other data along with the ancillary data,
+	 * otherwise the other side won't recieve any data. This is very
+	 * well-hidden in the documentation (and only applies to
+	 * SOCK_STREAM). See the bottom part of unix(7).
+	 */
+	iov[0].iov_base = file.name;
+	iov[0].iov_len = strlen(file.name) + 1;
+
+	msg.msg_name = NULL;
+	msg.msg_namelen = 0;
+	msg.msg_iov = iov;
+	msg.msg_iovlen = 1;
+	msg.msg_control = u.buf;
+	msg.msg_controllen = sizeof(u.buf);
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_RIGHTS;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+
+	fdptr = (int *) CMSG_DATA(cmsg);
+	memcpy(fdptr, &file.fd, sizeof(int));
+
+	return sendmsg(sockfd, &msg, 0);
+}
+
+/*
+ * Receives a file descriptor from the sockfd provided. Returns the file
+ * descriptor as sent from sendfd(). It will return the file descriptor
+ * or die (literally) trying. Any synchronisation and preparation of
+ * state should be done external to this (we expect the other side to be
+ * in sendfd() in the code).
+ */
+struct file_t recvfd(int sockfd)
+{
+	struct msghdr msg = {0};
+	struct iovec iov[1] = {0};
+	struct cmsghdr *cmsg;
+	struct file_t file = {0};
+	int *fdptr;
+	int olderrno;
+
+	union {
+		char buf[CMSG_SPACE(sizeof(file.fd))];
+		struct cmsghdr align;
+	} u;
+
+	/* Allocate a buffer. */
+	/* TODO: Make this dynamic with MSG_PEEK. */
+	file.name = malloc(TAG_BUFFER);
+	if (!file.name)
+		error("recvfd: failed to allocate file.tag buffer\n");
+
+	/*
+	 * We need to "recieve" the non-ancillary data even though we don't
+	 * plan to use it at all. Otherwise, things won't work as expected.
+	 * See unix(7) and other well-hidden documentation.
+	 */
+	iov[0].iov_base = file.name;
+	iov[0].iov_len = TAG_BUFFER;
+
+	msg.msg_name = NULL;
+	msg.msg_namelen = 0;
+	msg.msg_iov = iov;
+	msg.msg_iovlen = 1;
+	msg.msg_control = u.buf;
+	msg.msg_controllen = sizeof(u.buf);
+
+	ssize_t ret = recvmsg(sockfd, &msg, 0);
+	if (ret < 0)
+		goto err;
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	if (!cmsg)
+		error("recvfd: got NULL from CMSG_FIRSTHDR");
+	if (cmsg->cmsg_level != SOL_SOCKET)
+		error("recvfd: expected SOL_SOCKET in cmsg: %d", cmsg->cmsg_level);
+	if (cmsg->cmsg_type != SCM_RIGHTS)
+		error("recvfd: expected SCM_RIGHTS in cmsg: %d", cmsg->cmsg_type);
+	if (cmsg->cmsg_len != CMSG_LEN(sizeof(int)))
+		error("recvfd: expected correct CMSG_LEN in cmsg: %lu", cmsg->cmsg_len);
+
+	fdptr = (int *) CMSG_DATA(cmsg);
+	if (!fdptr || *fdptr < 0)
+		error("recvfd: recieved invalid pointer");
+
+	file.fd = *fdptr;
+	return file;
+
+err:
+	olderrno = errno;
+	free(file.name);
+	errno = olderrno;
+	return (struct file_t){0};
+}

--- a/conmon/cmsg.h
+++ b/conmon/cmsg.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* NOTE: This code comes directly from runc/libcontainer/utils/cmsg.h. */
+
+#pragma once
+
+#if !defined(CMSG_H)
+#define CMSG_H
+
+#include <sys/types.h>
+
+/* TODO: Implement this properly with MSG_PEEK. */
+#define TAG_BUFFER 4096
+
+/* This mirrors Go's (*os.File). */
+struct file_t {
+	char *name;
+	int fd;
+};
+
+struct file_t recvfd(int sockfd);
+ssize_t sendfd(int sockfd, struct file_t file);
+
+#endif /* !defined(CMSG_H) */

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -93,6 +93,29 @@ static GOptionEntry entries[] =
   { NULL }
 };
 
+int set_k8s_timestamp(char *buf, ssize_t buflen, const char *stream_type)
+{
+	time_t now = time(NULL);
+	struct tm *tm;
+	char off_sign = '+';
+	int off;
+
+	if ((tm = localtime(&now)) == NULL) {
+		return -1;
+	}
+	off = (int) tm->tm_gmtoff;
+	if (tm->tm_gmtoff < 0) {
+		off_sign = '-';
+		off = -off;
+	}
+	snprintf(buf, buflen, "%d-%02d-%02dT%02d:%02d:%02d%c%02d:%02d %s ",
+		tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+		tm->tm_hour, tm->tm_min, tm->tm_sec,
+		off_sign, off / 3600, off % 3600, stream_type);
+
+	return 0;
+}
+
 int main(int argc, char *argv[])
 {
 	int ret, runtime_status;
@@ -372,6 +395,9 @@ int main(int argc, char *argv[])
 		pexit("Failed to add console master fd to epoll");
 	}
 
+	#define TSBUFLEN 34
+	char tsbuf[TSBUFLEN];
+
 	/*
 	 * Log all of the container's output and pipe STDIN into it. Currently
 	 * nothing using the STDIN setup (which makes its inclusion here a bit
@@ -403,6 +429,23 @@ int main(int argc, char *argv[])
 
 					ninfo("read a chunk: (fd=%d) '%s'", mfd, buf);
 
+
+					/* Prepend the CRI-mandated timestamp and other metadata. */
+					/*
+					 * FIXME: Currently this code makes the assumption that
+					 *        @buf doesn't contain any newlines (since the CRI
+					 *        requires each line to contain a timestamp). This
+					 *        is an /okay/ assumption in most cases because
+					 *        ptys generally have newline-buffered output.
+					 */
+					int rc = set_k8s_timestamp(tsbuf, TSBUFLEN, "stdout");
+					if (rc < 0) {
+						nwarn("failed to set timestamp");
+					} else {
+						if (write(logfd, tsbuf, TSBUFLEN) != TSBUFLEN) {
+							nwarn("partial/failed write ts (logFd)");
+						}
+					}
 					/* Log all output to logfd. */
 					if (write(logfd, buf, num_read) != num_read) {
 						nwarn("partial/failed write (logFd)");

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -212,10 +212,12 @@ int main(int argc, char *argv[])
 		 * both cases. The runtime_mfd will be closed after we dup over
 		 * everything.
 		 *
-		 * TODO: Maybe this should be done with pipe(2)s?
+		 * We use pipes here because open(/dev/std{out,err}) will fail if we
+		 * used anything else (and it wouldn't be a good idea to create a new
+		 * pty pair in the host).
 		 */
-		if (socketpair(AF_LOCAL, SOCK_STREAM, 0, fds) < 0)
-			pexit("Failed to create runtime_mfd socketpair");
+		if (pipe(fds) < 0)
+			pexit("Failed to create runtime_mfd pipes");
 
 		mfd = fds[0];
 		runtime_mfd = fds[1];

--- a/server/config.go
+++ b/server/config.go
@@ -56,8 +56,6 @@ type RootConfig struct {
 
 	// LogDir is the default log directory were all logs will go unless kubelet
 	// tells us to put them somewhere else.
-	//
-	// TODO: This is currently unused until the conmon logging rewrite is done.
 	LogDir string `toml:"log_dir"`
 }
 

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -332,6 +332,22 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	}
 
 	logPath := containerConfig.LogPath
+	if logPath == "" {
+		// TODO: Should we use sandboxConfig.GetLogDirectory() here?
+		logPath = filepath.Join(sb.logDir, containerID+".log")
+	}
+	if !filepath.IsAbs(logPath) {
+		// XXX: It's not really clear what this should be versus the sbox logDirectory.
+		logrus.Warnf("requested logPath for ctr id %s is a relative path: %s", containerID, logPath)
+		logPath = filepath.Join(sb.logDir, logPath)
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"sbox.logdir": sb.logDir,
+		"ctr.logfile": containerConfig.LogPath,
+		"log_path":    logPath,
+	}).Debugf("setting container's log_path")
+
 	specgen.SetProcessTerminal(containerConfig.Tty)
 
 	linux := containerConfig.GetLinux()

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -203,6 +203,29 @@ func setupContainerUser(specgen *generate.Generator, rootfs string, sc *pb.Linux
 	return nil
 }
 
+// ensureSaneLogPath is a hack to fix https://issues.k8s.io/44043 which causes
+// logPath to be a broken symlink to some magical Docker path. Ideally we
+// wouldn't have to deal with this, but until that issue is fixed we have to
+// remove the path if it's a broken symlink.
+func ensureSaneLogPath(logPath string) error {
+	// If the path exists but the resolved path does not, then we have a broken
+	// symlink and we need to remove it.
+	fi, err := os.Lstat(logPath)
+	if err != nil || fi.Mode()&os.ModeSymlink == 0 {
+		// Non-existant files and non-symlinks aren't our problem.
+		return nil
+	}
+
+	_, err = os.Stat(logPath)
+	if os.IsNotExist(err) {
+		err = os.RemoveAll(logPath)
+		if err != nil {
+			return fmt.Errorf("ensureSaneLogPath remove bad logPath: %s", err)
+		}
+	}
+	return nil
+}
+
 // CreateContainer creates a new container in specified PodSandbox
 func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (res *pb.CreateContainerResponse, err error) {
 	logrus.Debugf("CreateContainerRequest %+v", req)
@@ -340,6 +363,11 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		// XXX: It's not really clear what this should be versus the sbox logDirectory.
 		logrus.Warnf("requested logPath for ctr id %s is a relative path: %s", containerID, logPath)
 		logPath = filepath.Join(sb.logDir, logPath)
+	}
+
+	// Handle https://issues.k8s.io/44043
+	if err := ensureSaneLogPath(logPath); err != nil {
+		return nil, err
 	}
 
 	logrus.WithFields(logrus.Fields{

--- a/server/sandbox.go
+++ b/server/sandbox.go
@@ -121,7 +121,6 @@ func hostNetNsPath() (string, error) {
 	}
 
 	defer netNS.Close()
-
 	return netNS.Path(), nil
 }
 

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -255,6 +255,11 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	// set log path inside log directory
 	logPath := filepath.Join(logDir, id+".log")
 
+	// Handle https://issues.k8s.io/44043
+	if err := ensureSaneLogPath(logPath); err != nil {
+		return nil, err
+	}
+
 	privileged := s.privilegedSandbox(req)
 	g.AddAnnotation("ocid/metadata", string(metadataJSON))
 	g.AddAnnotation("ocid/labels", string(labelsJSON))

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/Sirupsen/logrus"
@@ -175,7 +176,7 @@ func (s *Server) loadSandbox(id string) error {
 	sb := &sandbox{
 		id:           id,
 		name:         name,
-		logDir:       m.Annotations["ocid/log_path"],
+		logDir:       filepath.Dir(m.Annotations["ocid/log_path"]),
 		labels:       labels,
 		containers:   oci.NewMemoryStore(),
 		processLabel: processLabel,
@@ -225,7 +226,7 @@ func (s *Server) loadSandbox(id string) error {
 		}
 	}()
 
-	scontainer, err := oci.NewContainer(m.Annotations["ocid/container_id"], cname, sandboxPath, sandboxPath, sb.netNs(), labels, annotations, nil, nil, id, false, privileged)
+	scontainer, err := oci.NewContainer(m.Annotations["ocid/container_id"], cname, sandboxPath, m.Annotations["ocid/log_path"], sb.netNs(), labels, annotations, nil, nil, id, false, privileged)
 	if err != nil {
 		return err
 	}

--- a/test/runtimeversion.bats
+++ b/test/runtimeversion.bats
@@ -8,7 +8,7 @@ function teardown() {
 
 @test "ocic runtimeversion" {
 	start_ocid
-	ocic runtimeversion
+	run ocic runtimeversion
 	echo "$output"
 	[ "$status" -eq 0 ]
 	stop_ocid

--- a/test/testdata/container_config.json
+++ b/test/testdata/container_config.json
@@ -7,11 +7,9 @@
 		"image": "docker://redis:latest"
 	},
 	"command": [
-		"/bin/bash"
-	],
-	"args": [
 		"/bin/ls"
 	],
+	"args": [],
 	"working_dir": "/",
 	"envs": [
 		{

--- a/test/testdata/container_config.json
+++ b/test/testdata/container_config.json
@@ -41,7 +41,7 @@
 	},
 	"privileged": true,
 	"readonly_rootfs": true,
-	"log_path": "container.log",
+	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
 	"tty": false,

--- a/test/testdata/container_config_by_imageid.json
+++ b/test/testdata/container_config_by_imageid.json
@@ -41,7 +41,7 @@
 	},
 	"privileged": true,
 	"readonly_rootfs": true,
-	"log_path": "container.log",
+	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
 	"tty": false,

--- a/test/testdata/container_config_logging.json
+++ b/test/testdata/container_config_logging.json
@@ -4,13 +4,13 @@
 		"attempt": 1
 	},
 	"image": {
-		"image": "docker://redis:latest"
+		"image": "docker://busybox:latest"
 	},
 	"command": [
-		"/bin/bash"
+		"/bin/echo"
 	],
 	"args": [
-		"/bin/chmod", "777", "."
+		"%echooutput%"
 	],
 	"working_dir": "/",
 	"envs": [
@@ -66,8 +66,8 @@
 		"selinux_options": {
 			"user": "system_u",
 			"role": "system_r",
-			"type": "svirt_lxc_net_t",
-			"level": "s0:c4-c5"
+			"type": "container_t",
+			"level": "s0:c4,c5"
 		},
 		"user": {
 			"uid": 5,

--- a/test/testdata/container_exit_test.json
+++ b/test/testdata/container_exit_test.json
@@ -15,7 +15,7 @@
 		}
 	],
 	"readonly_rootfs": true,
-	"log_path": "container.log",
+	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
 	"tty": false,

--- a/test/testdata/container_redis.json
+++ b/test/testdata/container_redis.json
@@ -39,7 +39,7 @@
 		"pod": "podsandbox1"
 	},
 	"readonly_rootfs": false,
-	"log_path": "container.log",
+	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
 	"tty": false,

--- a/test/testdata/sandbox_config.json
+++ b/test/testdata/sandbox_config.json
@@ -6,7 +6,7 @@
 		"attempt": 1
 	},
 	"hostname": "ocic_host",
-	"log_directory": ".",
+	"log_directory": "",
 	"dns_options": {
 		"servers": [
 			"server1.redhat.com",

--- a/test/testdata/sandbox_config_hostnet.json
+++ b/test/testdata/sandbox_config_hostnet.json
@@ -6,7 +6,7 @@
 		"attempt": 1
 	},
 	"hostname": "ocic_host",
-	"log_directory": ".",
+	"log_directory": "",
 	"dns_options": {
 		"servers": [
 			"server1.redhat.com",

--- a/test/testdata/sandbox_config_seccomp.json
+++ b/test/testdata/sandbox_config_seccomp.json
@@ -6,7 +6,7 @@
 		"attempt": 1
 	},
 	"hostname": "ocic_host",
-	"log_directory": ".",
+	"log_directory": "",
 	"dns_options": {
 		"servers": [
 			"server1.redhat.com",


### PR DESCRIPTION
This adds a very simple implementation of logging within conmon, where
every buffer read from the masterfd of the container is also written to
the log file (with errors during writing to the log file ignored). It also
includes changes to how we compute the logPath for a container.

The WIP part of this PR is that conmon currently doesn't really handle
containers where `terminal: false`. This is going to be not-very-nice to
fix because the current runC API is broken (which is why we need to
make sure that the current state of opencontainers/runtime-spec#513
is **fixed**). However, while that's being sorted (and I work on the
relevant console changes in runC) we can solve it with a `fork+execve`
though no doubt there will be some fun issues with the exit code.

Closes #24.

Signed-off-by: Aleksa Sarai asarai@suse.de
