### PR TITLE
Add Initial networking BATs

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -17,6 +17,8 @@ const (
 	seccompProfilePath  = "/etc/ocid/seccomp.json"
 	apparmorProfileName = "ocid-default"
 	cgroupManager       = "cgroupfs"
+	cniConfigDir        = "/etc/cni/net.d/"
+	cniBinDir           = "/opt/cni/bin/"
 )
 
 var commentedConfigTemplate = template.Must(template.New("config").Parse(`
@@ -81,6 +83,17 @@ cgroup_manager = "{{ .CgroupManager }}"
 # pause is the path to the statically linked pause container binary, used
 # as the entrypoint for infra containers.
 pause = "{{ .Pause }}"
+
+# The "ocid.network" table contains settings pertaining to the
+# management of CNI plugins.
+[ocid.network]
+
+# network_dir is is where CNI network configuration
+# files are stored.
+network_dir = "{{ .NetworkDir }}"
+
+# plugin_dir is is where CNI plugin binaries are stored.
+plugin_dir = "{{ .PluginDir }}"
 `))
 
 // TODO: Currently ImageDir isn't really used, so we haven't added it to this
@@ -112,6 +125,10 @@ func DefaultConfig() *server.Config {
 		ImageConfig: server.ImageConfig{
 			Pause:    pausePath,
 			ImageDir: filepath.Join(ocidRoot, "store"),
+		},
+		NetworkConfig: server.NetworkConfig{
+			NetworkDir: cniConfigDir,
+			PluginDir:  cniBinDir,
 		},
 	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -66,6 +66,12 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("cgroup-manager") {
 		config.CgroupManager = ctx.GlobalString("cgroup-manager")
 	}
+	if ctx.GlobalIsSet("cni-config-dir") {
+		config.NetworkDir = ctx.GlobalString("cni-config-dir")
+	}
+	if ctx.GlobalIsSet("cni-plugin-dir") {
+		config.PluginDir = ctx.GlobalString("cni-plugin-dir")
+	}
 	return nil
 }
 
@@ -156,6 +162,14 @@ func main() {
 		cli.StringFlag{
 			Name:  "cgroup-manager",
 			Usage: "cgroup manager (cgroupfs or systemd)",
+		},
+		cli.StringFlag{
+			Name:  "cni-config-dir",
+			Usage: "CNI configuration files directory",
+		},
+		cli.StringFlag{
+			Name:  "cni-plugin-dir",
+			Usage: "CNI plugin binaries directory",
 		},
 	}
 

--- a/docs/ocid.8.md
+++ b/docs/ocid.8.md
@@ -21,6 +21,8 @@ ocid - Enable OCI Kubernetes Container Runtime daemon
 [**--selinux**]
 [**--seccomp-profile**=[*value*]]
 [**--apparmor-profile**=[*value*]]
+[**---cni-config-dir**=[*value*]]
+[**---cni-plugin-dir**=[*value*]]
 [**--version**|**-v**]
 
 # DESCRIPTION
@@ -85,6 +87,12 @@ ocid is meant to provide an integration path between OCI conformant runtimes and
 
 **--apparmor_profile**=""
   Name of the apparmor profile to be used as the runtime's default (default: "ocid-default")
+
+**--cni-config-dir**=""
+  CNI configuration files directory (defautl: "/etc/cni/net.d/")
+
+**--cni-plugin-dir**=""
+  CNI plugin binaries directory (defautl: "/opt/cni/bin/")
 
 **--version, -v**
   Print the version

--- a/docs/ocid.conf.5.md
+++ b/docs/ocid.conf.5.md
@@ -69,6 +69,14 @@ The `ocid` table supports the following options:
 **pause**=""
   Path to the pause executable (default: "/usr/libexec/ocid/pause")
 
+## OCID.NETWORK TABLE
+
+**network_dir**=""
+  Path to CNI configuration files (default: "/etc/cni/net.d/")
+
+**plugin_dir**=""
+  Path to CNI plugin binaries (default: "/opt/cni/bin/")
+
 # SEE ALSO
 ocid(8)
 

--- a/server/config.go
+++ b/server/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	APIConfig
 	RuntimeConfig
 	ImageConfig
+	NetworkConfig
 }
 
 // This structure is necessary to fake the TOML tables when parsing,
@@ -93,6 +94,15 @@ type ImageConfig struct {
 	ImageDir string `toml:"image_dir"`
 }
 
+// NetworkConfig represents the "ocid.network" TOML config table
+type NetworkConfig struct {
+	// NetworkDir is where CNI network configuration files are stored.
+	NetworkDir string `toml:"network_dir"`
+
+	// PluginDir is where CNI plugin binaries are stored.
+	PluginDir string `toml:"plugin_dir"`
+}
+
 // tomlConfig is another way of looking at a Config, which is
 // TOML-friendly (it has all of the explicit tables). It's just used for
 // conversions.
