### PR TITLE
store annotations and image for a container

### DIFF
--- a/cmd/client/container.go
+++ b/cmd/client/container.go
@@ -505,6 +505,9 @@ func ListContainers(client pb.RuntimeServiceClient, opts listOptions) error {
 		if c.State != nil {
 			fmt.Printf("Status: %s\n", *c.State)
 		}
+		if c.Image != nil {
+			fmt.Printf("Image: %s\n", c.Image.GetImage())
+		}
 		if c.CreatedAt != nil {
 			ctm := time.Unix(0, *c.CreatedAt)
 			fmt.Printf("Created: %v\n", ctm)

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -336,16 +336,18 @@ func (r *Runtime) ContainerStatus(c *Container) *ContainerState {
 
 // Container respresents a runtime container.
 type Container struct {
-	id         string
-	name       string
-	bundlePath string
-	logPath    string
-	labels     fields.Set
-	sandbox    string
-	terminal   bool
-	state      *ContainerState
-	metadata   *pb.ContainerMetadata
-	stateLock  sync.Mutex
+	id          string
+	name        string
+	bundlePath  string
+	logPath     string
+	labels      fields.Set
+	annotations fields.Set
+	image       *pb.ImageSpec
+	sandbox     string
+	terminal    bool
+	state       *ContainerState
+	metadata    *pb.ContainerMetadata
+	stateLock   sync.Mutex
 }
 
 // ContainerState represents the status of a container.
@@ -358,16 +360,18 @@ type ContainerState struct {
 }
 
 // NewContainer creates a container object.
-func NewContainer(id string, name string, bundlePath string, logPath string, labels map[string]string, metadata *pb.ContainerMetadata, sandbox string, terminal bool) (*Container, error) {
+func NewContainer(id string, name string, bundlePath string, logPath string, labels map[string]string, annotations map[string]string, image *pb.ImageSpec, metadata *pb.ContainerMetadata, sandbox string, terminal bool) (*Container, error) {
 	c := &Container{
-		id:         id,
-		name:       name,
-		bundlePath: bundlePath,
-		logPath:    logPath,
-		labels:     labels,
-		sandbox:    sandbox,
-		terminal:   terminal,
-		metadata:   metadata,
+		id:          id,
+		name:        name,
+		bundlePath:  bundlePath,
+		logPath:     logPath,
+		labels:      labels,
+		sandbox:     sandbox,
+		terminal:    terminal,
+		metadata:    metadata,
+		annotations: annotations,
+		image:       image,
 	}
 	return c, nil
 }
@@ -395,6 +399,16 @@ func (c *Container) LogPath() string {
 // Labels returns the labels of the container.
 func (c *Container) Labels() map[string]string {
 	return c.labels
+}
+
+// Annotations returns the annotations of the container.
+func (c *Container) Annotations() map[string]string {
+	return c.annotations
+}
+
+// Image returns the image of the container.
+func (c *Container) Image() *pb.ImageSpec {
+	return c.image
 }
 
 // Sandbox returns the sandbox name of the container.

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -82,6 +82,8 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 			CreatedAt:    int64Ptr(created),
 			Labels:       ctr.Labels(),
 			Metadata:     ctr.Metadata(),
+			Annotations:  ctr.Annotations(),
+			Image:        ctr.Image(),
 		}
 
 		switch cState.Status {

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -267,7 +267,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 	}
 
-	container, err := oci.NewContainer(containerID, containerName, podSandboxDir, podSandboxDir, labels, nil, id, false)
+	container, err := oci.NewContainer(containerID, containerName, podSandboxDir, podSandboxDir, labels, annotations, nil, nil, id, false)
 	if err != nil {
 		return nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -79,7 +79,20 @@ func (s *Server) loadContainer(id string) error {
 	}
 	containerPath := filepath.Join(s.runtime.ContainerDir(), id)
 
-	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations["ocid/log_path"], labels, &metadata, sb.id, tty)
+	var img *pb.ImageSpec
+	image, ok := m.Annotations["ocid/image"]
+	if ok {
+		img = &pb.ImageSpec{
+			Image: &image,
+		}
+	}
+
+	annotations := make(map[string]string)
+	if err = json.Unmarshal([]byte(m.Annotations["ocid/annotations"]), &annotations); err != nil {
+		return err
+	}
+
+	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations["ocid/log_path"], labels, annotations, img, &metadata, sb.id, tty)
 	if err != nil {
 		return err
 	}
@@ -150,7 +163,7 @@ func (s *Server) loadSandbox(id string) error {
 	if err != nil {
 		return err
 	}
-	scontainer, err := oci.NewContainer(m.Annotations["ocid/container_id"], cname, sandboxPath, sandboxPath, labels, nil, id, false)
+	scontainer, err := oci.NewContainer(m.Annotations["ocid/container_id"], cname, sandboxPath, sandboxPath, labels, annotations, nil, nil, id, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
First of all - thanks to @jjlakis for the patience he went through this issue with me on Slack. All credits for this PR goes to him.

Long story: while testing k8s integration (with #189), pods with `RestartPolicy: Always` failed to run and were always restarted by the kubelet, eventually failing with a conflict about containers names.
This patch makes sure we return annotations and image in contaienrs listing so that the kubelet isn't fooled by the container computed hash used to check if a container has changed (and other stuff). Basically the kubelet didn't understand if a container was already running by looking at the containers list and kept re-running the container (note, this wasn't happening with `--restart=Never`).

/cc @mrunalp @jjlakis  

Signed-off-by: Antonio Murdaca <runcom@redhat.com>