### PR TITLE
Fix client size reporting

### DIFF
--- a/cmd/client/image.go
+++ b/cmd/client/image.go
@@ -74,7 +74,7 @@ var listImageCommand = cli.Command{
 				fmt.Printf("Digest: %s\n", digest)
 			}
 			if image.Size_ != nil {
-				fmt.Printf("Size: %d\n", image.Size_)
+				fmt.Printf("Size: %d\n", *image.Size_)
 			}
 		}
 		return nil
@@ -115,7 +115,7 @@ var imageStatusCommand = cli.Command{
 			fmt.Printf("Digest: %s\n", digest)
 		}
 		if image.Size_ != nil {
-			fmt.Printf("Size: %d\n", image.Size_)
+			fmt.Printf("Size: %d\n", *image.Size_)
 		}
 		return nil
 	},


### PR DESCRIPTION
The client size field that we get back when we inspect an image is a pointer to a number, not just a number, so we need to dereference it for display.