### PR TITLE
Use build tags for bin2img and copyimg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,19 +45,19 @@ gofmt:
 	@./hack/verify-gofmt.sh
 
 conmon:
-	make -C $@
+	$(MAKE) -C $@
 
 pause:
-	make -C $@
+	$(MAKE) -C $@
 
 bin2img:
-	make -C test/$@
+	$(MAKE) -C test/$@ BUILDTAGS="$(BUILDTAGS)"
 
 copyimg:
-	make -C test/$@
+	$(MAKE) -C test/$@ BUILDTAGS="$(BUILDTAGS)"
 
 checkseccomp: check-gopath
-	make -C test/$@
+	$(MAKE) -C test/$@
 
 ocid: check-gopath
 	$(GO) install \

--- a/hack/libdm_tag.sh
+++ b/hack/libdm_tag.sh
@@ -2,10 +2,11 @@
 tmpdir="$PWD/tmp.$RANDOM"
 mkdir -p "$tmpdir"
 trap 'rm -fr "$tmpdir"' EXIT
-cc -c -o "$tmpdir"/libdm_tag.o -x c - > /dev/null 2> /dev/null << EOF
+cc -o "$tmpdir"/libdm_tag -ldevmapper -x c - > /dev/null 2> /dev/null << EOF
 #include <libdevmapper.h>
 int main() {
 	struct dm_task *task;
+	dm_task_deferred_remove(task);
 	return 0;
 }
 EOF

--- a/test/bin2img/Makefile
+++ b/test/bin2img/Makefile
@@ -1,5 +1,5 @@
 bin2img: $(wildcard *.go)
-	go build -o $@
+	go build -tags "$(BUILDTAGS)" -o $@
 
 .PHONY: clean
 clean:

--- a/test/copyimg/Makefile
+++ b/test/copyimg/Makefile
@@ -1,5 +1,5 @@
 copyimg: $(wildcard *.go)
-	go build -o $@
+	go build -tags "$(BUILDTAGS)" -o $@
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Use the same build tags for bin2img and copyimg that we use for ocid, and improve detection of the case where we need to use the "libdm_no_deferred_remove" tag.