### PR TITLE
server: Export more container metadata for VM containers

### DIFF
--- a/server/container.go
+++ b/server/container.go
@@ -6,6 +6,13 @@ import (
 	"github.com/kubernetes-incubator/cri-o/oci"
 )
 
+const (
+	// containerTypeSandbox represents a pod sandbox container
+	containerTypeSandbox = "sandbox"
+	// containerTypeContainer represents a container running within a pod
+	containerTypeContainer = "container"
+)
+
 type containerRequest interface {
 	GetContainerId() string
 }

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -275,6 +275,8 @@ func (s *Server) createSandboxContainer(containerID string, containerName string
 
 	specgen.AddAnnotation("ocid/name", containerName)
 	specgen.AddAnnotation("ocid/sandbox_id", sb.id)
+	specgen.AddAnnotation("ocid/sandbox_name", sb.infraContainer.Name())
+	specgen.AddAnnotation("ocid/container_type", containerTypeContainer)
 	specgen.AddAnnotation("ocid/log_path", logPath)
 	specgen.AddAnnotation("ocid/tty", fmt.Sprintf("%v", containerConfig.GetTty()))
 

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -167,6 +167,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	g.AddAnnotation("ocid/annotations", string(annotationsJSON))
 	g.AddAnnotation("ocid/log_path", logDir)
 	g.AddAnnotation("ocid/name", name)
+	g.AddAnnotation("ocid/container_type", containerTypeSandbox)
 	g.AddAnnotation("ocid/container_name", containerName)
 	g.AddAnnotation("ocid/container_id", containerID)
 


### PR DESCRIPTION
VM base container runtimes (e.g. Clear Containers) will run each pod
in a VM and will create containers within that pod VM. Unfortunately
those runtimes will get called by ocid with the same commands
(create and start) for both the pause containers and subsequent
containers to be added to the pod namespace. Unless they work around
that by e.g. infering that a container which rootfs is under
"/pause" would represent a pod, they have no way to decide if they
need to create/start a VM or if they need to add a container to an
already running VM pod.

This patch tries to formalize this difference through pod
annotations. When starting a container or a sandbox, we now add 2
annotations for the container type (Infrastructure or not) and the
sandbox name. This will allow VM based container runtimes to handle 2
things:

- Decide if they need to create a pod VM or not.
- Keep track of which pod ID runs in a given VM, so that they
  know to which sandbox they have to add containers.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>