### PR TITLE
Add missing steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ $ mkdir $GOPATH
 $ go get -d github.com/kubernetes-incubator/cri-o
 $ cd $GOPATH/src/github.com/kubernetes-incubator/cri-o
 $ make install.tools
+$ make
 $ sudo make install
 ```
 


### PR DESCRIPTION
The guideline in README doesn't work, one important step `#make` is
missing, so fix it.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>