### PR TITLE
Depracate --storage-option for --storage-opt

### DIFF
--- a/cmd/ocid/main.go
+++ b/cmd/ocid/main.go
@@ -57,8 +57,8 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("storage-driver") {
 		config.Storage = ctx.GlobalString("storage-driver")
 	}
-	if ctx.GlobalIsSet("storage-option") {
-		config.StorageOptions = ctx.GlobalStringSlice("storage-option")
+	if ctx.GlobalIsSet("storage-opt") {
+		config.StorageOptions = ctx.GlobalStringSlice("storage-opt")
 	}
 	if ctx.GlobalIsSet("default-transport") {
 		config.DefaultTransport = ctx.GlobalString("default-transport")
@@ -175,7 +175,7 @@ func main() {
 			Usage: "storage driver",
 		},
 		cli.StringSliceFlag{
-			Name:  "storage-option",
+			Name:  "storage-opt",
 			Usage: "storage driver option",
 		},
 		cli.StringFlag{

--- a/docs/ocid.8.md
+++ b/docs/ocid.8.md
@@ -21,7 +21,7 @@ ocid - Enable OCI Kubernetes Container Runtime daemon
 [**--runtime**=[*value*]]
 [**--signature-policy**=[*value*]]
 [**--storage-driver**=[*value*]]
-[**--storage-option**=[*value*]]
+[**--storage-opt**=[*value*]]
 [**--selinux**]
 [**--seccomp-profile**=[*value*]]
 [**--apparmor-profile**=[*value*]]
@@ -101,7 +101,7 @@ ocid is meant to provide an integration path between OCI conformant runtimes and
 **--storage-driver**
   OCI storage driver (default: "devicemapper")
 
-**--storage-option**
+**--storage-opt**
   OCI storage driver option (no default)
 
 **--cni-config-dir**=""

--- a/test/bin2img/bin2img.go
+++ b/test/bin2img/bin2img.go
@@ -47,7 +47,7 @@ func main() {
 			Usage: "storage driver",
 		},
 		cli.StringSliceFlag{
-			Name:  "storage-option",
+			Name:  "storage-opt",
 			Usage: "storage option",
 		},
 		cli.StringFlag{
@@ -72,7 +72,7 @@ func main() {
 		rootDir := c.GlobalString("root")
 		runrootDir := c.GlobalString("runroot")
 		storageDriver := c.GlobalString("storage-driver")
-		storageOptions := c.GlobalStringSlice("storage-option")
+		storageOptions := c.GlobalStringSlice("storage-opt")
 		imageName := c.GlobalString("image-name")
 		sourceBinary := c.GlobalString("source-binary")
 		imageBinary := c.GlobalString("image-binary")

--- a/test/copyimg/copyimg.go
+++ b/test/copyimg/copyimg.go
@@ -42,7 +42,7 @@ func main() {
 			Usage: "storage driver",
 		},
 		cli.StringSliceFlag{
-			Name:  "storage-option",
+			Name:  "storage-opt",
 			Usage: "storage option",
 		},
 		cli.StringFlag{
@@ -76,7 +76,7 @@ func main() {
 		rootDir := c.GlobalString("root")
 		runrootDir := c.GlobalString("runroot")
 		storageDriver := c.GlobalString("storage-driver")
-		storageOptions := c.GlobalStringSlice("storage-option")
+		storageOptions := c.GlobalStringSlice("storage-opt")
 		signaturePolicy := c.GlobalString("signature-policy")
 		imageName := c.GlobalString("image-name")
 		addName := c.GlobalString("add-name")


### PR DESCRIPTION
container-storage-setup (Formerly docker-storage-setup) is being converted to
run with container runtimes outside of docker.  Specifically we want to use it
with CRI-O/ocid.  It does not know anything about the container runtimes it
is generating options for, so it generates them based on the storage CLI of
docker.  I see no reason to have the storage option for ocid to be different
and we can just depracate the option for now.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>