### PR TITLE
fixes issue with make install on ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,9 @@ install:
 	install -D -m 755 ocic $(BINDIR)/ocic
 	install -D -m 755 conmon/conmon $(LIBEXECDIR)/ocid/conmon
 	install -D -m 755 pause/pause $(LIBEXECDIR)/ocid/pause
-	install -d -m 755 $(MANDIR)/man{1,5,8}
+	install -d -m 755 $(MANDIR)/man1
+	install -d -m 755 $(MANDIR)/man5
+	install -d -m 755 $(MANDIR)/man8
 	install -m 644 $(filter %.1,$(MANPAGES)) -t $(MANDIR)/man1
 	install -m 644 $(filter %.5,$(MANPAGES)) -t $(MANDIR)/man5
 	install -m 644 $(filter %.8,$(MANPAGES)) -t $(MANDIR)/man8


### PR DESCRIPTION
{1,5,8} not being parsed correctly when running sudo make install on Ubuntu..

So just splitting it out.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>