### PR TITLE
Return pod metadata in container list and status APIs 

### DIFF
--- a/cmd/client/container.go
+++ b/cmd/client/container.go
@@ -364,6 +364,14 @@ func ContainerStatus(client pb.RuntimeServiceClient, ID string) error {
 		return err
 	}
 	fmt.Printf("ID: %s\n", *r.Status.Id)
+	if r.Status.Metadata != nil {
+		if r.Status.Metadata.Name != nil {
+			fmt.Printf("Name: %s\n", *r.Status.Metadata.Name)
+		}
+		if r.Status.Metadata.Attempt != nil {
+			fmt.Printf("Attempt: %v\n", *r.Status.Metadata.Attempt)
+		}
+	}
 	if r.Status.State != nil {
 		fmt.Printf("Status: %s\n", r.Status.State)
 	}
@@ -428,6 +436,14 @@ func ListContainers(client pb.RuntimeServiceClient, opts listOptions) error {
 		}
 		fmt.Printf("ID: %s\n", *c.Id)
 		fmt.Printf("Pod: %s\n", *c.PodSandboxId)
+		if c.Metadata != nil {
+			if c.Metadata.Name != nil {
+				fmt.Printf("Name: %s\n", *c.Metadata.Name)
+			}
+			if c.Metadata.Attempt != nil {
+				fmt.Printf("Attempt: %v\n", *c.Metadata.Attempt)
+			}
+		}
 		if c.State != nil {
 			fmt.Printf("Status: %s\n", *c.State)
 		}
@@ -447,6 +463,7 @@ func ListContainers(client pb.RuntimeServiceClient, opts listOptions) error {
 				fmt.Printf("\t%s -> %s\n", k, v)
 			}
 		}
+		fmt.Println()
 	}
 	return nil
 }

--- a/cmd/client/container.go
+++ b/cmd/client/container.go
@@ -453,14 +453,14 @@ func ListContainers(client pb.RuntimeServiceClient, opts listOptions) error {
 		}
 		if c.Labels != nil {
 			fmt.Println("Labels:")
-			for k, v := range c.Labels {
-				fmt.Printf("\t%s -> %s\n", k, v)
+			for _, k := range getSortedKeys(c.Labels) {
+				fmt.Printf("\t%s -> %s\n", k, c.Labels[k])
 			}
 		}
 		if c.Annotations != nil {
 			fmt.Println("Annotations:")
-			for k, v := range c.Annotations {
-				fmt.Printf("\t%s -> %s\n", k, v)
+			for _, k := range getSortedKeys(c.Annotations) {
+				fmt.Printf("\t%s -> %s\n", k, c.Annotations[k])
 			}
 		}
 		fmt.Println()

--- a/cmd/client/sandbox.go
+++ b/cmd/client/sandbox.go
@@ -379,6 +379,7 @@ func ListPodSandboxes(client pb.RuntimeServiceClient, opts listOptions) error {
 				fmt.Printf("\t%s -> %s\n", k, v)
 			}
 		}
+		fmt.Println()
 	}
 	return nil
 }

