### PR TITLE
Support alternate runtime for host privileged operations

### DIFF
--- a/cmd/ocid/config.go
+++ b/cmd/ocid/config.go
@@ -42,6 +42,12 @@ listen = "{{ .Listen }}"
 # runtime is a path to the OCI runtime which ocid will be using.
 runtime = "{{ .Runtime }}"
 
+# runtime_host_privileged is a path to the OCI runtime which ocid
+# will be using for host privileged operations.
+# If this string is empty, ocid will not try to use the "runtime"
+# for all operations.
+runtime_host_privileged = "{{ .RuntimeHostPrivileged }}"
+
 # conmon is the path to conmon binary, used for managing the runtime.
 conmon = "{{ .Conmon }}"
 

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -450,7 +450,7 @@ type ContainerState struct {
 }
 
 // NewContainer creates a container object.
-func NewContainer(id string, name string, bundlePath string, logPath string, netns ns.NetNS, labels map[string]string, annotations map[string]string, image *pb.ImageSpec, metadata *pb.ContainerMetadata, sandbox string, terminal bool) (*Container, error) {
+func NewContainer(id string, name string, bundlePath string, logPath string, netns ns.NetNS, labels map[string]string, annotations map[string]string, image *pb.ImageSpec, metadata *pb.ContainerMetadata, sandbox string, terminal bool, privileged bool) (*Container, error) {
 	c := &Container{
 		id:          id,
 		name:        name,
@@ -460,6 +460,7 @@ func NewContainer(id string, name string, bundlePath string, logPath string, net
 		sandbox:     sandbox,
 		netns:       netns,
 		terminal:    terminal,
+		privileged:  privileged,
 		metadata:    metadata,
 		annotations: annotations,
 		image:       image,

--- a/server/config.go
+++ b/server/config.go
@@ -76,6 +76,10 @@ type RuntimeConfig struct {
 	// yet merged a CLI API (so we assume runC's API here).
 	Runtime string `toml:"runtime"`
 
+	// RuntimeHostPrivileged is a path to the OCI runtime which ocid will be
+	// using for host privileged operations.
+	RuntimeHostPrivileged string `toml:"runtime_host_privileged"`
+
 	// Conmon is the path to conmon binary, used for managing the runtime.
 	Conmon string `toml:"conmon"`
 
@@ -205,8 +209,9 @@ func DefaultConfig() *Config {
 			Listen: "/var/run/ocid.sock",
 		},
 		RuntimeConfig: RuntimeConfig{
-			Runtime: "/usr/bin/runc",
-			Conmon:  conmonPath,
+			Runtime:               "/usr/bin/runc",
+			RuntimeHostPrivileged: "",
+			Conmon:                conmonPath,
 			ConmonEnv: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			},

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -384,7 +384,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		return nil, err
 	}
 
-	container, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, sb.netNs(), labels, annotations, imageSpec, metadata, sb.id, containerConfig.Tty)
+	container, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, sb.netNs(), labels, annotations, imageSpec, metadata, sb.id, containerConfig.Tty, sb.privileged)
 	if err != nil {
 		return nil, err
 	}

--- a/server/sandbox.go
+++ b/server/sandbox.go
@@ -139,6 +139,7 @@ type sandbox struct {
 	metadata       *pb.PodSandboxMetadata
 	shmPath        string
 	cgroupParent   string
+	privileged     bool
 }
 
 const (

--- a/server/server.go
+++ b/server/server.go
@@ -452,7 +452,7 @@ func New(config *Config) (*Server, error) {
 		return nil, err
 	}
 
-	r, err := oci.New(config.Runtime, config.Conmon, config.ConmonEnv, config.CgroupManager)
+	r, err := oci.New(config.Runtime, config.RuntimeHostPrivileged, config.Conmon, config.ConmonEnv, config.CgroupManager)
 	if err != nil {
 		return nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -105,7 +105,7 @@ func (s *Server) loadContainer(id string) error {
 		return err
 	}
 
-	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations["ocid/log_path"], sb.netNs(), labels, annotations, img, &metadata, sb.id, tty)
+	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations["ocid/log_path"], sb.netNs(), labels, annotations, img, &metadata, sb.id, tty, sb.privileged)
 	if err != nil {
 		return err
 	}
@@ -173,6 +173,8 @@ func (s *Server) loadSandbox(id string) error {
 		return err
 	}
 
+	privileged := m.Annotations["ocid/privileged_runtime"] == "true"
+
 	sb := &sandbox{
 		id:           id,
 		name:         name,
@@ -184,6 +186,7 @@ func (s *Server) loadSandbox(id string) error {
 		annotations:  annotations,
 		metadata:     &metadata,
 		shmPath:      m.Annotations["ocid/shm_path"],
+		privileged:   privileged,
 	}
 
 	// We add a netNS only if we can load a permanent one.
@@ -223,7 +226,8 @@ func (s *Server) loadSandbox(id string) error {
 			s.releaseContainerName(cname)
 		}
 	}()
-	scontainer, err := oci.NewContainer(m.Annotations["ocid/container_id"], cname, sandboxPath, sandboxPath, sb.netNs(), labels, annotations, nil, nil, id, false)
+
+	scontainer, err := oci.NewContainer(m.Annotations["ocid/container_id"], cname, sandboxPath, sandboxPath, sb.netNs(), labels, annotations, nil, nil, id, false, privileged)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Some CRI-O runtimes (like [cc-oci-runtime](https://github.com/01org/cc-oci-runtime)) do not support many host privileged operations like e.g. giving access to the host namespaces or running fully privileged containers (with access to *all* host devices). Those runtimes usually provide a higher level of container security by e.g. running container workloads within virtual machines and therefore running host privileged containers with them makes little sense.

This pull request tries to overcome that problem by allowing `ocid` users to define a *host privileged capable runtime path* in addition to the default runtime path. When `ocid` gets a request for creating a container or a sandbox with either the privileged flag set or access to at least one of the host namespaces (PID, IPC or networking), it will check if a host privileged runtime is defined and use it if it is. It will obviously use the default runtime if the host privileged one is not defined.

This PR only checks for the pod security context and each container within a given pod will inherit its pod privileged flags. In other words, that means we will run the privileged runtime in either one of those 2 cases:

1. The sandbox supports running at least one privileged container.
2. The sandbox requires access to either one of the host PID, IPC or networking namespace.

##### Note
I realize this **might** be fixed with [CRI multiple runtimes](https://github.com/kubernetes/kubernetes/pull/40662) support. If/when this happens, we should be able to remove part of this PR code.

cc @feiskyer @mcastelino