### PR TITLE
Fix panic create container when sb is fail

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -271,6 +271,10 @@ func (s *Server) createSandboxContainer(containerID string, containerName string
 	// Join the namespace paths for the pod sandbox container.
 	podInfraState := s.runtime.ContainerStatus(sb.infraContainer)
 
+	if podInfraState == nil {
+		return nil, fmt.Errorf("state of infra container of given sandbox: %q is nil, which is unexpected", sb.metadata.GetName())
+	}
+
 	logrus.Debugf("pod container state %+v", podInfraState)
 
 	for nsType, nsFile := range map[string]string{


### PR DESCRIPTION
When manually testing cri-o, in some cases e.g. the sandbox fail due to mis-configuration etc, the `podInfraState` may be nil, then create container will panic ocid.

This fix added a check to `podInfraState`.

Signed-off-by: Harry Zhang <harryz@hyper.sh>