### PR TITLE
Add support to configure ocid storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,8 @@ install.systemd:
 	install -D -m 644 contrib/systemd/crio.service $(PREFIX)/lib/systemd/system/crio.service
 	install -D -m 644 contrib/systemd/crio-shutdown.service $(PREFIX)/lib/systemd/system/crio-shutdown.service
 	ln -s crio.service $(PREFIX)/lib/systemd/system/cri-o.service
+	install -D -m 644 contrib/systemd/crio-storage-setup.service $(PREFIX)/lib/systemd/system/crio-storage-setup.service
+	install -D -m 644 contrib/systemd/crio-storage-setup.default ${ETCDIR}/sysconfig/crio-storage-setup
 
 uninstall:
 	rm -f $(BINDIR)/crio

--- a/contrib/rpm/crio.spec
+++ b/contrib/rpm/crio.spec
@@ -21,6 +21,7 @@ Source0:        https://%{provider_prefix}/archive/%{commit}/%{repo}-%{shortcomm
 Provides:       %{repo}
 
 BuildRequires:  golang-github-cpuguy83-go-md2man
+Requires: container-storage-setup >= 0.6
 
 %description
 The crio package provides an implementation of the
@@ -57,6 +58,9 @@ make all
 /%{_libexecdir}/crio/conmon
 /%{_libexecdir}/crio/pause
 %{_unitdir}/crio.service
+%{_unitdir}/crio-storage-setup.service
+%{_sysconfdir}/sysconfig/crio-storage-setup
+%ghost %{_sysconfdir}/sysconfig/crio-storage
 %doc README.md
 %license LICENSE
 

--- a/contrib/systemd/crio-storage-setup.default
+++ b/contrib/systemd/crio-storage-setup.default
@@ -1,0 +1,5 @@
+# Edit this file to override any configuration options specified in
+# /usr/share/container-storage-setup/container-storage-setup.
+#
+# For more details refer to "man container-storage-setup"
+STORAGE_DRIVER=overlay

--- a/contrib/systemd/crio-storage-setup.service
+++ b/contrib/systemd/crio-storage-setup.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Open Container Initiative Daemon Storage Setup
+Documentation=https://github.com/kubernetes-incubator/cri-o
+After=cloud-init.service
+Before=crio.service
+
+[Service]
+Type=oneshot
+ExecStartPre=-/usr/bin/container-storage-setup create -o /etc/sysconfig/crio-storage crio-storage /etc/sysconfig/crio-storage-setup
+ExecStart=/usr/bin/container-storage-setup activate crio-storage
+ExecStop=/usr/bin/container-storage-setup deactivate crio-storage
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Implement ocid-storage-setup.service which executes container-storage-setup
to configure COW Storage.

If you use this script you are requiring container-storage-setup to be
installed.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>