### PR TITLE
Dockerfile: bump to golang 1.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.1
+FROM golang:1.7.3
 
 # libseccomp in jessie is not _quite_ new enough -- need backports version
 RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/backports.list


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>