### PR TITLE
version: remove checking gRPC version

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -1,15 +1,10 @@
 package server
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
-	"runtime"
 	"strings"
-
-	"github.com/kubernetes-incubator/cri-o/utils"
 )
 
 const (
@@ -28,24 +23,6 @@ func int32Ptr(i int32) *int32 {
 
 func sPtr(s string) *string {
 	return &s
-}
-
-func getGPRCVersion() (string, error) {
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		return "", errors.New("failed to recover the caller information")
-	}
-
-	ocidRoot := filepath.Dir(filepath.Dir(file))
-	p := filepath.Join(ocidRoot, "Godeps/Godeps.json")
-
-	grepCmd := fmt.Sprintf(`grep -r "\"google.golang.org/grpc\"" %s -A 1 | grep "\"Rev\"" | cut -d: -f2 | tr -d ' "\n'`, p)
-
-	out, err := utils.ExecCmd("bash", "-c", grepCmd)
-	if err != nil {
-		return "", err
-	}
-	return out, nil
 }
 
 func copyFile(src, dest string) error {

--- a/server/version.go
+++ b/server/version.go
@@ -7,10 +7,6 @@ import (
 
 // Version returns the runtime name, runtime version and runtime API version
 func (s *Server) Version(ctx context.Context, req *pb.VersionRequest) (*pb.VersionResponse, error) {
-	version, err := getGPRCVersion()
-	if err != nil {
-		return nil, err
-	}
 
 	runtimeVersion, err := s.runtime.Version()
 	if err != nil {
@@ -18,7 +14,7 @@ func (s *Server) Version(ctx context.Context, req *pb.VersionRequest) (*pb.Versi
 	}
 
 	// TODO: Track upstream code. For now it expects 0.1.0
-	version = "0.1.0"
+	version := "0.1.0"
 
 	// taking const address
 	rav := runtimeAPIVersion


### PR DESCRIPTION
gRPC version is not needed in Version() endpoint.
PTAL @runcom 