### PR TITLE
storage: fix image retrieval by id

### DIFF
--- a/pkg/storage/runtime.go
+++ b/pkg/storage/runtime.go
@@ -167,7 +167,11 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 			ref, err = istorage.Transport.ParseStoreReference(r.image.GetStore(), otherRef.DockerReference().FullName())
 		}
 		if err != nil {
-			return ContainerInfo{}, err
+			// maybe it's just imageID
+			ref, err = istorage.Transport.ParseStoreReference(r.image.GetStore(), "@"+imageID)
+			if err != nil {
+				return ContainerInfo{}, err
+			}
 		}
 	}
 	img, err := istorage.Transport.GetStoreImage(r.image.GetStore(), ref)

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -350,7 +350,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	attempt := metadata.GetAttempt()
 	containerInfo, err := s.storage.CreateContainer(s.imageContext,
 		sb.name, sb.id,
-		image, "",
+		image, image,
 		containerName, containerID,
 		metaname,
 		attempt,

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -142,8 +142,9 @@ function start_ocid() {
 
 	run ocic image status --id=redis
 	if [ "$status" -ne 0 ] ; then
-		ocic image pull docker://redis:latest
+		ocic image pull redis:latest
 	fi
+	REDIS_IMAGEID=$(ocic image status --id=redis | head -1 | sed -e "s/ID: //g")
 }
 
 function cleanup_ctrs() {

--- a/test/image.bats
+++ b/test/image.bats
@@ -8,6 +8,21 @@ function teardown() {
 	cleanup_test
 }
 
+@test "run container in pod with image ID" {
+	start_ocid
+	run ocic pod run --config "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+	sed -e "s/%VALUE%/$REDIS_IMAGEID/g" "$TESTDATA"/container_config_by_imageid.json > "$TESTDIR"/ctr_by_imageid.json
+	run ocic ctr create --config "$TESTDIR"/ctr_by_imageid.json --pod "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_ocid
+}
+
 @test "image pull" {
 	start_ocid "" "" --no-pause-image
 	run ocic image pull "$IMAGE"

--- a/test/testdata/container_config_by_imageid.json
+++ b/test/testdata/container_config_by_imageid.json
@@ -1,0 +1,82 @@
+{
+	"metadata": {
+		"name": "container1",
+		"attempt": 1
+	},
+	"image": {
+		"image": "%VALUE%"
+	},
+	"command": [
+		"/bin/bash"
+	],
+	"args": [
+		"/bin/ls"
+	],
+	"working_dir": "/",
+	"envs": [
+		{
+			"key": "PATH",
+			"value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+		},
+		{
+			"key": "TERM",
+			"value": "xterm"
+		},
+		{
+			"key": "TESTDIR",
+			"value": "test/dir1"
+		},
+		{
+			"key": "TESTFILE",
+			"value": "test/file1"
+		}
+	],
+	"labels": {
+		"type": "small",
+		"batch": "no"
+	},
+	"annotations": {
+		"owner": "dragon",
+		"daemon": "ocid"
+	},
+	"privileged": true,
+	"readonly_rootfs": true,
+	"log_path": "container.log",
+	"stdin": false,
+	"stdin_once": false,
+	"tty": false,
+	"linux": {
+		"resources": {
+			"cpu_period": 10000,
+			"cpu_quota": 20000,
+			"cpu_shares": 512,
+			"memory_limit_in_bytes": 88000000,
+			"oom_score_adj": 30
+		},
+		"capabilities": {
+			"add_capabilities": [
+				"setuid",
+				"setgid"
+			],
+			"drop_capabilities": [
+				"audit_write",
+				"audit_read"
+			]
+		},
+		"selinux_options": {
+			"user": "system_u",
+			"role": "system_r",
+			"type": "container_t",
+			"level": "s0:c4,c5"
+		},
+		"user": {
+			"uid": 5,
+			"gid": 300,
+			"additional_gids": [
+				400,
+				401,
+				402
+			]
+		}
+	}
+}


### PR DESCRIPTION
kubelet sends a request to create a container with an image ID (as
opposed as an image name). That ID comes from the ImageStatus response.
This patch fixes that by setting the image ID as well as the image name
and fix the logic to lookup for image ID as well.

Found while running `make test-e2e-node`.

@nalind PTAL, the logic is tricky in that piece of code since it's full of if/else. Hope I got it correctly though, we can refactor that code soon(ish).
@mrunalp PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>