### PR TITLE
Set timestamps to nanoseconds

### DIFF
--- a/server/container.go
+++ b/server/container.go
@@ -490,7 +490,7 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 
 		podSandboxID := ctr.Sandbox()
 		cState := s.runtime.ContainerStatus(ctr)
-		created := cState.Created.Unix()
+		created := cState.Created.UnixNano()
 		rState := pb.ContainerState_UNKNOWN
 		cID := ctr.ID()
 
@@ -551,21 +551,21 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 	switch cState.Status {
 	case oci.ContainerStateCreated:
 		rStatus = pb.ContainerState_CREATED
-		created := cState.Created.Unix()
+		created := cState.Created.UnixNano()
 		resp.Status.CreatedAt = int64Ptr(created)
 	case oci.ContainerStateRunning:
 		rStatus = pb.ContainerState_RUNNING
-		created := cState.Created.Unix()
+		created := cState.Created.UnixNano()
 		resp.Status.CreatedAt = int64Ptr(created)
-		started := cState.Started.Unix()
+		started := cState.Started.UnixNano()
 		resp.Status.StartedAt = int64Ptr(started)
 	case oci.ContainerStateStopped:
 		rStatus = pb.ContainerState_EXITED
-		created := cState.Created.Unix()
+		created := cState.Created.UnixNano()
 		resp.Status.CreatedAt = int64Ptr(created)
-		started := cState.Started.Unix()
+		started := cState.Started.UnixNano()
 		resp.Status.StartedAt = int64Ptr(started)
-		finished := cState.Finished.Unix()
+		finished := cState.Finished.UnixNano()
 		resp.Status.FinishedAt = int64Ptr(finished)
 		resp.Status.ExitCode = int32Ptr(cState.ExitCode)
 	}

--- a/server/sandbox.go
+++ b/server/sandbox.go
@@ -454,7 +454,7 @@ func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusR
 	}
 
 	cState := s.runtime.ContainerStatus(podInfraContainer)
-	created := cState.Created.Unix()
+	created := cState.Created.UnixNano()
 
 	netNsPath, err := podInfraContainer.NetNsPath()
 	if err != nil {
@@ -545,7 +545,7 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxReque
 			return nil, err
 		}
 		cState := s.runtime.ContainerStatus(podInfraContainer)
-		created := cState.Created.Unix()
+		created := cState.Created.UnixNano()
 		rStatus := pb.PodSandBoxState_NOTREADY
 		if cState.Status == oci.ContainerStateRunning {
 			rStatus = pb.PodSandBoxState_READY


### PR DESCRIPTION
CRI requires all timestamps in nanoseconds instead of seconds.

Signed-off-by: Pengfei Ni <feiskyer@gmail.com>

cc @mrunalp 