### PR TITLE
Need to cleanup all pods on system shutdown poweroff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,7 @@ install.completions:
 
 install.systemd:
 	install -D -m 644 contrib/systemd/ocid.service $(PREFIX)/lib/systemd/system/ocid.service
+	install -D -m 644 contrib/systemd/ocid-shutdown.service $(PREFIX)/lib/systemd/system/ocid-shutdown.service
 
 uninstall:
 	rm -f $(BINDIR)/ocid

--- a/contrib/systemd/ocid-shutdown.service
+++ b/contrib/systemd/ocid-shutdown.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Shutdown OCID containers before shutting down the system
+Wants=ocid.service
+After=ocid.service
+Documentation=man:ocid(8)
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/true
+ExecStop=mkdir -p /var/lib/ocid; touch /var/lib/ocid/ocid.shutdown
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -40,7 +40,8 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 		cState := s.runtime.ContainerStatus(c)
 		if cState.Status == oci.ContainerStateCreated || cState.Status == oci.ContainerStateRunning {
 			if err := s.runtime.StopContainer(c); err != nil {
-				return nil, fmt.Errorf("failed to stop container %s: %v", c.Name(), err)
+				// Assume container is already stopped
+				logrus.Warnf("failed to stop container %s: %v", c.Name(), err)
 			}
 		}
 
@@ -106,4 +107,18 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 	resp := &pb.RemovePodSandboxResponse{}
 	logrus.Debugf("RemovePodSandboxResponse %+v", resp)
 	return resp, nil
+}
+
+// RemoveAllPodSandboxes removes all pod sandboxes
+func (s *Server) RemoveAllPodSandboxes() {
+	logrus.Debugf("RemoveAllPodSandboxes")
+	s.Update()
+	for _, sb := range s.state.sandboxes {
+		pod := &pb.RemovePodSandboxRequest{
+			PodSandboxId: sb.id,
+		}
+		if _, err := s.RemovePodSandbox(nil, pod); err != nil {
+			logrus.Warnf("could not RemovePodSandbox %s: %v", sb.id, err)
+		}
+	}
 }


### PR DESCRIPTION
Need to cleanup all pods on service poweroff

When powering off the system, we want the ocid service, to shutdown
all containers running on the system so they can cleanup properly
This patch will cleanup all pods on poweroff.



Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>