### PR TITLE
execsync: return proper error description

### DIFF
--- a/server/container_execsync.go
+++ b/server/container_execsync.go
@@ -32,6 +32,9 @@ func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (*pb.Exe
 	}
 
 	execResp, err := s.runtime.ExecSync(c, cmd, req.GetTimeout())
+	if err != nil {
+		return nil, err
+	}
 	resp := &pb.ExecSyncResponse{
 		Stdout:   execResp.Stdout,
 		Stderr:   execResp.Stderr,
@@ -39,5 +42,5 @@ func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (*pb.Exe
 	}
 
 	logrus.Debugf("ExecSyncResponse: %+v", resp)
-	return resp, err
+	return resp, nil
 }

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -360,3 +360,31 @@ function teardown() {
 	cleanup_pods
 	stop_ocid
 }
+
+@test "ctr execsync failure" {
+	# this test requires docker, thus it can't yet be run in a container
+	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
+		skip "cannot yet run this test in a container, use sudo make localintegration"
+	fi
+
+	start_ocid
+	run ocic pod create --config "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+	run ocic ctr create --config "$TESTDATA"/container_redis.json --pod "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run ocic ctr start --id "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run ocic ctr execsync --id "$ctr_id" doesnotexist
+	echo "$output"
+	[ "$status" -ne 0 ]
+	[[ "$output" =~ "executable file not found in" ]]
+
+	cleanup_ctrs
+	cleanup_pods
+	stop_ocid
+}


### PR DESCRIPTION
The gprc execsync client call doesn't populate `ExecSyncResponse` on
error at all. You just get an error https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/api/v1alpha1/runtime/api.pb.go#L3144.
This patch modifies the code to include command's streams, exit code
and error direcly into the error. `ocic` will then print useful
infomation in the cli, otherwise it won't.

found while working on https://github.com/kubernetes-incubator/cri-o/pull/211
@mrunalp PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>