### PR TITLE
Run without seccomp

### DIFF
--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -326,6 +326,10 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 	}
 
+	if !s.seccompEnabled {
+		g.Spec().Linux.Seccomp = nil
+	}
+
 	saveOptions := generate.ExportOptions{}
 	mountPoint, err := s.storage.StartContainer(id)
 	if err != nil {

--- a/server/seccomp/seccomp.go
+++ b/server/seccomp/seccomp.go
@@ -19,7 +19,7 @@ func IsEnabled() bool {
 	// seccompModeFilter refers to the syscall argument SECCOMP_MODE_FILTER.
 	const seccompModeFilter = uintptr(2)
 
-	var enabled bool
+	enabled := false
 	// Check if Seccomp is supported, via CONFIG_SECCOMP.
 	if _, _, err := syscall.RawSyscall(syscall.SYS_PRCTL, syscall.PR_GET_SECCOMP, 0, 0); err != syscall.EINVAL {
 		// Make sure the kernel has CONFIG_SECCOMP_FILTER.

--- a/server/seccomp/seccomp_unsupported.go
+++ b/server/seccomp/seccomp_unsupported.go
@@ -4,6 +4,11 @@ package seccomp
 
 import "github.com/opencontainers/runtime-tools/generate"
 
+// IsEnabled returns false, when build without seccomp build tag.
+func IsEnabled() bool {
+	return false
+}
+
 // LoadProfileFromStruct takes a Seccomp struct and setup seccomp in the spec.
 func LoadProfileFromStruct(config Seccomp, specgen *generate.Generator) error {
 	return nil

--- a/server/server.go
+++ b/server/server.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"sync"
-	"syscall"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/types"
@@ -425,23 +424,6 @@ func (s *Server) releaseContainerName(name string) {
 	s.ctrNameIndex.Release(name)
 }
 
-const (
-	// SeccompModeFilter refers to the syscall argument SECCOMP_MODE_FILTER.
-	SeccompModeFilter = uintptr(2)
-)
-
-func seccompEnabled() bool {
-	var enabled bool
-	// Check if Seccomp is supported, via CONFIG_SECCOMP.
-	if _, _, err := syscall.RawSyscall(syscall.SYS_PRCTL, syscall.PR_GET_SECCOMP, 0, 0); err != syscall.EINVAL {
-		// Make sure the kernel has CONFIG_SECCOMP_FILTER.
-		if _, _, err := syscall.RawSyscall(syscall.SYS_PRCTL, syscall.PR_SET_SECCOMP, SeccompModeFilter, 0); err != syscall.EINVAL {
-			enabled = true
-		}
-	}
-	return enabled
-}
-
 // Shutdown attempts to shut down the server's storage cleanly
 func (s *Server) Shutdown() error {
 	_, err := s.store.Shutdown(false)
@@ -491,7 +473,7 @@ func New(config *Config) (*Server, error) {
 			sandboxes:  sandboxes,
 			containers: containers,
 		},
-		seccompEnabled:  seccompEnabled(),
+		seccompEnabled:  seccomp.IsEnabled(),
 		appArmorEnabled: apparmor.IsEnabled(),
 		appArmorProfile: config.ApparmorProfile,
 	}


### PR DESCRIPTION
This fixes issues running without seccomp compiled in and issues running with seccomp disabled. Before this change, the demo pod in sandbox_config fails to start with runc returning the following error:
`seccomp: config provided but seccomp not supported`