### PR TITLE
Add runtime status compliant with CRI

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -310,3 +310,15 @@ func newPipe() (parent *os.File, child *os.File, err error) {
 	}
 	return os.NewFile(uintptr(fds[1]), "parent"), os.NewFile(uintptr(fds[0]), "child"), nil
 }
+
+// RuntimeReady checks if the runtime is up and ready to accept
+// basic containers e.g. container only needs host network.
+func (r *Runtime) RuntimeReady() (bool, error) {
+	return true, nil
+}
+
+// NetworkReady checks if the runtime network is up and ready to
+// accept containers which require container network.
+func (r *Runtime) NetworkReady() (bool, error) {
+	return true, nil
+}

--- a/server/container.go
+++ b/server/container.go
@@ -597,5 +597,35 @@ func (s *Server) PortForward(ctx context.Context, req *pb.PortForwardRequest) (*
 
 // Status returns the status of the runtime
 func (s *Server) Status(ctx context.Context, req *pb.StatusRequest) (*pb.StatusResponse, error) {
-	return nil, nil
+
+	// Deal with Runtime conditions
+	runtimeReady, err := s.runtime.RuntimeReady()
+	if err != nil {
+		return nil, err
+	}
+	networkReady, err := s.runtime.NetworkReady()
+	if err != nil {
+		return nil, err
+	}
+
+	// Use vendored strings
+	runtimeReadyConditionString := pb.RuntimeReady
+	networkReadyConditionString := pb.NetworkReady
+
+	resp := &pb.StatusResponse{
+		Status: &pb.RuntimeStatus{
+			Conditions: []*pb.RuntimeCondition{
+				&pb.RuntimeCondition{
+					Type:   &runtimeReadyConditionString,
+					Status: &runtimeReady,
+				},
+				&pb.RuntimeCondition{
+					Type:   &networkReadyConditionString,
+					Status: &networkReady,
+				},
+			},
+		},
+	}
+
+	return resp, nil
 }


### PR DESCRIPTION
[Status](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/api/v1alpha1/runtime/api.pb.go#L3562) is one of the first queries sent to cri-o from kubelet on recent kubernetes master => cri-o crashes on unmarshaling `<nil>`. Added empty functions to provide this functionality. 

Motivation: [StatusResponse](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/api/v1alpha1/runtime/api.pb.go#L2854) --> [RuntimeStatus](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/api/v1alpha1/runtime/api.pb.go#L2827) --> [RuntimeCondition](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/api/v1alpha1/runtime/api.pb.go#L2768)