### PR TITLE
OWNERS: add @sameo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,3 +5,4 @@ assignees:
   - cyphar
   - mikebrow
   - feiskyer
+  - sameo


### PR DESCRIPTION
@kubernetes-incubator/maintainers-cri-o PTAL

@sameo has been helping a lot on the networking side of `cri-o` and we can now fully run cri-o fully backed by CNI. Would be great to have him on board.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>