### PR TITLE
Don't try to parse an image ID a second time

### DIFF
--- a/pkg/storage/runtime.go
+++ b/pkg/storage/runtime.go
@@ -167,7 +167,7 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 			ref, err = istorage.Transport.ParseStoreReference(r.image.GetStore(), otherRef.DockerReference().FullName())
 		}
 		if err != nil {
-			// maybe it's just imageID
+			// Maybe the image ID is sufficient?
 			ref, err = istorage.Transport.ParseStoreReference(r.image.GetStore(), "@"+imageID)
 			if err != nil {
 				return ContainerInfo{}, err
@@ -175,13 +175,6 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 		}
 	}
 	img, err := istorage.Transport.GetStoreImage(r.image.GetStore(), ref)
-	if img == nil && err == storage.ErrImageUnknown && imageID != "" {
-		ref, err = istorage.Transport.ParseStoreReference(r.image.GetStore(), "@"+imageID)
-		if err != nil {
-			return ContainerInfo{}, err
-		}
-		img, err = istorage.Transport.GetStoreImage(r.image.GetStore(), ref)
-	}
 	if img == nil && err == storage.ErrImageUnknown && imageName == r.pauseImage {
 		image := imageID
 		if imageName != "" {


### PR DESCRIPTION
When looking for the image to use for creating a container, there's no need to attempt parsing the ID a second time, and doing so can create confusing error messages.  This should fix #361.