### PR TITLE
testdata: sandbox ns options should be under security_context

### DIFF
--- a/test/testdata/sandbox_config.json
+++ b/test/testdata/sandbox_config.json
@@ -53,10 +53,11 @@
 	},
 	"linux": {
 		"cgroup_parent": "podsandbox1.slice:container:infra",
-		"namespace_options": {
-			"host_network": false,
-			"host_pid": false,
-			"host_ipc": false
-		}
+		"security_context": {
+			"namespace_options": {
+				"host_network": false,
+				"host_pid": false,
+				"host_ipc": false
+			}
 	}
 }

--- a/test/testdata/sandbox_config_seccomp.json
+++ b/test/testdata/sandbox_config_seccomp.json
@@ -51,10 +51,11 @@
 	},
 	"linux": {
 		"cgroup_parent": "podsandbox1.slice:container:infra",
-		"namespace_options": {
-			"host_network": false,
-			"host_pid": false,
-			"host_ipc": false
-		}
+		"security_context": {
+			"namespace_options": {
+				"host_network": false,
+				"host_pid": false,
+				"host_ipc": false
+			}
 	}
 }


### PR DESCRIPTION
And not directly under linux.

Fixes #243

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>