### PR TITLE
Promote DefaultConfig() to server package

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -84,7 +84,7 @@ func main() {
 	app.Usage = "ocid server"
 	app.Version = "0.0.1"
 	app.Metadata = map[string]interface{}{
-		"config": DefaultConfig(),
+		"config": server.DefaultConfig(),
 	}
 
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
The default configuration can only be accessed from the cmd/server
package, which cannot be imported (since it's a "package main").
This change promotes DefaultConfig() to the "server" package.

Closes: #315

Signed-off-by: Jonathan Yu <jawnsy@redhat.com>