### PR TITLE
server: respect ocid.network.plugin_dir setting

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -476,7 +476,7 @@ func New(config *Config) (*Server, error) {
 	}
 	sandboxes := make(map[string]*sandbox)
 	containers := oci.NewMemoryStore()
-	netPlugin, err := ocicni.InitCNI(config.NetworkDir)
+	netPlugin, err := ocicni.InitCNI(config.NetworkDir, config.PluginDir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously ocicni did not have support for setting the plugin directory.
Now that it has grown support for it, use it to actually respect the
setting a user has provided for ocid.network.* options.

Part of the whole CNI networking information cleanup.

Signed-off-by: Aleksa Sarai <asarai@suse.de>