### PR TITLE
Fix make

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get -qq install btrfs-tools libdevmapper-dev libgpgme11-dev
+  - sudo apt-get -qq install btrfs-tools libdevmapper-dev libgpgme11-dev libapparmor-dev libseccomp-dev
 
 install:
   - make install.tools
@@ -26,6 +26,7 @@ script:
   - make lint
   - make integration
   - make docs
+  - make
 
 notifications:
   irc: "chat.freenode.net#ocid"

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ kpod: check-gopath
 	$(GO) build -o $@ $(PROJECT)/cmd/kpod
 
 ocid.conf: ocid
-	ocid --config="" config --default > ocid.conf
+	./ocid --config="" config --default > ocid.conf
 
 clean:
 	rm -f docs/*.1 docs/*.5 docs/*.8


### PR DESCRIPTION
Make failed because ocid doesn't installed yet into system path:

```
ocid --config="" config --default > ocid.conf
/bin/sh: 1: ocid: not found
Makefile:72: recipe for target 'ocid.conf' failed
```

This PR fixed this and also adds make to travis.