### PR TITLE
Default type for containers is not container_t

### DIFF
--- a/test/testdata/container_config.json
+++ b/test/testdata/container_config.json
@@ -66,8 +66,8 @@
 		"selinux_options": {
 			"user": "system_u",
 			"role": "system_r",
-			"type": "svirt_lxc_net_t",
-			"level": "s0:c4-c5"
+			"type": "container_t",
+			"level": "s0:c4,c5"
 		},
 		"user": {
 			"uid": 5,

--- a/test/testdata/sandbox_config_seccomp.json
+++ b/test/testdata/sandbox_config_seccomp.json
@@ -57,6 +57,12 @@
 				"host_pid": false,
 				"host_ipc": false
 			}
+		},
+		"selinux_options": {
+			"user": "system_u",
+			"role": "system_r",
+			"type": "container_t",
+			"level": "s0:c1,c2"
 		}
 	}
 }


### PR DESCRIPTION
We usually specify MCS Labels as comma separated pair.
Finally if we run two different containers we want them on different
MCS labels.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>