### PR TITLE
ocid, docs: change default runc path

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -94,7 +94,7 @@ func DefaultConfig() *server.Config {
 			Listen: "/var/run/ocid.sock",
 		},
 		RuntimeConfig: server.RuntimeConfig{
-			Runtime: "/usr/bin/runc",
+			Runtime: "/usr/sbin/runc",
 			Conmon:  conmonPath,
 			ConmonEnv: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",

--- a/docs/ocid.8.md
+++ b/docs/ocid.8.md
@@ -72,7 +72,7 @@ ocid is meant to provide an integration path between OCI conformant runtimes and
   OCID root dir (default: "/var/lib/ocid")
 
 **--runtime**=""
-  OCI runtime path (default: "/usr/bin/runc")
+  OCI runtime path (default: "/usr/sbin/runc")
 
 **--sandboxdir**=""
   OCID pod sandbox dir (default: "/var/lib/ocid/sandboxes")

--- a/docs/ocid.conf.5.md
+++ b/docs/ocid.conf.5.md
@@ -53,7 +53,7 @@ The `ocid` table supports the following options:
   Environment variable list for conmon process (default: ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",])
 
 **runtime**=""
-  OCI runtime path (default: "/usr/bin/runc")
+  OCI runtime path (default: "/usr/sbin/runc")
 
 **selinux**=*true*|*false*
   Enable selinux support (default: false)


### PR DESCRIPTION
After installing runc via package manager:

```
whereis runc
runc: /usr/sbin/runc /usr/share/man/man8/runc.8.gz
```

So `/usr/bin/runc` looks like old path