--- a/cmd/client/sandbox.go
+++ b/cmd/client/sandbox.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
@@ -302,14 +303,14 @@ func PodSandboxStatus(client pb.RuntimeServiceClient, ID string) error {
 	}
 	if r.Status.Labels != nil {
 		fmt.Println("Labels:")
-		for k, v := range r.Status.Labels {
-			fmt.Printf("\t%s -> %s\n", k, v)
+		for _, k := range getSortedKeys(r.Status.Labels) {
+			fmt.Printf("\t%s -> %s\n", k, r.Status.Labels[k])
 		}
 	}
 	if r.Status.Annotations != nil {
 		fmt.Println("Annotations:")
-		for k, v := range r.Status.Annotations {
-			fmt.Printf("\t%s -> %s\n", k, v)
+		for _, k := range getSortedKeys(r.Status.Annotations) {
+			fmt.Printf("\t%s -> %s\n", k, r.Status.Annotations[k])
 		}
 	}
 	return nil
@@ -369,17 +370,27 @@ func ListPodSandboxes(client pb.RuntimeServiceClient, opts listOptions) error {
 		fmt.Printf("Created: %v\n", ctm)
 		if pod.Labels != nil {
 			fmt.Println("Labels:")
-			for k, v := range pod.Labels {
-				fmt.Printf("\t%s -> %s\n", k, v)
+			for _, k := range getSortedKeys(pod.Labels) {
+				fmt.Printf("\t%s -> %s\n", k, pod.Labels[k])
 			}
 		}
 		if pod.Annotations != nil {
 			fmt.Println("Annotations:")
-			for k, v := range pod.Annotations {
-				fmt.Printf("\t%s -> %s\n", k, v)
+			for _, k := range getSortedKeys(pod.Annotations) {
+				fmt.Printf("\t%s -> %s\n", k, pod.Annotations[k])
 			}
 		}
 		fmt.Println()
 	}
 	return nil
+}
+
+func getSortedKeys(m map[string]string) []string {
+	var keys []string
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	return keys
 }

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -19,6 +19,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
 	"k8s.io/kubernetes/pkg/fields"
+	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
 
 const (
@@ -228,6 +229,7 @@ type Container struct {
 	sandbox    string
 	terminal   bool
 	state      *ContainerState
+	metadata   *pb.ContainerMetadata
 	stateLock  sync.Mutex
 }
 
@@ -241,7 +243,7 @@ type ContainerState struct {
 }
 
 // NewContainer creates a container object.
-func NewContainer(id string, name string, bundlePath string, logPath string, labels map[string]string, sandbox string, terminal bool) (*Container, error) {
+func NewContainer(id string, name string, bundlePath string, logPath string, labels map[string]string, metadata *pb.ContainerMetadata, sandbox string, terminal bool) (*Container, error) {
 	c := &Container{
 		id:         id,
 		name:       name,
@@ -250,6 +252,7 @@ func NewContainer(id string, name string, bundlePath string, logPath string, lab
 		labels:     labels,
 		sandbox:    sandbox,
 		terminal:   terminal,
+		metadata:   metadata,
 	}
 	return c, nil
 }
@@ -290,6 +293,11 @@ func (c *Container) NetNsPath() (string, error) {
 		return "", fmt.Errorf("container state is not populated")
 	}
 	return fmt.Sprintf("/proc/%d/ns/net", c.state.Pid), nil
+}
+
+// Metadata returns the metadata of the container.
+func (c *Container) Metadata() *pb.ContainerMetadata {
+	return c.metadata
 }
 
 // newPipe creates a unix socket pair for communication

--- a/server/sandbox.go
+++ b/server/sandbox.go
@@ -175,6 +175,13 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 	g.AddBindMount(resolvPath, "/etc/resolv.conf", "ro")
 
+	// add metadata
+	metadata := req.GetConfig().GetMetadata()
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, err
+	}
+
 	// add labels
 	labels := req.GetConfig().GetLabels()
 	labelsJSON, err := json.Marshal(labels)
@@ -221,6 +228,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 	}()
 
+	g.AddAnnotation("ocid/metadata", string(metadataJSON))
 	g.AddAnnotation("ocid/labels", string(labelsJSON))
 	g.AddAnnotation("ocid/annotations", string(annotationsJSON))
 	g.AddAnnotation("ocid/log_path", logDir)
@@ -237,7 +245,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		containers:   oci.NewMemoryStore(),
 		processLabel: processLabel,
 		mountLabel:   mountLabel,
-		metadata:     req.GetConfig().GetMetadata(),
+		metadata:     metadata,
 	}
 
 	s.addSandbox(sb)
@@ -290,7 +298,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 	}
 
-	container, err := oci.NewContainer(containerID, containerName, podSandboxDir, podSandboxDir, labels, id, false)
+	container, err := oci.NewContainer(containerID, containerName, podSandboxDir, podSandboxDir, labels, nil, id, false)
 	if err != nil {
 		return nil, err
 	}

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -292,3 +292,38 @@ function teardown() {
 	cleanup_pods
 	stop_ocid
 }
+
+@test "ctr metadata in list & status" {
+	# this test requires docker, thus it can't yet be run in a container
+	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
+		skip "cannot yet run this test in a container, use sudo make localintegration"
+	fi
+
+	start_ocid
+	run ocic pod create --config "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+	run ocic ctr create --config "$TESTDATA"/container_config.json --pod "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+
+	run ocic ctr list --id "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# TODO: expected value should not hard coded here
+	[[ "$output" =~ "Name: container1" ]]
+	[[ "$output" =~ "Attempt: 1" ]]
+
+	run ocic ctr status --id "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# TODO: expected value should not hard coded here
+	[[ "$output" =~ "Name: container1" ]]
+	[[ "$output" =~ "Attempt: 1" ]]
+
+	cleanup_ctrs
+	cleanup_pods
+	stop_ocid
+}

--- a/test/pod.bats
+++ b/test/pod.bats
@@ -153,3 +153,37 @@ function teardown() {
 	cleanup_pods
 	stop_ocid
 }
+
+@test "pod metadata in list & status" {
+	# this test requires docker, thus it can't yet be run in a container
+	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
+		skip "cannot yet run this test in a container, use sudo make localintegration"
+	fi
+
+	start_ocid
+	run ocic pod create --config "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	run ocic pod list --id "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# TODO: expected value should not hard coded here
+	[[ "$output" =~ "Name: podsandbox1" ]]
+	[[ "$output" =~ "UID: redhat-test-ocid" ]]
+	[[ "$output" =~ "Namespace: redhat.test.ocid" ]]
+	[[ "$output" =~ "Attempt: 1" ]]
+
+	run ocic pod status --id "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# TODO: expected value should not hard coded here
+	[[ "$output" =~ "Name: podsandbox1" ]]
+	[[ "$output" =~ "UID: redhat-test-ocid" ]]
+	[[ "$output" =~ "Namespace: redhat.test.ocid" ]]
+	[[ "$output" =~ "Attempt: 1" ]]
+
+	cleanup_pods
+	stop_ocid
+}

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -18,10 +18,30 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	pod_id="$output"
 
+	run ocic pod list --id "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_list_info="$output"
+
+	run ocic pod status --id "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_status_info="$output"
+
 	run ocic ctr create --config "$TESTDATA"/container_config.json --pod "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	ctr_id="$output"
+
+	run ocic ctr list --id "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_list_info="$output"
+
+	run ocic ctr status --id "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_status_info="$output"
 
 	stop_ocid
 
@@ -32,11 +52,31 @@ function teardown() {
 	[[ "${output}" != "" ]]
 	[[ "${output}" =~ "${pod_id}" ]]
 
+	run ocic pod list --id "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "${output}" == "${pod_list_info}" ]]
+
+	run ocic pod status --id "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "${output}" == "${pod_status_info}" ]]
+
 	run ocic ctr list
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "${output}" != "" ]]
 	[[ "${output}" =~ "${pod_id}" ]]
+
+	run ocic ctr list --id "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "${output}" == "${ctr_list_info}" ]]
+
+	run ocic ctr status --id "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "${output}" == "${ctr_status_info}" ]]
 
 	cleanup_ctrs
 	cleanup_pods

--- a/test/testdata/container_config.json
+++ b/test/testdata/container_config.json
@@ -1,6 +1,7 @@
 {
 	"metadata": {
-		"name": "container1"
+		"name": "container1",
+		"attempt": 1
 	},
 	"image": {
 		"image": "docker://redis:latest"

--- a/test/testdata/sandbox_config.json
+++ b/test/testdata/sandbox_config.json
@@ -1,6 +1,9 @@
 {
 	"metadata": {
-		"name": "podsandbox1"
+		"name": "podsandbox1",
+		"uid": "redhat-test-ocid",
+		"namespace": "redhat.test.ocid",
+		"attempt": 1
 	},
 	"hostname": "ocic_host",
 	"log_directory": ".",


### PR DESCRIPTION
Currently, 
1. we didn't store container/pod metadata.
2. metadata in container is not returned to kubelet in list and status APIs

Fix that.

Added test case:
1. add test for pod/ctr metadata in list/status.
2. enhance restore test to check list/status consistency before/after restore.
