### PR TITLE
server: remove reaper, let runc take care of reaping

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -17,8 +17,8 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/kubernetes-incubator/cri-o/utils"
 	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/kubernetes-incubator/cri-o/utils"
 	"golang.org/x/sys/unix"
 	"k8s.io/kubernetes/pkg/fields"
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
@@ -275,6 +275,7 @@ func (r *Runtime) StopContainer(c *Container) error {
 			if err != nil && err != syscall.ESRCH {
 				return fmt.Errorf("failed to kill process: %v", err)
 			}
+			break
 		}
 		// Check if the process is still around
 		err := unix.Kill(c.state.Pid, 0)

--- a/server/server.go
+++ b/server/server.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kubernetes-incubator/cri-o/oci"
 	"github.com/kubernetes-incubator/cri-o/server/apparmor"
 	"github.com/kubernetes-incubator/cri-o/server/seccomp"
-	"github.com/kubernetes-incubator/cri-o/utils"
 	"github.com/opencontainers/runc/libcontainer/label"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/rajatchopra/ocicni"
@@ -297,14 +296,6 @@ func seccompEnabled() bool {
 
 // New creates a new Server with options provided
 func New(config *Config) (*Server, error) {
-	// TODO: This will go away later when we have wrapper process or systemd acting as
-	// subreaper.
-	if err := utils.SetSubreaper(1); err != nil {
-		return nil, fmt.Errorf("failed to set server as subreaper: %v", err)
-	}
-
-	utils.StartReaper()
-
 	if err := os.MkdirAll(config.ImageDir, 0755); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is likely fixing tests and `wait: no child processes` error when running `cri-o`.

Fix https://github.com/kubernetes-incubator/cri-o/issues/268

@mrunalp @jjlakis @feiskyer @Crazykev please test this out (as I cannot reproduce `ECHILD` error anymore with this patch) 

runc does already take care of reaping childs (as I read the code) - I believe we're late here in to reap and killing/stopping/removing/state causes ECHILD so frequently when ops are really fast.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>