### PR TITLE
Add support for sysctls

### DIFF
--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -188,6 +188,18 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		g.AddAnnotation(k, v)
 	}
 
+	// extract linux sysctls from annotations and pass down to oci runtime
+	safe, unsafe, err := SysctlsFromPodAnnotations(annotations)
+	if err != nil {
+		return nil, err
+	}
+	for _, sysctl := range safe {
+		g.AddLinuxSysctl(sysctl.Name, sysctl.Value)
+	}
+	for _, sysctl := range unsafe {
+		g.AddLinuxSysctl(sysctl.Name, sysctl.Value)
+	}
+
 	// setup cgroup settings
 	cgroupParent := req.GetConfig().GetLinux().GetCgroupParent()
 	if cgroupParent != "" {

--- a/server/utils.go
+++ b/server/utils.go
@@ -95,3 +95,64 @@ func parseDNSOptions(servers, searches, options []string, path string) error {
 
 	return nil
 }
+
+// TODO: remove sysctl extraction related code here, instead we import from k8s directly.
+
+const (
+	// SysctlsPodAnnotationKey represents the key of sysctls which are set for the infrastructure
+	// container of a pod. The annotation value is a comma separated list of sysctl_name=value
+	// key-value pairs. Only a limited set of whitelisted and isolated sysctls is supported by
+	// the kubelet. Pods with other sysctls will fail to launch.
+	SysctlsPodAnnotationKey string = "security.alpha.kubernetes.io/sysctls"
+
+	// UnsafeSysctlsPodAnnotationKey represents the key of sysctls which are set for the infrastructure
+	// container of a pod. The annotation value is a comma separated list of sysctl_name=value
+	// key-value pairs. Unsafe sysctls must be explicitly enabled for a kubelet. They are properly
+	// namespaced to a pod or a container, but their isolation is usually unclear or weak. Their use
+	// is at-your-own-risk. Pods that attempt to set an unsafe sysctl that is not enabled for a kubelet
+	// will fail to launch.
+	UnsafeSysctlsPodAnnotationKey string = "security.alpha.kubernetes.io/unsafe-sysctls"
+)
+
+// Sysctl defines a kernel parameter to be set
+type Sysctl struct {
+	// Name of a property to set
+	Name string `json:"name"`
+	// Value of a property to set
+	Value string `json:"value"`
+}
+
+// SysctlsFromPodAnnotations parses the sysctl annotations into a slice of safe Sysctls
+// and a slice of unsafe Sysctls. This is only a convenience wrapper around
+// SysctlsFromPodAnnotation.
+func SysctlsFromPodAnnotations(a map[string]string) ([]Sysctl, []Sysctl, error) {
+	safe, err := SysctlsFromPodAnnotation(a[SysctlsPodAnnotationKey])
+	if err != nil {
+		return nil, nil, err
+	}
+	unsafe, err := SysctlsFromPodAnnotation(a[UnsafeSysctlsPodAnnotationKey])
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return safe, unsafe, nil
+}
+
+// SysctlsFromPodAnnotation parses an annotation value into a slice of Sysctls.
+func SysctlsFromPodAnnotation(annotation string) ([]Sysctl, error) {
+	if len(annotation) == 0 {
+		return nil, nil
+	}
+
+	kvs := strings.Split(annotation, ",")
+	sysctls := make([]Sysctl, len(kvs))
+	for i, kv := range kvs {
+		cs := strings.Split(kv, "=")
+		if len(cs) != 2 || len(cs[0]) == 0 {
+			return nil, fmt.Errorf("sysctl %q not of the format sysctl_name=value", kv)
+		}
+		sysctls[i].Name = cs[0]
+		sysctls[i].Value = cs[1]
+	}
+	return sysctls, nil
+}

--- a/test/testdata/sandbox_config.json
+++ b/test/testdata/sandbox_config.json
@@ -46,7 +46,9 @@
 		"group": "test"
 	},
 	"annotations": {
-		"owner": "hmeng"
+		"owner": "hmeng",
+		"security.alpha.kubernetes.io/sysctls": "kernel.shm_rmid_forced=1,net.ipv4.ip_local_port_range=1024 65000",
+		"security.alpha.kubernetes.io/unsafe-sysctls": "kernel.msgmax=8192" 
 	},
 	"linux": {
 		"cgroup_parent": "podsandbox1.slice:container:infra",


### PR DESCRIPTION
close #198 
1. extract sysctls config from annotations and set to oci spec config, treat safe/unsafe sysctls in the same way here.
2. add test case for sysctls, mainly test whether sysctls have been pass to spec config, and whether pod can  start with some specified sysctls. 
Note: the valid of sysctls may be concerned with kernel version( see opencontainers/runc#1193), I picked three I think it's general here. But if someone failed to pass the case, pls let me know that. Or any advice?