### PR TITLE
do not allow to remove infra container

### DIFF
--- a/server/container.go
+++ b/server/container.go
@@ -381,6 +381,16 @@ func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerReq
 		return nil, err
 	}
 
+	sb := s.getSandbox(c.Sandbox())
+	if sb == nil {
+		return nil, fmt.Errorf("failed to find sandbox for container %s", c.ID())
+	}
+
+	podInfraContainerName := sb.name + "-infra"
+	if podInfraContainerName == c.Name() {
+		return nil, fmt.Errorf("can not delete Infra container %s\n", c.ID())
+	}
+
 	if err := s.runtime.UpdateStatus(c); err != nil {
 		return nil, fmt.Errorf("failed to update container state: %v", err)
 	}


### PR DESCRIPTION
Infra container is special, sandbox won't work well
without infra container. If user really want to remove
it, they should remove sanbox instead.

this also fix a panic due to c.state is nil.
1, remove infra container
2, ocic ctr create 

or
1, remove infra container
2, restart ocid
3, ocic ctr list

Signed-off-by: Gao feng <omarapazanadi@gmail.com>

panic on ctr list
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x605606]

goroutine 12 [running]:
github.com/kubernetes-incubator/cri-o/oci.(*History).Less(0xc820011660, 0x1, 0x0, 0xb43390)
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/github.com/kubernetes-incubator/cri-o/oci/history.go:23 +0x296
sort.insertionSort(0x7f3d4e687c80, 0xc820011660, 0x0, 0x2)
	/usr/lib/golang/src/sort/sort.go:32 +0x6f
sort.quickSort(0x7f3d4e687c80, 0xc820011660, 0x0, 0x2, 0x4)
	/usr/lib/golang/src/sort/sort.go:184 +0x153
sort.Sort(0x7f3d4e687c80, 0xc820011660)
	/usr/lib/golang/src/sort/sort.go:199 +0x74
github.com/kubernetes-incubator/cri-o/oci.(*History).sort(0xc820011660)
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/github.com/kubernetes-incubator/cri-o/oci/history.go:34 +0x48
github.com/kubernetes-incubator/cri-o/oci.(*memoryStore).List(0xc82034ffe0, 0x0, 0x0, 0x0)
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/github.com/kubernetes-incubator/cri-o/oci/memory_store.go:45 +0x95
github.com/kubernetes-incubator/cri-o/server.(*Server).ListContainers(0xc82012f860, 0x7f3d4c5ff418, 0xc8201448a0, 0xc820011600, 0x0, 0x0, 0x0)
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/github.com/kubernetes-incubator/cri-o/server/container.go:436 +0x99
k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime._RuntimeService_ListContainers_Handler(0xb026c0, 0xc82012f860, 0x7f3d4c5ff418, 0xc8201448a0, 0xc820017590, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime/api.pb.go:2846 +0x168
google.golang.org/grpc.(*Server).processUnaryRPC(0xc82037e5a0, 0x7f3d4c5ff210, 0xc82001a990, 0xc8204d2000, 0xc820385d10, 0x10544f0, 0xc820144870, 0x0, 0x0)
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/google.golang.org/grpc/server.go:608 +0x10e1
google.golang.org/grpc.(*Server).handleStream(0xc82037e5a0, 0x7f3d4c5ff210, 0xc82001a990, 0xc8204d2000, 0xc820144870)
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/google.golang.org/grpc/server.go:766 +0x10a0
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc82013c6c0, 0xc82037e5a0, 0x7f3d4c5ff210, 0xc82001a990, 0xc8204d2000)
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/google.golang.org/grpc/server.go:419 +0xa0
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/google.golang.org/grpc/server.go:420 +0x9a


panic on ctr create
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x6089fc]

goroutine 43 [running]:
github.com/kubernetes-incubator/cri-o/oci.(*Runtime).ContainerStatus(0xc820361700, 0x0, 0x0)
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/github.com/kubernetes-incubator/cri-o/oci/oci.go:214 +0x9c
github.com/kubernetes-incubator/cri-o/server.(*Server).createSandboxContainer(0xc8201492b0, 0xc8204b7880, 0x40, 0xc82048f530, 0x29, 0xc8202fff80, 0x0, 0xc8202efc80, 0x59, 0xc82019e540, ...)
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/github.com/kubernetes-incubator/cri-o/server/container.go:295 +0x2493
github.com/kubernetes-incubator/cri-o/server.(*Server).CreateContainer(0xc8201492b0, 0x7f5ae283fc70, 0xc82048ee40, 0xc82048eea0, 0x0, 0x0, 0x0)
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/github.com/kubernetes-incubator/cri-o/server/container.go:113 +0xba2
k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime._RuntimeService_CreateContainer_Handler(0xb02260, 0xc8201492b0, 0x7f5ae283fc70, 0xc82048ee40, 0xc8204b4410, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime/api.pb.go:2774 +0x168
google.golang.org/grpc.(*Server).processUnaryRPC(0xc82038c5a0, 0x7f5ae283fa68, 0xc82001a7e0, 0xc82026ae10, 0xc82048e060, 0x1053490, 0xc82048ee10, 0x0, 0x0)
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/google.golang.org/grpc/server.go:608 +0x10e1
google.golang.org/grpc.(*Server).handleStream(0xc82038c5a0, 0x7f5ae283fa68, 0xc82001a7e0, 0xc82026ae10, 0xc82048ee10)
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/google.golang.org/grpc/server.go:766 +0x10a0
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc820145000, 0xc82038c5a0, 0x7f5ae283fa68, 0xc82001a7e0, 0xc82026ae10)
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/google.golang.org/grpc/server.go:419 +0xa0
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/home/gaofeng/go/src/github.com/kubernetes-incubator/cri-o/vendor/src/google.golang.org/grpc/server.go:420 +0x9a
