### PR TITLE
Fixes for kubelet 1.6 and kubeadm 1.7

### DIFF
--- a/server/container_status.go
+++ b/server/container_status.go
@@ -16,17 +16,26 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 		return nil, err
 	}
 
-	if err := s.runtime.UpdateStatus(c); err != nil {
+	if err = s.runtime.UpdateStatus(c); err != nil {
 		return nil, err
 	}
 
 	containerID := c.ID()
+	image := c.Image()
 	resp := &pb.ContainerStatusResponse{
 		Status: &pb.ContainerStatus{
 			Id:       containerID,
 			Metadata: c.Metadata(),
+			Image:    image,
 		},
 	}
+
+	status, err := s.images.ImageStatus(s.imageContext, image.Image)
+	if err != nil {
+		return nil, err
+	}
+
+	resp.Status.ImageRef = status.ID
 
 	cState := s.runtime.ContainerStatus(c)
 	rStatus := pb.ContainerState_CONTAINER_UNKNOWN


### PR DESCRIPTION
While testing CRI-O with a kubeadm deployed k8s 1.6 cluster, we found a couple of issues:

- The container status response was missing the image name and ID entries
- The OCI container process arguments were incorrectly built.

With this PR we can run k8s 1.6 on top of CRI-O.