### PR TITLE
server: check for expected files

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -163,6 +163,10 @@ func main() {
 			return err
 		}
 
+		if err := config.Check(); err != nil {
+			return err
+		}
+
 		cf := &logrus.TextFormatter{
 			TimestampFormat: "2006-01-02 15:04:05.000000000Z07:00",
 			FullTimestamp:   true,


### PR DESCRIPTION
When the configuration is loaded, check that expected files are present
early. This can prevent getting into a partial state later.

Now the output would like this if `pause` was missing:
```
[vbatts@valse] {master *} ~/src/github.com/kubernetes-incubator/cri-o$ sudo ./ocid --runtime $(which runc) --debug --seccomp-profile $(readlink -f ./tmp/etc/ocid/seccomp.json) --config $(readlink -f ./tmp/etc/ocid/ocid.conf)  --containerdir $(readlink -f ./tmp/containers/ ) --conmon $(readlink -f ./conmon/conmon)
"/usr/libexec/ocid/pause" does not exist

NAME:
   ocid - ocid server

USAGE:
   ocid [global options] command [command options] [arguments...]

VERSION:
   0.0.1

COMMANDS:
     config   generate ocid configuration files
     help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --apparmor-profile value  default apparmor profile name (default: "ocid-default")
   --config value            path to configuration file (default: "/etc/ocid/ocid.conf")
   --conmon value            path to the conmon executable
   --containerdir value      ocid container dir
   --debug                   enable debug output for logging
   --listen value            path to ocid socket
   --log value               set the log file path where internal debug information is written
   --log-format value        set the format used by logs ('text' (default), or 'json') (default: "text")
   --pause value             path to the pause executable
   --root value              ocid root dir
   --runtime value           OCI runtime path
   --sandboxdir value        ocid pod sandbox dir
   --seccomp-profile value   default seccomp profile path
   --selinux                 enable selinux support
   --help, -h                show help
   --version, -v             print the version

FATA[0000] "/usr/libexec/ocid/pause" does not exist
```


Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>