### PR TITLE
server: mock UpdateRuntimeConfig

### DIFF
--- a/server/container_updateruntimeconfig.go
+++ b/server/container_updateruntimeconfig.go
@@ -7,5 +7,5 @@ import (
 
 // UpdateRuntimeConfig updates the configuration of a running container.
 func (s *Server) UpdateRuntimeConfig(ctx context.Context, req *pb.UpdateRuntimeConfigRequest) (*pb.UpdateRuntimeConfigResponse, error) {
-	return nil, nil
+	return &pb.UpdateRuntimeConfigResponse{}, nil
 }


### PR DESCRIPTION
k8s's e2e node tests does a call to updateruntimeconfig to set the network CIDR - unfortunately playing with CNI conf file to update `IPAM.Subnet` is infeasible and awful to me (maybe we should try to find a way to `SetCIDR` for a network in CNI (or `ocicni`) /cc @sameo). So, I just mocked the call so that cri-o doesn't crash when returning `nil` to the grpc API.

@mrunalp PTAL (@sameo PTAL at the network stuff)

Signed-off-by: Antonio Murdaca <runcom@redhat.com>