### PR TITLE
Additional networking tests

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -235,14 +235,14 @@ function check_pod_cidr() {
 }
 
 function parse_pod_ip() {
-  for arg
-  do
-      cidr=`echo "$arg" | grep $POD_CIDR_MASK`
-      if [ "$cidr" == "$arg" ]
-      then
-	  echo `echo "$arg" | sed "s/\/[0-9][0-9]//"`
-      fi
-  done
+	for arg
+	do
+		cidr=`echo "$arg" | grep $POD_CIDR_MASK`
+		if [ "$cidr" == "$arg" ]
+		then
+			echo `echo "$arg" | sed "s/\/[0-9][0-9]//"`
+		fi
+	done
 }
 
 function ping_host_pod() {
@@ -254,7 +254,7 @@ function ping_host_pod() {
 }
 
 function ping_pod() {
-        netns=`ocic pod status --id $1 | grep namespace | cut -d ' ' -f 3`
+	netns=`ocic pod status --id $1 | grep namespace | cut -d ' ' -f 3`
 	inet=`ip netns exec \`basename $netns\` ip addr show dev eth0 scope global | grep inet`
 
 	IFS=" "

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -245,6 +245,14 @@ function parse_pod_ip() {
   done
 }
 
+function ping_host_pod() {
+	pod_ip=`ocic pod status --id $1 | grep "IP Address" | cut -d ' ' -f 3`
+
+	ping -W 1 -c 5 $pod_ip
+
+	echo $?
+}
+
 function ping_pod() {
         netns=`ocic pod status --id $1 | grep namespace | cut -d ' ' -f 3`
 	inet=`ip netns exec \`basename $netns\` ip addr show dev eth0 scope global | grep inet`

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -257,8 +257,22 @@ function ping_pod() {
 	echo $?
 }
 
+function ping_pod_from_pod() {
+	pod_ip=`ocic pod status --id $1 | grep "IP Address" | cut -d ' ' -f 3`
+	netns=`ocic pod status --id $2 | grep namespace | cut -d ' ' -f 3`
+
+	ip netns exec `basename $netns` ping -W 1 -c 2 $pod_ip
+
+	echo $?
+}
+
+
 function cleanup_network_conf() {
 	rm -rf $OCID_CNI_CONFIG
 
 	echo 0
+}
+
+function temp_sandbox_conf() {
+	sed -e s/\"namespace\":.*/\"namespace\":\ \"$1\",/g "$TESTDATA"/sandbox_config.json > $TESTDIR/sandbox_config_$1.json
 }

--- a/test/network.bats
+++ b/test/network.bats
@@ -31,7 +31,7 @@ load helpers
 	stop_ocid
 }
 
-@test "Ping pod netns from the host" {
+@test "Ping pod from the host" {
 	# this test requires docker, thus it can't yet be run in a container
 	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
 		skip "cannot yet run this test in a container, use sudo make localintegration"
@@ -54,6 +54,46 @@ load helpers
 	pod_id="$output"
 
 	ping_pod $pod_id
+
+	cleanup_pods
+	cleanup_network_conf
+	stop_ocid
+}
+
+@test "Ping pod from another pod" {
+	# this test requires docker, thus it can't yet be run in a container
+	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
+		skip "cannot yet run this test in a container, use sudo make localintegration"
+	fi
+
+	if [ ! -f "$OCID_CNI_PLUGIN/bridge" ]; then
+		skip "missing CNI bridge plugin, please install it"
+	fi
+
+	if [ ! -f "$OCID_CNI_PLUGIN/host-local" ]; then
+		skip "missing CNI host-local IPAM, please install it"
+	fi
+
+	prepare_network_conf $POD_CIDR
+
+	start_ocid
+	run ocic pod run --config "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod1_id="$output"
+
+	temp_sandbox_conf cni_test
+
+	run ocic pod run --config "$TESTDIR"/sandbox_config_cni_test.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod2_id="$output"
+
+	ping_pod_from_pod $pod1_id $pod2_id
+	[ "$status" -eq 0 ]
+
+	ping_pod_from_pod $pod2_id $pod1_id
+	[ "$status" -eq 0 ]
 
 	cleanup_pods
 	cleanup_network_conf

--- a/test/network.bats
+++ b/test/network.bats
@@ -60,6 +60,37 @@ load helpers
 	stop_ocid
 }
 
+@test "Ping host pod from the host" {
+	# this test requires docker, thus it can't yet be run in a container
+	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
+		skip "cannot yet run this test in a container, use sudo make localintegration"
+	fi
+
+	if [ ! -f "$OCID_CNI_PLUGIN/bridge" ]; then
+		skip "missing CNI bridge plugin, please install it"
+	fi
+
+	if [ ! -f "$OCID_CNI_PLUGIN/host-local" ]; then
+		skip "missing CNI host-local IPAM, please install it"
+	fi
+
+	prepare_network_conf $POD_CIDR
+
+	start_ocid
+	run ocic pod run --config "$TESTDATA"/sandbox_config_hostnet.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	ping_host_pod $pod_id
+
+	cleanup_pods
+	cleanup_network_conf
+
+	stop_ocid
+}
+
+
 @test "Ping pod from another pod" {
 	# this test requires docker, thus it can't yet be run in a container
 	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here

--- a/test/testdata/sandbox_config_hostnet.json
+++ b/test/testdata/sandbox_config_hostnet.json
@@ -1,0 +1,63 @@
+{
+	"metadata": {
+		"name": "podsandbox1",
+		"uid": "redhat-test-ocid",
+		"namespace": "redhat.test.ocid",
+		"attempt": 1
+	},
+	"hostname": "ocic_host",
+	"log_directory": ".",
+	"dns_options": {
+		"servers": [
+			"server1.redhat.com",
+			"server2.redhat.com"
+		],
+		"searches": [
+			"8.8.8.8"
+		]
+	},
+	"port_mappings": [
+		{
+			"name": "port_map1",
+			"protocol": 1,
+			"container_port": 80,
+			"host_port": 4888,
+			"host_ip": "192.168.0.33"
+		},
+		{
+			"name": "port_map2",
+			"protocol": 2,
+			"container_port": 81,
+			"host_port": 4889,
+			"host_ip": "192.168.0.33"
+		}
+	],
+	"resources": {
+		"cpu": {
+			"limits": 3,
+			"requests": 2
+		},
+		"memory": {
+			"limits": 50000000,
+			"requests": 2000000
+		}
+	},
+	"labels": {
+		"group": "test"
+	},
+	"annotations": {
+		"owner": "hmeng",
+		"security.alpha.kubernetes.io/unsafe-sysctls": "kernel.msgmax=8192" ,
+		"security.alpha.kubernetes.io/seccomp/pod": "unconfined"
+	},
+	"linux": {
+		"cgroup_parent": "/ocid-podsandbox1",
+		"security_context": {
+			"namespace_options": {
+				"host_network": true,
+				"host_pid": false,
+				"host_ipc": false
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces 2 new networking BATs:

- Inter pod networking check: We create 2 separate pods in 2 permanent networking namespaces and try to have them ping each others.

- Basic host networking check: This is a marginal use case, but we create a pod on the host netns and try to ping it from the host as well. This checks that host pods gets their networking interface up and running at least. 