### PR TITLE
Set SELinux mount label for pod sandbox

### DIFF
--- a/.tool/lint
+++ b/.tool/lint
@@ -18,5 +18,5 @@ for d in $(find . -type d -not -iwholename '*.git*' -a -not -iname '.tool' -a -n
 		 --cyclo-over=60 \
 		 --dupl-threshold=100 \
 		 --tests \
-		 --deadline=30s "${d}"
+		 --deadline=60s "${d}"
 done

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -201,6 +201,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 			return nil, err
 		}
 		g.SetProcessSelinuxLabel(processLabel)
+		g.SetLinuxMountLabel(mountLabel)
 	}
 
 	// create shm mount for the pod containers.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -69,10 +69,8 @@ func RunUnderSystemdScope(pid int, slice string, unitName string) error {
 	properties = append(properties, newProp("PIDs", []uint32{uint32(pid)}))
 	properties = append(properties, newProp("Delegate", true))
 	properties = append(properties, newProp("DefaultDependencies", false))
-	if _, err := conn.StartTransientUnit(unitName, "replace", properties, nil); err != nil {
-		return err
-	}
-	return nil
+	_, err = conn.StartTransientUnit(unitName, "replace", properties, nil)
+	return err
 }
 
 func newProp(name string, units interface{}) systemdDbus.Property {


### PR DESCRIPTION
The pause container is creating an AVC since the /dev/null device
is not labeled correctly.  Looks like we are only setting the label of
the process not the label of the content inside of the container.
This change will label content in the pause container correctly and
eliminate the AVC.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>