### PR TITLE
fix integration tests in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ ocid.conf
 test/bin2img/bin2img
 test/copyimg/copyimg
 test/testdata/redis-image
+test/checkseccomp/checkseccomp

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.artifacts/
 conmon/conmon
 conmon/conmon.o
 pause/pause

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.3
+FROM golang:1.7
 
 # libseccomp in jessie is not _quite_ new enough -- need backports version
 RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/backports.list

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,16 @@ RUN set -x \
 	&& cp runc /usr/local/bin/runc \
 	&& rm -rf "$GOPATH"
 
+# Install CNI plugins
+RUN set -x \
+       && export GOPATH="$(mktemp -d)" \
+       && git clone https://github.com/containernetworking/cni.git "$GOPATH/src/github.com/containernetworking/cni" \
+       && cd "$GOPATH/src/github.com/containernetworking/cni" \
+       && ./build \
+       && mkdir -p /opt/cni/bin \
+       && cp bin/* /opt/cni/bin/ \
+       && rm -rf "$GOPATH"
+
 # Make sure we have some policy for pulling images
 RUN mkdir -p /etc/containers
 COPY test/policy.json /etc/containers/policy.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,3 +70,7 @@ COPY test/policy.json /etc/containers/policy.json
 WORKDIR /go/src/github.com/kubernetes-incubator/cri-o
 
 ADD . /go/src/github.com/kubernetes-incubator/cri-o
+
+RUN make copyimg \
+	&& mkdir -p .artifacts/redis-image \
+	&& ./test/copyimg/copyimg --import-from=docker://redis --export-to=dir:.artifacts/redis-image --signature-policy ./test/policy.json

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ bin2img:
 copyimg:
 	make -C test/$@
 
+checkseccomp:
+	make -C test/$@
+
 ocid:
 ifndef GOPATH
 	$(error GOPATH is not set)
@@ -82,6 +85,7 @@ clean:
 	make -C pause clean
 	make -C test/bin2img clean
 	make -C test/copyimg clean
+	make -C test/checkseccomp clean
 
 ocidimage:
 	docker build -t ${OCID_IMAGE} .
@@ -95,7 +99,7 @@ integration: ocidimage
 localintegration: binaries
 	./test/test_runner.sh ${TESTFLAGS}
 
-binaries: ocid ocic kpod conmon pause bin2img copyimg
+binaries: ocid ocic kpod conmon pause bin2img copyimg checkseccomp
 
 MANPAGES_MD := $(wildcard docs/*.md)
 MANPAGES    := $(MANPAGES_MD:%.md=%)
@@ -191,6 +195,7 @@ install.tools: .install.gitvalidation .install.gometalinter .install.md2man
 .PHONY: \
 	bin2img \
 	binaries \
+	checkseccomp \
 	clean \
 	conmon \
 	copyimg \

--- a/test/apparmor.bats
+++ b/test/apparmor.bats
@@ -9,11 +9,6 @@ function teardown() {
 # 1. test running with loading the default apparmor profile.
 # test that we can run with the default apparmor profile which will not block touching a file in `.`
 @test "load default apparmor profile and run a container with it" {
-    # this test requires docker, thus it can't yet be run in a container
-    if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-        skip "cannot yet run this test in a container, use sudo make localintegration"
-    fi
-
     # this test requires apparmor, so skip this test if apparmor is not enabled.
     enabled=$(is_apparmor_enabled)
     if [[ "$enabled" -eq 0 ]]; then
@@ -46,11 +41,6 @@ function teardown() {
 # 2. test running with loading a specific apparmor profile as ocid default apparmor profile.
 # test that we can run with a specific apparmor profile which will block touching a file in `.` as ocid default apparmor profile.
 @test "load a specific apparmor profile as default apparmor and run a container with it" {
-    # this test requires docker, thus it can't yet be run in a container
-    if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-        skip "cannot yet run this test in a container, use sudo make localintegration"
-    fi
-
     # this test requires apparmor, so skip this test if apparmor is not enabled.
     enabled=$(is_apparmor_enabled)
     if [[ "$enabled" -eq 0 ]]; then
@@ -85,11 +75,6 @@ function teardown() {
 # 3. test running with loading a specific apparmor profile but not as ocid default apparmor profile.
 # test that we can run with a specific apparmor profile which will block touching a file in `.`
 @test "load default apparmor profile and run a container with another apparmor profile" {
-    # this test requires docker, thus it can't yet be run in a container
-    if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-        skip "cannot yet run this test in a container, use sudo make localintegration"
-    fi
-
     # this test requires apparmor, so skip this test if apparmor is not enabled.
     enabled=$(is_apparmor_enabled)
     if [[ "$enabled" -eq 0 ]]; then
@@ -124,11 +109,6 @@ function teardown() {
 # 4. test running with wrong apparmor profile name.
 # test that we can will fail when running a ctr with rong apparmor profile name.
 @test "run a container with wrong apparmor profile name" {
-    # this test requires docker, thus it can't yet be run in a container
-    if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-        skip "cannot yet run this test in a container, use sudo make localintegration"
-    fi
-
     # this test requires apparmor, so skip this test if apparmor is not enabled.
     enabled=$(is_apparmor_enabled)
     if [[ "$enabled" -eq 0 ]]; then
@@ -157,11 +137,6 @@ function teardown() {
 # 5. test running with default apparmor profile unloaded.
 # test that we can will fail when running a ctr with rong apparmor profile name.
 @test "run a container after unloading default apparmor profile" {
-    # this test requires docker, thus it can't yet be run in a container
-    if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-        skip "cannot yet run this test in a container, use sudo make localintegration"
-    fi
-
     # this test requires apparmor, so skip this test if apparmor is not enabled.
     enabled=$(is_apparmor_enabled)
     if [[ "$enabled" -eq 0 ]]; then

--- a/test/checkseccomp/Makefile
+++ b/test/checkseccomp/Makefile
@@ -1,0 +1,6 @@
+checkseccomp: $(wildcard *.go)
+	go build -o $@
+
+.PHONY: clean
+	clean:
+	rm -f checkseccomp

--- a/test/checkseccomp/checkseccomp.go
+++ b/test/checkseccomp/checkseccomp.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+const (
+	// SeccompModeFilter refers to the syscall argument SECCOMP_MODE_FILTER.
+	SeccompModeFilter = uintptr(2)
+)
+
+func main() {
+	// Check if Seccomp is supported, via CONFIG_SECCOMP.
+	if _, _, err := syscall.RawSyscall(syscall.SYS_PRCTL, syscall.PR_GET_SECCOMP, 0, 0); err != syscall.EINVAL {
+		// Make sure the kernel has CONFIG_SECCOMP_FILTER.
+		if _, _, err := syscall.RawSyscall(syscall.SYS_PRCTL, syscall.PR_SET_SECCOMP, SeccompModeFilter, 0); err != syscall.EINVAL {
+			os.Exit(0)
+		}
+	}
+	os.Exit(1)
+}

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -7,11 +7,6 @@ function teardown() {
 }
 
 @test "ctr remove" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -39,11 +34,6 @@ function teardown() {
 }
 
 @test "ctr lifecycle" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -111,11 +101,6 @@ function teardown() {
 
 # regression test for #127
 @test "ctrs status for a pod" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -143,11 +128,6 @@ function teardown() {
 }
 
 @test "ctr list filtering" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json --name pod1
 	echo "$output"
@@ -246,11 +226,6 @@ function teardown() {
 }
 
 @test "ctr list label filtering" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -299,11 +274,6 @@ function teardown() {
 }
 
 @test "ctr metadata in list & status" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -334,11 +304,6 @@ function teardown() {
 }
 
 @test "ctr execsync" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -367,11 +332,6 @@ function teardown() {
 }
 
 @test "ctr execsync failure" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -394,11 +354,6 @@ function teardown() {
 }
 
 @test "ctr stop idempotent" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -42,6 +42,8 @@ BIN2IMG_BINARY=${BIN2IMG_BINARY:-${OCID_ROOT}/cri-o/test/bin2img/bin2img}
 COPYIMG_BINARY=${COPYIMG_BINARY:-${OCID_ROOT}/cri-o/test/copyimg/copyimg}
 # Path of tests artifacts.
 ARTIFACTS_PATH=${ARTIFACTS_PATH:-${OCID_ROOT}/cri-o/.artifacts}
+# Path of the checkseccomp binary.
+CHECKSECCOMP_BINARY=${CHECKSECCOMP_BINARY:-${OCID_ROOT}/cri-o/test/checkseccomp/checkseccomp}
 
 TESTDIR=$(mktemp -d)
 if [ -e /usr/sbin/selinuxenabled ] && /usr/sbin/selinuxenabled; then
@@ -214,14 +216,11 @@ function remove_apparmor_profile() {
 }
 
 function is_seccomp_enabled() {
-	if [[ -f "$BOOT_CONFIG_FILE_PATH" ]]; then
-		out=$(cat "$BOOT_CONFIG_FILE_PATH" | grep CONFIG_SECCOMP=)
-		if [[ "$out" =~ "CONFIG_SECCOMP=y" ]]; then
-			echo 1
-			return
-		fi
+	if ! "$CHECKSECCOMP_BINARY" ; then
+		echo 0
+		return
 	fi
-	echo 0
+	echo 1
 }
 
 function is_apparmor_enabled() {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -40,6 +40,8 @@ APPARMOR_PARAMETERS_FILE_PATH=${APPARMOR_PARAMETERS_FILE_PATH:-/sys/module/appar
 BIN2IMG_BINARY=${BIN2IMG_BINARY:-${OCID_ROOT}/cri-o/test/bin2img/bin2img}
 # Path of the copyimg binary.
 COPYIMG_BINARY=${COPYIMG_BINARY:-${OCID_ROOT}/cri-o/test/copyimg/copyimg}
+# Path of tests artifacts.
+ARTIFACTS_PATH=${ARTIFACTS_PATH:-${OCID_ROOT}/cri-o/.artifacts}
 
 TESTDIR=$(mktemp -d)
 if [ -e /usr/sbin/selinuxenabled ] && /usr/sbin/selinuxenabled; then
@@ -61,11 +63,11 @@ mkdir -p $OCID_CNI_CONFIG
 PATH=$PATH:$TESTDIR
 
 # Make sure we have a copy of the redis:latest image.
-if ! [ -d "$TESTDATA"/redis-image ]; then
-    mkdir -p "$TESTDATA"/redis-image
-    if ! "$COPYIMG_BINARY" --import-from=docker://redis --export-to=dir:"$TESTDATA"/redis-image --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
+if ! [ -d "$ARTIFACTS_PATH"/redis-image ]; then
+    mkdir -p "$ARTIFACTS_PATH"/redis-image
+    if ! "$COPYIMG_BINARY" --import-from=docker://redis --export-to=dir:"$ARTIFACTS_PATH"/redis-image --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
         echo "Error pulling docker://redis"
-        rm -fr "$TESTDATA"/redis-image
+        rm -fr "$ARTIFACTS_PATH"/redis-image
         exit 1
     fi
 fi
@@ -130,7 +132,7 @@ function start_ocid() {
 	if ! [ "$3" = "--no-pause-image" ] ; then
 		"$BIN2IMG_BINARY" --root "$TESTDIR/ocid" --runroot "$TESTDIR/ocid-run" --source-binary "$PAUSE_BINARY"
 	fi
-	"$COPYIMG_BINARY" --root "$TESTDIR/ocid" --runroot "$TESTDIR/ocid-run" --image-name=redis --import-from=dir:"$TESTDATA"/redis-image --add-name=docker://docker.io/library/redis:latest
+	"$COPYIMG_BINARY" --root "$TESTDIR/ocid" --runroot "$TESTDIR/ocid-run" --image-name=redis --import-from=dir:"$ARTIFACTS_PATH"/redis-image --add-name=docker://docker.io/library/redis:latest
 	"$OCID_BINARY" --conmon "$CONMON_BINARY" --listen "$OCID_SOCKET" --runtime "$RUNC_BINARY" --root "$TESTDIR/ocid" --runroot "$TESTDIR/ocid-run" --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$OCID_CNI_CONFIG" --signature-policy "$INTEGRATION_ROOT"/policy.json config >$OCID_CONFIG
 	"$OCID_BINARY" --debug --config "$OCID_CONFIG" & OCID_PID=$!
 	wait_until_reachable

--- a/test/network.bats
+++ b/test/network.bats
@@ -3,11 +3,6 @@
 load helpers
 
 @test "Check for valid pod netns CIDR" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	if [ ! -f "$OCID_CNI_PLUGIN/bridge" ]; then
 		skip "missing CNI bridge plugin, please install it"
 	fi
@@ -32,11 +27,6 @@ load helpers
 }
 
 @test "Ping pod from the host" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	if [ ! -f "$OCID_CNI_PLUGIN/bridge" ]; then
 		skip "missing CNI bridge plugin, please install it"
 	fi
@@ -61,11 +51,6 @@ load helpers
 }
 
 @test "Ping pod from another pod" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	if [ ! -f "$OCID_CNI_PLUGIN/bridge" ]; then
 		skip "missing CNI bridge plugin, please install it"
 	fi

--- a/test/pod.bats
+++ b/test/pod.bats
@@ -8,11 +8,6 @@ function teardown() {
 
 # PR#59
 @test "pod release name on remove" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -41,11 +36,6 @@ function teardown() {
 }
 
 @test "pod remove" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -67,11 +57,6 @@ function teardown() {
 }
 
 @test "pod list filtering" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json -name pod1 --label "a=b" --label "c=d" --label "e=f"
 	echo "$output"
@@ -161,11 +146,6 @@ function teardown() {
 }
 
 @test "pod metadata in list & status" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -195,11 +175,6 @@ function teardown() {
 }
 
 @test "pass pod sysctls to runtime" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -235,11 +210,6 @@ function teardown() {
 }
 
 @test "pod stop idempotent" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -258,11 +228,6 @@ function teardown() {
 }
 
 @test "pod remove idempotent" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -281,11 +246,6 @@ function teardown() {
 }
 
 @test "pod stop idempotent with ctrs already stopped" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -308,11 +268,6 @@ function teardown() {
 }
 
 @test "restart ocid and still get pod status" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"

--- a/test/restore.bats
+++ b/test/restore.bats
@@ -7,11 +7,6 @@ function teardown() {
 }
 
 @test "ocid restore" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	start_ocid
 	run ocic pod run --config "$TESTDATA"/sandbox_config.json
 	echo "$output"

--- a/test/seccomp.bats
+++ b/test/seccomp.bats
@@ -9,11 +9,6 @@ function teardown() {
 # 1. test running with ctr unconfined
 # test that we can run with a syscall which would be otherwise blocked
 @test "ctr seccomp profiles unconfined" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	# this test requires seccomp, so skip this test if seccomp is not enabled.
 	enabled=$(is_seccomp_enabled)
     if [[ "$enabled" -eq 0 ]]; then
@@ -50,11 +45,6 @@ function teardown() {
 # 2. test running with ctr runtime/default
 # test that we cannot run with a syscall blocked by the default seccomp profile
 @test "ctr seccomp profiles runtime/default" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	# this test requires seccomp, so skip this test if seccomp is not enabled.
 	enabled=$(is_seccomp_enabled)
 	if [[ "$enabled" -eq 0 ]]; then
@@ -91,11 +81,6 @@ function teardown() {
 
 # 3. test running with ctr wrong profile name
 @test "ctr seccomp profiles wrong profile name" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	# this test requires seccomp, so skip this test if seccomp is not enabled.
 	enabled=$(is_seccomp_enabled)
 	if [[ "$enabled" -eq 0 ]]; then
@@ -127,11 +112,6 @@ function teardown() {
 # TODO(runcom): need https://issues.k8s.io/36997
 # 4. test running with ctr localhost/profile_name
 @test "ctr seccomp profiles localhost/profile_name" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	# this test requires seccomp, so skip this test if seccomp is not enabled.
 	enabled=$(is_seccomp_enabled)
 	if [[ "$enabled" -eq 0 ]]; then
@@ -152,11 +132,6 @@ function teardown() {
 # pod -> runtime/default
 # result: fail chmod
 @test "ctr seccomp profiles falls back to pod profile" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	# this test requires seccomp, so skip this test if seccomp is not enabled.
 	enabled=$(is_seccomp_enabled)
 	if [[ "$enabled" -eq 0 ]]; then
@@ -196,11 +171,6 @@ function teardown() {
 # pod -> NO
 # result: success, running unconfined
 @test "ctr seccomp profiles falls back to unconfined" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	# this test requires seccomp, so skip this test if seccomp is not enabled.
 	enabled=$(is_seccomp_enabled)
 	if [[ "$enabled" -eq 0 ]]; then
@@ -237,11 +207,6 @@ function teardown() {
 # 1. test running with pod unconfined
 # test that we can run with a syscall which would be otherwise blocked
 @test "pod seccomp profiles unconfined" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	# this test requires seccomp, so skip this test if seccomp is not enabled.
 	enabled=$(is_seccomp_enabled)
 	if [[ "$enabled" -eq 0 ]]; then
@@ -278,11 +243,6 @@ function teardown() {
 # 2. test running with pod runtime/default
 # test that we cannot run with a syscall blocked by the default seccomp profile
 @test "pod seccomp profiles runtime/default" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	# this test requires seccomp, so skip this test if seccomp is not enabled.
 	enabled=$(is_seccomp_enabled)
 	if [[ "$enabled" -eq 0 ]]; then
@@ -319,11 +279,6 @@ function teardown() {
 
 # 3. test running with pod wrong profile name
 @test "pod seccomp profiles wrong profile name" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	# this test requires seccomp, so skip this test if seccomp is not enabled.
 	enabled=$(is_seccomp_enabled)
 	if [[ "$enabled" -eq 0 ]]; then
@@ -356,11 +311,6 @@ function teardown() {
 # TODO(runcom): need https://issues.k8s.io/36997
 # 4. test running with pod localhost/profile_name
 @test "pod seccomp profiles localhost/profile_name" {
-	# this test requires docker, thus it can't yet be run in a container
-	if [ "$TRAVIS" = "true" ]; then # instead of $TRAVIS, add a function is_containerized to skip here
-		skip "cannot yet run this test in a container, use sudo make localintegration"
-	fi
-
 	# this test requires seccomp, so skip this test if seccomp is not enabled.
 	enabled=$(is_seccomp_enabled)
 	if [[ "$enabled" -eq 0 ]]; then


### PR DESCRIPTION
Trying to tackle performance issues as found in #324 
Also, fixing a bunch of stuff to enable network and seccomp tests in container (otherwise disabled...).
I can run `make integration` in about ~7/8min with this branch.

TODO:

- [x] enable integration tests in Travis
- [x] cleanup commits (split the one there's right now)

Signed-off-by: Antonio Murdaca <runcom@redhat.com>