### PR TITLE
Add README for kpod

### DIFF
--- a/cmd/kpod/README.md
+++ b/cmd/kpod/README.md
@@ -1,0 +1,16 @@
+# kpod - Simple debugging tool for pods and images
+kpod is a simple client only tool to help with debugging issues when daemons such as CRI runtime and the kubelet are not responding or
+failing. A shared API layer could be created to share code between the daemon and kpod. kpod does not require any daemon running. kpod
+utilizes the same underlying components that ocid uses i.e. containers/image, container/storage, oci-runtime-tool/generate, runc or
+any other OCI compatible runtime. kpod shares state with ocid and so has the capability to debug pods/images created by ocid.
+
+## Use cases
+1. List pods.
+2. Launch simple pods (that require no daemon support).
+3. Exec commands in a container in a pod.
+4. Launch additional containers in a pod.
+5. List images.
+6. Remove images not in use.
+7. Pull images.
+8. Check image size.
+9. Report pod disk resource usage.


### PR DESCRIPTION
We have gotten feedback from discussions with kubernetes developers that we need a utility to debug pods and images when the daemons are wedged. This PR proposes kpod to fulfill the role.

Signed-off-by: Mrunal Patel <mpatel@redhat.com>