### PR TITLE
Use canonical import path for apimachinery

### DIFF
--- a/server/container_list.go
+++ b/server/container_list.go
@@ -4,8 +4,8 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/kubernetes-incubator/cri-o/oci"
 	"golang.org/x/net/context"
+	"k8s.io/apimachinery/pkg/fields"
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
-	"k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/fields"
 )
 
 // filterContainer returns whether passed container matches filtering criteria

--- a/server/sandbox_list.go
+++ b/server/sandbox_list.go
@@ -4,8 +4,8 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/kubernetes-incubator/cri-o/oci"
 	"golang.org/x/net/context"
+	"k8s.io/apimachinery/pkg/fields"
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
-	"k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/fields"
 )
 
 // filterSandbox returns whether passed container matches filtering criteria


### PR DESCRIPTION
This change fixes some apimachinery imports so they are pulled from their canonical path rather than from the kubernetes staging location. This mismatch prevents removing the vendor directory and building with the version of kubernetes in my GOPATH. The go tools should be enforcing this but they are not due to a bug: golang/go#19224

cc @mzylowski 