### PR TITLE
testdata: fix invalid json doc

### DIFF
--- a/test/testdata/sandbox_config.json
+++ b/test/testdata/sandbox_config.json
@@ -59,5 +59,6 @@
 				"host_pid": false,
 				"host_ipc": false
 			}
+		}
 	}
 }


### PR DESCRIPTION
The json doc referenced by the README was missing a closed curly.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>