### PR TITLE
Support pod level qos in cri-o

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -251,6 +251,11 @@ func (s *Server) createSandboxContainer(containerID string, containerName string
 			specgen.SetLinuxResourcesOOMScoreAdj(int(oomScoreAdj))
 		}
 
+		if sb.cgroupParent != "" {
+			// NOTE: we only support cgroupfs for now, discussion happens in issue #270.
+			specgen.SetLinuxCgroupsPath(sb.cgroupParent + "/" + containerID)
+		}
+
 		capabilities := linux.GetSecurityContext().GetCapabilities()
 		if capabilities != nil {
 			addCaps := capabilities.GetAddCapabilities()

--- a/server/sandbox.go
+++ b/server/sandbox.go
@@ -9,20 +9,20 @@ import (
 	"sync"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/kubernetes-incubator/cri-o/oci"
-	"github.com/containernetworking/cni/pkg/ns"
+	"golang.org/x/sys/unix"
 	"k8s.io/kubernetes/pkg/fields"
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
-	"golang.org/x/sys/unix"
 )
 
 type sandboxNetNs struct {
 	sync.Mutex
-	ns        ns.NetNS
-	symlink   *os.File
-	closed    bool
-	restored  bool
+	ns       ns.NetNS
+	symlink  *os.File
+	closed   bool
+	restored bool
 }
 
 func (ns *sandboxNetNs) symlinkCreate(name string) error {
@@ -138,6 +138,7 @@ type sandbox struct {
 	netns          *sandboxNetNs
 	metadata       *pb.PodSandboxMetadata
 	shmPath        string
+	cgroupParent   string
 }
 
 const (
@@ -190,7 +191,7 @@ func (s *sandbox) netNsCreate() error {
 	}
 
 	s.netns = &sandboxNetNs{
-		ns: netNS,
+		ns:     netNS,
 		closed: false,
 	}
 

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -245,7 +245,9 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	// setup cgroup settings
 	cgroupParent := req.GetConfig().GetLinux().GetCgroupParent()
 	if cgroupParent != "" {
-		g.SetLinuxCgroupsPath(cgroupParent)
+		// NOTE: we only support cgroupfs for now, discussion happens in issue #270.
+		g.SetLinuxCgroupsPath(cgroupParent + "/" + containerID)
+		sb.cgroupParent = cgroupParent
 	}
 
 	// set up namespaces
@@ -273,7 +275,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 			if netnsErr := sb.netNsRemove(); netnsErr != nil {
 				logrus.Warnf("Failed to remove networking namespace: %v", netnsErr)
 			}
-		} ()
+		}()
 
 		// Pass the created namespace path to the runtime
 		err = g.AddOrReplaceLinuxNamespace("network", sb.netNsPath())


### PR DESCRIPTION
This PR makes cri-o support pod level qos model introduced recently by kubernetes.

This feature is required by new resource qos tiers model, and VM based containers like runv and cc can also read pod level qos value to decide the resource boundary for the sandbox.

NOTE: systemd cgroup support is discussed in #270.

Signed-off-by: Harry Zhang <harryz@hyper.sh>