### PR TITLE
Add basic skeleton of kpod executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /ocid
 /ocic
+/kpod
 conmon/conmon
 conmon/conmon.o
 pause/pause

--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,16 @@ ocid: $(GO_SRC) | ${OCID_LINK}
 ocic: $(GO_SRC) | ${OCID_LINK}
 	$(GO) build -o $@ ./cmd/client/
 
+kpod: $(GO_SRC) | ${OCID_LINK}
+	$(GO) build -o $@ ./cmd/kpod/
+
 ocid.conf: ocid
 	./ocid --config="" config --default > ocid.conf
 
 clean:
 	rm -f ocid.conf
 	rm -f ocic ocid
+	rm -f kpod
 	rm -f ${OCID_LINK}
 	rm -f docs/*.5 docs/*.8
 	find . -name \*~ -delete
@@ -77,7 +81,7 @@ integration: ocidimage
 localintegration: binaries
 	./test/test_runner.sh ${TESTFLAGS}
 
-binaries: ocid ocic conmon pause
+binaries: ocid ocic kpod conmon pause
 
 MANPAGES_MD := $(wildcard docs/*.md)
 MANPAGES    := $(MANPAGES_MD:%.md=%)

--- a/cmd/kpod/launch.go
+++ b/cmd/kpod/launch.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+)
+
+// TODO implement
+var launchCommand = cli.Command{
+	Name:  "launch",
+	Usage: "launch a pod",
+	Action: func(context *cli.Context) error {
+		return fmt.Errorf("this functionality is not yet implemented")
+	},
+}

--- a/cmd/kpod/main.go
+++ b/cmd/kpod/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "kpod"
+	app.Usage = "manage pods and images"
+	app.Version = "0.0.1"
+
+	app.Commands = []cli.Command{
+		launchCommand,
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		logrus.Fatal(err)
+	}
+}


### PR DESCRIPTION
Add a basic framework for kpod, a debugging tool for Kubernetes and cri-o. The goals of kpod are described in the recently-merged readme (#220). Actual code will follow, as there's a bit of refactoring needed to allow code to be used by both the cri-o server and kpod. 