### PR TITLE
Make RemovePodSandbox idempotent

### DIFF
--- a/server/sandbox.go
+++ b/server/sandbox.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/docker/docker/pkg/stringid"
@@ -24,6 +25,10 @@ type sandbox struct {
 
 const (
 	podDefaultNamespace = "default"
+)
+
+var (
+	errSandboxIDEmpty = errors.New("PodSandboxId should not be empty")
 )
 
 func (s *sandbox) addContainer(c *oci.Container) {
@@ -60,7 +65,7 @@ type podSandboxRequest interface {
 func (s *Server) getPodSandboxFromRequest(req podSandboxRequest) (*sandbox, error) {
 	sbID := req.GetPodSandboxId()
 	if sbID == "" {
-		return nil, fmt.Errorf("PodSandboxId should not be empty")
+		return nil, errSandboxIDEmpty
 	}
 
 	sandboxID, err := s.podIDIndex.Get(sbID)

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -18,7 +18,13 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 	logrus.Debugf("RemovePodSandboxRequest %+v", req)
 	sb, err := s.getPodSandboxFromRequest(req)
 	if err != nil {
-		return nil, err
+		if err == errSandboxIDEmpty {
+			return nil, err
+		}
+
+		resp := &pb.RemovePodSandboxResponse{}
+		logrus.Warnf("could not get sandbox %s, it's probably been removed already: %v", req.GetPodSandboxId(), err)
+		return resp, nil
 	}
 
 	podInfraContainer := sb.infraContainer


### PR DESCRIPTION
And in particular make it not fail when removing an already removed
sandbox pod. According to the CRI spec:

  [RemovePodSandbox] is idempotent, and must not return an error if
  the sandbox has already been removed.

We now only print a warning instead of returning an error.

Fixes #240

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>