@@ -102,6 +112,7 @@ type tomlConfig struct {
 		API     struct{ APIConfig }     `toml:"api"`
 		Runtime struct{ RuntimeConfig } `toml:"runtime"`
 		Image   struct{ ImageConfig }   `toml:"image"`
+		Network struct{ NetworkConfig } `toml:"network"`
 	} `toml:"ocid"`
 }
 
@@ -110,6 +121,7 @@ func (t *tomlConfig) toConfig(c *Config) {
 	c.APIConfig = t.Ocid.API.APIConfig
 	c.RuntimeConfig = t.Ocid.Runtime.RuntimeConfig
 	c.ImageConfig = t.Ocid.Image.ImageConfig
+	c.NetworkConfig = t.Ocid.Network.NetworkConfig
 }
 
 func (t *tomlConfig) fromConfig(c *Config) {
@@ -117,6 +129,7 @@ func (t *tomlConfig) fromConfig(c *Config) {
 	t.Ocid.API.APIConfig = c.APIConfig
 	t.Ocid.Runtime.RuntimeConfig = c.RuntimeConfig
 	t.Ocid.Image.ImageConfig = c.ImageConfig
+	t.Ocid.Network.NetworkConfig = c.NetworkConfig
 }
 
 // FromFile populates the Config from the TOML-encoded file at the given path.

--- a/server/server.go
+++ b/server/server.go
@@ -310,7 +310,7 @@ func New(config *Config) (*Server, error) {
 	}
 	sandboxes := make(map[string]*sandbox)
 	containers := oci.NewMemoryStore()
-	netPlugin, err := ocicni.InitCNI("")
+	netPlugin, err := ocicni.InitCNI(config.NetworkDir)
 	if err != nil {
 		return nil, err
 	}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -46,6 +46,7 @@ fi
 OCID_SOCKET="$TESTDIR/ocid.sock"
 OCID_CONFIG="$TESTDIR/ocid.conf"
 OCID_CNI_CONFIG="$TESTDIR/cni/net.d/"
+OCID_CNI_PLUGIN="/opt/cni/bin/"
 POD_CIDR="10.88.0.0/16"
 POD_CIDR_MASK="10.88.*.*"
 

--- a/test/network.bats
+++ b/test/network.bats
@@ -8,6 +8,14 @@ load helpers
 		skip "cannot yet run this test in a container, use sudo make localintegration"
 	fi
 
+	if [ ! -f "$OCID_CNI_PLUGIN/bridge" ]; then
+		skip "missing CNI bridge plugin, please install it"
+	fi
+
+	if [ ! -f "$OCID_CNI_PLUGIN/host-local" ]; then
+		skip "missing CNI host-local IPAM, please install it"
+	fi
+
 	prepare_network_conf $POD_CIDR
 
 	start_ocid
@@ -27,6 +35,14 @@ load helpers
 	# this test requires docker, thus it can't yet be run in a container
 	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
 		skip "cannot yet run this test in a container, use sudo make localintegration"
+	fi
+
+	if [ ! -f "$OCID_CNI_PLUGIN/bridge" ]; then
+		skip "missing CNI bridge plugin, please install it"
+	fi
+
+	if [ ! -f "$OCID_CNI_PLUGIN/host-local" ]; then
+		skip "missing CNI host-local IPAM, please install it"
 	fi
 
 	prepare_network_conf $POD_CIDR

--- a/test/network.bats
+++ b/test/network.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "Check for valid pod netns CIDR" {
+	# this test requires docker, thus it can't yet be run in a container
+	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
+		skip "cannot yet run this test in a container, use sudo make localintegration"
+	fi
+
+	prepare_network_conf $POD_CIDR
+
+	start_ocid
+	run ocic pod run --config "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	check_pod_cidr $pod_id
+
+	cleanup_pods
+	cleanup_network_conf
+	stop_ocid
+}
+
+@test "Ping pod netns from the host" {
+	# this test requires docker, thus it can't yet be run in a container
+	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
+		skip "cannot yet run this test in a container, use sudo make localintegration"
+	fi
+
+	prepare_network_conf $POD_CIDR
+
+	start_ocid
+	run ocic pod run --config "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	ping_pod $pod_id
+
+	cleanup_pods
+	cleanup_network_conf
+	stop_ocid
+}


### PR DESCRIPTION
This PR includes 2 changes:

1. Add `--cni-config-dir` and `--config-plugin-dir` options to ocid, in order to specify where the CNI configuration and plugin binaries live. This is needed so that we can run BATs with temporarily created CNI configuration files.

2. Add 2 initial networking BATs where we test that the netns interface is using a valid CIDR and can be pinged from the host netns.

Next step is to add host networking tests, so that we can close #266.