### PR TITLE
Handle PodSandboxConfig.DNSConfig.Options

### DIFF
--- a/server/sandbox.go
+++ b/server/sandbox.go
@@ -162,8 +162,9 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	// set DNS options
 	dnsServers := req.GetConfig().GetDnsConfig().GetServers()
 	dnsSearches := req.GetConfig().GetDnsConfig().GetSearches()
+	dnsOptions := req.GetConfig().GetDnsConfig().GetOptions()
 	resolvPath := fmt.Sprintf("%s/resolv.conf", podSandboxDir)
-	err = parseDNSOptions(dnsServers, dnsSearches, resolvPath)
+	err = parseDNSOptions(dnsServers, dnsSearches, dnsOptions, resolvPath)
 	if err != nil {
 		err1 := removeFile(resolvPath)
 		if err1 != nil {

--- a/server/utils.go
+++ b/server/utils.go
@@ -74,10 +74,11 @@ func removeFile(path string) error {
 	return nil
 }
 
-func parseDNSOptions(servers, searches []string, path string) error {
+func parseDNSOptions(servers, searches, options []string, path string) error {
 	nServers := len(servers)
 	nSearches := len(searches)
-	if nServers == 0 && nSearches == 0 {
+	nOptions := len(options)
+	if nServers == 0 && nSearches == 0 && nOptions == 0 {
 		return copyFile("/etc/resolv.conf", path)
 	}
 
@@ -101,6 +102,14 @@ func parseDNSOptions(servers, searches []string, path string) error {
 
 	if nServers > 0 {
 		data := fmt.Sprintf("nameserver %s\n", strings.Join(servers, "\nnameserver "))
+		_, err = f.Write([]byte(data))
+		if err != nil {
+			return err
+		}
+	}
+
+	if nOptions > 0 {
+		data := fmt.Sprintf("options %s\n", strings.Join(options, " "))
 		_, err = f.Write([]byte(data))
 		if err != nil {
 			return err


### PR DESCRIPTION
DNSConfig can pass "options" settings in now, so we should add them to the resolv.conf that we're generating.