### PR TITLE
contrib: cni: provide example CNI configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,41 +91,10 @@ Follow this [tutorial](tutorial.md) to get started with CRI-O.
 
 ### Setup CNI networking
 
-Follow the steps below in order to setup networking in your pods using the CNI
-bridge plugin. Nothing else is required after this since `CRI-O` automatically
-setup networking if it finds any CNI plugin.
-
-```sh
-$ go get -d github.com/containernetworking/cni
-$ cd $GOPATH/src/github.com/containernetworking/cni
-$ sudo mkdir -p /etc/cni/net.d
-$ sudo sh -c 'cat >/etc/cni/net.d/10-mynet.conf <<-EOF
-{
-    "cniVersion": "0.2.0",
-    "name": "mynet",
-    "type": "bridge",
-    "bridge": "cni0",
-    "isGateway": true,
-    "ipMasq": true,
-    "ipam": {
-        "type": "host-local",
-        "subnet": "10.88.0.0/16",
-        "routes": [
-            { "dst": "0.0.0.0/0"  }
-        ]
-    }
-}
-EOF'
-$ sudo sh -c 'cat >/etc/cni/net.d/99-loopback.conf <<-EOF
-{
-    "cniVersion": "0.2.0",
-    "type": "loopback"
-}
-EOF'
-$ ./build
-$ sudo mkdir -p /opt/cni/bin
-$ sudo cp bin/* /opt/cni/bin/
-```
+A proper description of setting up CNI networking is given in the
+[`contrib/cni` README](contrib/cni/README.md). But the gist is that you need to
+have some basic network configurations enabled and CNI plugins installed on
+your system.
 
 ### Running with kubernetes
 You can run the local version of kubernetes using `local-up-cluster.sh`. After starting `ocid` daemon:

--- a/contrib/cni/10-ocid-bridge.conf
+++ b/contrib/cni/10-ocid-bridge.conf
@@ -1,0 +1,15 @@
+{
+    "cniVersion": "0.2.0",
+    "name": "ocid-bridge",
+    "type": "bridge",
+    "bridge": "cni0",
+    "isGateway": true,
+    "ipMasq": true,
+    "ipam": {
+        "type": "host-local",
+        "subnet": "10.88.0.0/16",
+        "routes": [
+            { "dst": "0.0.0.0/0" }
+        ]
+    }
+}

--- a/contrib/cni/99-loopback.conf
+++ b/contrib/cni/99-loopback.conf
@@ -1,0 +1,4 @@
+{
+    "cniVersion": "0.2.0",
+    "type": "loopback"
+}

--- a/contrib/cni/README.md
+++ b/contrib/cni/README.md
@@ -1,0 +1,16 @@
+## `contrib/cni` ##
+
+There are a wide variety of different [CNI][cni] network configurations. This
+directory just contains some example configurations that can be used as the
+basis for your own configurations (distibutions should package these files in
+example directories).
+
+To use these configurations, place them in `/etc/cni/net.d` (or the directory
+specified by `ocid.network.network_dir` in your `ocid.conf`).
+
+In addition, you need to install the [CNI plugins][cni] necessary into
+`/opt/cni/bin` (or the directory specified by `ocid.network.plugin_dir`). The
+two plugins necessary for the example CNI configurations are `loopback` and
+`bridge`.
+
+[cni]: https://github.com/containernetworking/cni


### PR DESCRIPTION
This also updates the readme to no longer contain CNI configuration
information (which had incorrect steps), and rather just points to the
example configs.

Closes #208
Signed-off-by: Aleksa Sarai <asarai@suse.com>