### PR TITLE
Default all container storage to /var/lib/containers/storage

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,4 +5,3 @@ assignees:
   - mikebrow
   - feiskyer
   - sameo
-  - dwalsh

--- a/OWNERS
+++ b/OWNERS
@@ -5,3 +5,4 @@ assignees:
   - mikebrow
   - feiskyer
   - sameo
+  - dwalsh

--- a/docs/ocid.8.md
+++ b/docs/ocid.8.md
@@ -81,10 +81,10 @@ ocid is meant to provide an integration path between OCI conformant runtimes and
   Image which contains the pause executable (default: "kubernetes/pause")
 
 **--root**=""
-  OCID root dir (default: "/var/lib/containers")
+  OCID root dir (default: "/var/lib/containers/storage")
 
 **--runroot**=""
-  OCID state dir (default: "/var/run/containers")
+  OCID state dir (default: "/var/run/containers/storage")
 
 **--runtime**=""
   OCI runtime path (default: "/usr/bin/runc")

--- a/docs/ocid.conf.5.md
+++ b/docs/ocid.conf.5.md
@@ -30,10 +30,10 @@ The `ocid` table supports the following options:
 
 
 **root**=""
-  OCID root dir (default: "/var/lib/containers")
+  OCID root dir (default: "/var/lib/containers/storage")
 
 **runroot**=""
-  OCID state dir (default: "/var/run/containers")
+  OCID state dir (default: "/var/run/containers/storage")
 
 **storage_driver**=""
   OCID storage driver (default is "devicemapper")

--- a/server/config.go
+++ b/server/config.go
@@ -10,8 +10,8 @@ import (
 
 // Default paths if none are specified
 const (
-	ocidRoot            = "/var/lib/ocid"
-	ocidRunRoot         = "/var/run/containers"
+	ocidRoot            = "/var/lib/containers/storage"
+	ocidRunRoot         = "/var/run/containers/storage"
 	conmonPath          = "/usr/libexec/ocid/conmon"
 	pauseImage          = "kubernetes/pause"
 	pauseCommand        = "/pause"

--- a/test/testdata/README.md
+++ b/test/testdata/README.md
@@ -7,9 +7,9 @@ In terminal 2:
 ```
 sudo ./ocic runtimeversion
 
-sudo rm -rf /var/lib/ocid/sandboxes/podsandbox1
+sudo rm -rf /var/lib/containers/storage/sandboxes/podsandbox1
 sudo ./ocic pod run --config testdata/sandbox_config.json
 
-sudo rm -rf /var/lib/ocid/containers/container1
+sudo rm -rf /var/lib/containers/storage/containers/container1
 sudo ./ocic container create --pod podsandbox1 --config testdata/container_config.json
 ```


### PR DESCRIPTION
containers/storage is defaulting to /var/lib/containers/storage
for image and containers storage.  It is also defaulting to
/var/run/containers/storage for all runtime.  The defaults
for CRI-O should match so that lots of other tools that use
containers/storage can share the same storage.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>