### PR TITLE
Don't share container UTS namespace with pod

### DIFF
--- a/server/container.go
+++ b/server/container.go
@@ -298,7 +298,6 @@ func (s *Server) createSandboxContainer(containerID string, containerName string
 
 	for nsType, nsFile := range map[string]string{
 		"ipc":     "ipc",
-		"uts":     "uts",
 		"network": "net",
 	} {
 		nsPath := fmt.Sprintf("/proc/%d/ns/%s", podInfraState.Pid, nsFile)


### PR DESCRIPTION
kubernetes doesn't share the UTS namespace

Signed-off-by: Mrunal Patel <mpatel@redhat.com>