### PR TITLE
Switch to using opencontainers/selinux

### DIFF
--- a/cmd/ocid/main.go
+++ b/cmd/ocid/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/kubernetes-incubator/cri-o/server"
-	"github.com/opencontainers/runc/libcontainer/selinux"
+	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 	"k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"

--- a/lock.json
+++ b/lock.json
@@ -1,5 +1,5 @@
 {
-    "memo": "f9f05813d58aa8fce2eed8aae7f05fd12d1f2965afb0fea7ed0ead9a70836e53",
+    "memo": "982a27b328719863bc88dcd24142002eee29fab7f48fdc71340a0620fd5c3ebe",
     "projects": [
         {
             "name": "github.com/BurntSushi/toml",
@@ -338,6 +338,15 @@
             "packages": [
                 "generate",
                 "generate/seccomp"
+            ]
+        },
+        {
+            "name": "github.com/opencontainers/selinux",
+            "branch": "master",
+            "revision": "ba1aefe8057f1d0cfb8e88d0ec1dc85925ef987d",
+            "packages": [
+                "go-selinux",
+                "go-selinux/label"
             ]
         },
         {

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,9 @@
         "github.com/opencontainers/runtime-spec": {
             "branch": "master"
         },
+        "github.com/opencontainers/selinux": {
+            "branch": "master"
+        },
         "google.golang.org/grpc": {
             "version": "v1.0.1-GA"
         },

--- a/server/config.go
+++ b/server/config.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 
 	"github.com/BurntSushi/toml"
-	"github.com/opencontainers/runc/libcontainer/selinux"
+	"github.com/opencontainers/selinux/go-selinux"
 )
 
 // Default paths if none are specified
@@ -215,7 +215,7 @@ func DefaultConfig() *Config {
 			ConmonEnv: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			},
-			SELinux:         selinux.SelinuxEnabled(),
+			SELinux:         selinux.GetEnabled(),
 			SeccompProfile:  seccompProfilePath,
 			ApparmorProfile: apparmorProfileName,
 			CgroupManager:   cgroupManager,

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -14,8 +14,8 @@ import (
 	"github.com/kubernetes-incubator/cri-o/server/apparmor"
 	"github.com/kubernetes-incubator/cri-o/server/seccomp"
 	"github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/opencontainers/runc/libcontainer/label"
 	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/opencontainers/selinux/go-selinux/label"
 	"golang.org/x/net/context"
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/kubernetes-incubator/cri-o/oci"
-	"github.com/opencontainers/runc/libcontainer/label"
+	"github.com/opencontainers/selinux/go-selinux/label"
 	"golang.org/x/net/context"
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
@@ -66,7 +66,7 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 		}
 	}
 
-	if err := label.UnreserveLabel(sb.processLabel); err != nil {
+	if err := label.ReleaseLabel(sb.processLabel); err != nil {
 		return nil, err
 	}
 

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -11,8 +11,8 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/storage/storage"
 	"github.com/kubernetes-incubator/cri-o/oci"
-	"github.com/opencontainers/runc/libcontainer/label"
 	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/opencontainers/selinux/go-selinux/label"
 	"golang.org/x/net/context"
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )

--- a/server/server.go
+++ b/server/server.go
@@ -17,8 +17,8 @@ import (
 	"github.com/kubernetes-incubator/cri-o/pkg/storage"
 	"github.com/kubernetes-incubator/cri-o/server/apparmor"
 	"github.com/kubernetes-incubator/cri-o/server/seccomp"
-	"github.com/opencontainers/runc/libcontainer/label"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/selinux/go-selinux/label"
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
 

--- a/vendor/github.com/containers/image/copy/fixtures/Hello.bz2
+++ b/vendor/github.com/containers/image/copy/fixtures/Hello.bz2
@@ -1,1 +1,0 @@
-../../pkg/compression/fixtures/Hello.bz2

--- a/vendor/github.com/containers/image/copy/fixtures/Hello.gz
+++ b/vendor/github.com/containers/image/copy/fixtures/Hello.gz
@@ -1,1 +1,0 @@
-../../pkg/compression/fixtures/Hello.gz

--- a/vendor/github.com/containers/image/copy/fixtures/Hello.uncompressed
+++ b/vendor/github.com/containers/image/copy/fixtures/Hello.uncompressed
@@ -1,1 +1,0 @@
-../../pkg/compression/fixtures/Hello.uncompressed

--- a/vendor/github.com/containers/image/copy/fixtures/Hello.xz
+++ b/vendor/github.com/containers/image/copy/fixtures/Hello.xz
@@ -1,1 +1,0 @@
-../../pkg/compression/fixtures/Hello.xz

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-manifest-digest-error/manifest.json
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-manifest-digest-error/manifest.json
@@ -1,1 +1,0 @@
-../v2s1-invalid-signatures.manifest.json

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-manifest-digest-error/signature-1
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-manifest-digest-error/signature-1
@@ -1,1 +1,0 @@
-../dir-img-valid/signature-1

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-mixed/manifest.json
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-mixed/manifest.json
@@ -1,1 +1,0 @@
-../dir-img-valid/manifest.json

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-mixed/signature-1
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-mixed/signature-1
@@ -1,1 +1,0 @@
-../invalid-blob.signature

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-mixed/signature-2
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-mixed/signature-2
@@ -1,1 +1,0 @@
-../dir-img-valid/signature-1

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-modified-manifest/signature-1
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-modified-manifest/signature-1
@@ -1,1 +1,0 @@
-../dir-img-valid/signature-1

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-no-manifest/signature-1
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-no-manifest/signature-1
@@ -1,1 +1,0 @@
-../dir-img-valid/signature-1

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-unsigned/manifest.json
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-unsigned/manifest.json
@@ -1,1 +1,0 @@
-../dir-img-valid/manifest.json

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-valid-2/manifest.json
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-valid-2/manifest.json
@@ -1,1 +1,0 @@
-../dir-img-valid/manifest.json

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-valid-2/signature-1
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-valid-2/signature-1
@@ -1,1 +1,0 @@
-../dir-img-valid/signature-1

--- a/vendor/github.com/containers/image/signature/fixtures/dir-img-valid/manifest.json
+++ b/vendor/github.com/containers/image/signature/fixtures/dir-img-valid/manifest.json
@@ -1,1 +1,0 @@
-../image.manifest.json

--- a/vendor/github.com/opencontainers/selinux/.pullapprove.yml
+++ b/vendor/github.com/opencontainers/selinux/.pullapprove.yml
@@ -1,0 +1,11 @@
+approve_by_comment: true
+approve_regex: '^(Approved|lgtm|LGTM|:shipit:|:star:|:\+1:|:ship:)'
+reject_regex: ^Rejected
+reset_on_push: true
+signed_off_by:
+  required: true
+reviewers:
+  teams:
+  - go-selinux-maintainers
+  name: default
+  required: 2

--- a/vendor/github.com/opencontainers/selinux/.travis.yml
+++ b/vendor/github.com/opencontainers/selinux/.travis.yml
@@ -1,0 +1,17 @@
+language: go
+go:
+  - 1.8
+  - tip
+  - master
+
+env:
+  global:
+    - BUILDTAGS="selinux linux"
+
+before_install:
+  - go get -u github.com/golang/lint/golint
+  - go get -u github.com/vbatts/git-validation
+
+script:
+  - git-validation -run DCO,short-subject -v -range ${TRAVIS_COMMIT_RANGE}
+  - make BUILDTAGS="${BUILDTAGS}" lint test

--- a/vendor/github.com/opencontainers/selinux/CONTRIBUTING.md
+++ b/vendor/github.com/opencontainers/selinux/CONTRIBUTING.md
@@ -1,0 +1,119 @@
+## Contribution Guidelines
+
+### Security issues
+
+If you are reporting a security issue, do not create an issue or file a pull
+request on GitHub. Instead, disclose the issue responsibly by sending an email
+to security@opencontainers.org (which is inhabited only by the maintainers of
+the various OCI projects).
+
+### Pull requests are always welcome
+
+We are always thrilled to receive pull requests, and do our best to
+process them as fast as possible. Not sure if that typo is worth a pull
+request? Do it! We will appreciate it.
+
+If your pull request is not accepted on the first try, don't be
+discouraged! If there's a problem with the implementation, hopefully you
+received feedback on what to improve.
+
+We're trying very hard to keep the project lean and focused. We don't want it
+to do everything for everybody. This means that we might decide against
+incorporating a new feature.
+
+
+### Conventions
+
+Fork the repo and make changes on your fork in a feature branch.
+For larger bugs and enhancements, consider filing a leader issue or mailing-list thread for discussion that is independent of the implementation.
+Small changes or changes that have been discussed on the project mailing list may be submitted without a leader issue.
+
+If the project has a test suite, submit unit tests for your changes. Take a
+look at existing tests for inspiration. Run the full test suite on your branch
+before submitting a pull request.
+
+Update the documentation when creating or modifying features. Test
+your documentation changes for clarity, concision, and correctness, as
+well as a clean documentation build. See ``docs/README.md`` for more
+information on building the docs and how docs get released.
+
+Write clean code. Universally formatted code promotes ease of writing, reading,
+and maintenance. Always run `gofmt -s -w file.go` on each changed file before
+committing your changes. Most editors have plugins that do this automatically.
+
+Pull requests descriptions should be as clear as possible and include a
+reference to all the issues that they address.
+
+Commit messages must start with a capitalized and short summary
+written in the imperative, followed by an optional, more detailed
+explanatory text which is separated from the summary by an empty line.
+
+Code review comments may be added to your pull request. Discuss, then make the
+suggested modifications and push additional commits to your feature branch. Be
+sure to post a comment after pushing. The new commits will show up in the pull
+request automatically, but the reviewers will not be notified unless you
+comment.
+
+Before the pull request is merged, make sure that you squash your commits into
+logical units of work using `git rebase -i` and `git push -f`. After every
+commit the test suite (if any) should be passing. Include documentation changes
+in the same commit so that a revert would remove all traces of the feature or
+fix.
+
+Commits that fix or close an issue should include a reference like `Closes #XXX`
+or `Fixes #XXX`, which will automatically close the issue when merged.
+
+### Sign your work
+
+The sign-off is a simple line at the end of the explanation for the
+patch, which certifies that you wrote it or otherwise have the right to
+pass it on as an open-source patch.  The rules are pretty simple: if you
+can certify the below (from
+[developercertificate.org](http://developercertificate.org/)):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe@gmail.com>
+
+using your real name (sorry, no pseudonyms or anonymous contributions.)
+
+You can add the sign off when creating the git commit via `git commit -s`.

--- a/vendor/github.com/opencontainers/selinux/LICENSE
+++ b/vendor/github.com/opencontainers/selinux/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/opencontainers/selinux/MAINTAINERS
+++ b/vendor/github.com/opencontainers/selinux/MAINTAINERS
@@ -1,0 +1,3 @@
+Antonio Murdaca <runcom@redhat.com> (@runcom)
+Daniel J Walsh <dwalsh@redhat.com> (@rhatdan)
+Mrunal Patel <mpatel@redhat.com> (@mrunalp)

--- a/vendor/github.com/opencontainers/selinux/Makefile
+++ b/vendor/github.com/opencontainers/selinux/Makefile
@@ -1,0 +1,14 @@
+BUILDTAGS := selinux
+
+check-gopath:
+ifndef GOPATH
+	$(error GOPATH is not set)
+endif
+
+.PHONY: test
+test: check-gopath
+	go test -timeout 3m -tags "${BUILDTAGS}" ${TESTFLAGS} -v ./...
+
+.PHONY:
+lint:
+	golint go-selinux

--- a/vendor/github.com/opencontainers/selinux/README.md
+++ b/vendor/github.com/opencontainers/selinux/README.md
@@ -1,0 +1,7 @@
+# selinux
+
+[![GoDoc](https://godoc.org/github.com/opencontainers/selinux?status.svg)](https://godoc.org/github.com/opencontainers/selinux) [![Go Report Card](https://goreportcard.com/badge/github.com/opencontainers/selinux)](https://goreportcard.com/report/github.com/opencontainers/selinux) [![Build Status](https://travis-ci.org/opencontainers/selinux.svg?branch=master)](https://travis-ci.org/opencontainers/selinux)
+
+Common SELinux package used across the container ecosystem.
+
+Please see the [godoc](https://godoc.org/github.com/opencontainers/selinux) for more information.

--- a/vendor/github.com/opencontainers/selinux/go-selinux/label/label.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/label/label.go
@@ -1,0 +1,84 @@
+// +build !selinux !linux
+
+package label
+
+// InitLabels returns the process label and file labels to be used within
+// the container.  A list of options can be passed into this function to alter
+// the labels.
+func InitLabels(options []string) (string, string, error) {
+	return "", "", nil
+}
+
+func GetROMountLabel() string {
+	return ""
+}
+
+func GenLabels(options string) (string, string, error) {
+	return "", "", nil
+}
+
+func FormatMountLabel(src string, mountLabel string) string {
+	return src
+}
+
+func SetProcessLabel(processLabel string) error {
+	return nil
+}
+
+func GetFileLabel(path string) (string, error) {
+	return "", nil
+}
+
+func SetFileLabel(path string, fileLabel string) error {
+	return nil
+}
+
+func SetFileCreateLabel(fileLabel string) error {
+	return nil
+}
+
+func Relabel(path string, fileLabel string, shared bool) error {
+	return nil
+}
+
+func GetPidLabel(pid int) (string, error) {
+	return "", nil
+}
+
+func Init() {
+}
+
+func ReserveLabel(label string) error {
+	return nil
+}
+
+func ReleaseLabel(label string) error {
+	return nil
+}
+
+// DupSecOpt takes a process label and returns security options that
+// can be used to set duplicate labels on future container processes
+func DupSecOpt(src string) []string {
+	return nil
+}
+
+// DisableSecOpt returns a security opt that can disable labeling
+// support for future container processes
+func DisableSecOpt() []string {
+	return nil
+}
+
+// Validate checks that the label does not include unexpected options
+func Validate(label string) error {
+	return nil
+}
+
+// RelabelNeeded checks whether the user requested a relabel
+func RelabelNeeded(label string) bool {
+	return false
+}
+
+// IsShared checks that the label includes a "shared" mark
+func IsShared(label string) bool {
+	return false
+}

--- a/vendor/github.com/opencontainers/selinux/go-selinux/label/label_selinux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/label/label_selinux.go
@@ -1,0 +1,204 @@
+// +build selinux,linux
+
+package label
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/opencontainers/selinux/go-selinux"
+)
+
+// Valid Label Options
+var validOptions = map[string]bool{
+	"disable": true,
+	"type":    true,
+	"user":    true,
+	"role":    true,
+	"level":   true,
+}
+
+var ErrIncompatibleLabel = fmt.Errorf("Bad SELinux option z and Z can not be used together")
+
+// InitLabels returns the process label and file labels to be used within
+// the container.  A list of options can be passed into this function to alter
+// the labels.  The labels returned will include a random MCS String, that is
+// guaranteed to be unique.
+func InitLabels(options []string) (string, string, error) {
+	if !selinux.GetEnabled() {
+		return "", "", nil
+	}
+	processLabel, mountLabel := selinux.ContainerLabels()
+	if processLabel != "" {
+		pcon := selinux.NewContext(processLabel)
+		mcon := selinux.NewContext(mountLabel)
+		for _, opt := range options {
+			if opt == "disable" {
+				return "", "", nil
+			}
+			if i := strings.Index(opt, ":"); i == -1 {
+				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable' or \n'user, role, level, type' followed by ':' and a value", opt)
+			}
+			con := strings.SplitN(opt, ":", 2)
+			if !validOptions[con[0]] {
+				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable, user, role, level, type'", con[0])
+
+			}
+			pcon[con[0]] = con[1]
+			if con[0] == "level" || con[0] == "user" {
+				mcon[con[0]] = con[1]
+			}
+		}
+		processLabel = pcon.Get()
+		mountLabel = mcon.Get()
+	}
+	return processLabel, mountLabel, nil
+}
+
+func ROMountLabel() string {
+	return selinux.ROFileLabel()
+}
+
+// DEPRECATED: The GenLabels function is only to be used during the transition to the official API.
+func GenLabels(options string) (string, string, error) {
+	return InitLabels(strings.Fields(options))
+}
+
+// FormatMountLabel returns a string to be used by the mount command.
+// The format of this string will be used to alter the labeling of the mountpoint.
+// The string returned is suitable to be used as the options field of the mount command.
+// If you need to have additional mount point options, you can pass them in as
+// the first parameter.  Second parameter is the label that you wish to apply
+// to all content in the mount point.
+func FormatMountLabel(src, mountLabel string) string {
+	if mountLabel != "" {
+		switch src {
+		case "":
+			src = fmt.Sprintf("context=%q", mountLabel)
+		default:
+			src = fmt.Sprintf("%s,context=%q", src, mountLabel)
+		}
+	}
+	return src
+}
+
+// SetProcessLabel takes a process label and tells the kernel to assign the
+// label to the next program executed by the current process.
+func SetProcessLabel(processLabel string) error {
+	if processLabel == "" {
+		return nil
+	}
+	return selinux.SetExecLabel(processLabel)
+}
+
+// ProcessLabel returns the process label that the kernel will assign
+// to the next program executed by the current process.  If "" is returned
+// this indicates that the default labeling will happen for the process.
+func ProcessLabel() (string, error) {
+	return selinux.ExecLabel()
+}
+
+// GetFileLabel returns the label for specified path
+func FileLabel(path string) (string, error) {
+	return selinux.FileLabel(path)
+}
+
+// SetFileLabel modifies the "path" label to the specified file label
+func SetFileLabel(path string, fileLabel string) error {
+	if selinux.GetEnabled() && fileLabel != "" {
+		return selinux.SetFileLabel(path, fileLabel)
+	}
+	return nil
+}
+
+// SetFileCreateLabel tells the kernel the label for all files to be created
+func SetFileCreateLabel(fileLabel string) error {
+	if selinux.GetEnabled() {
+		return selinux.SetFSCreateLabel(fileLabel)
+	}
+	return nil
+}
+
+// Relabel changes the label of path to the filelabel string.
+// It changes the MCS label to s0 if shared is true.
+// This will allow all containers to share the content.
+func Relabel(path string, fileLabel string, shared bool) error {
+	if !selinux.GetEnabled() {
+		return nil
+	}
+
+	if fileLabel == "" {
+		return nil
+	}
+
+	exclude_paths := map[string]bool{"/": true, "/usr": true, "/etc": true}
+	if exclude_paths[path] {
+		return fmt.Errorf("SELinux relabeling of %s is not allowed", path)
+	}
+
+	if shared {
+		c := selinux.NewContext(fileLabel)
+		c["level"] = "s0"
+		fileLabel = c.Get()
+	}
+	if err := selinux.Chcon(path, fileLabel, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+// PidLabel will return the label of the process running with the specified pid
+func PidLabel(pid int) (string, error) {
+	return selinux.PidLabel(pid)
+}
+
+// Init initialises the labeling system
+func Init() {
+	selinux.GetEnabled()
+}
+
+// ReserveLabel will record the fact that the MCS label has already been used.
+// This will prevent InitLabels from using the MCS label in a newly created
+// container
+func ReserveLabel(label string) error {
+	selinux.ReserveLabel(label)
+	return nil
+}
+
+// ReleaseLabel will remove the reservation of the MCS label.
+// This will allow InitLabels to use the MCS label in a newly created
+// containers
+func ReleaseLabel(label string) error {
+	selinux.ReleaseLabel(label)
+	return nil
+}
+
+// DupSecOpt takes a process label and returns security options that
+// can be used to set duplicate labels on future container processes
+func DupSecOpt(src string) []string {
+	return selinux.DupSecOpt(src)
+}
+
+// DisableSecOpt returns a security opt that can disable labeling
+// support for future container processes
+func DisableSecOpt() []string {
+	return selinux.DisableSecOpt()
+}
+
+// Validate checks that the label does not include unexpected options
+func Validate(label string) error {
+	if strings.Contains(label, "z") && strings.Contains(label, "Z") {
+		return ErrIncompatibleLabel
+	}
+	return nil
+}
+
+// RelabelNeeded checks whether the user requested a relabel
+func RelabelNeeded(label string) bool {
+	return strings.Contains(label, "z") || strings.Contains(label, "Z")
+}
+
+// IsShared checks that the label includes a "shared" mark
+func IsShared(label string) bool {
+	return strings.Contains(label, "z")
+}

--- a/vendor/github.com/opencontainers/selinux/go-selinux/label/label_selinux_test.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/label/label_selinux_test.go
@@ -1,0 +1,146 @@
+// +build selinux,linux
+
+package label
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/opencontainers/selinux/go-selinux"
+)
+
+func TestInit(t *testing.T) {
+	if !selinux.GetEnabled() {
+		return
+	}
+	var testNull []string
+	plabel, mlabel, err := InitLabels(testNull)
+	if err != nil {
+		t.Log("InitLabels Failed")
+		t.Fatal(err)
+	}
+	testDisabled := []string{"disable"}
+	roMountLabel := ROMountLabel()
+	if roMountLabel == "" {
+		t.Errorf("ROMountLabel Failed")
+	}
+	plabel, mlabel, err = InitLabels(testDisabled)
+	if err != nil {
+		t.Log("InitLabels Disabled Failed")
+		t.Fatal(err)
+	}
+	if plabel != "" {
+		t.Log("InitLabels Disabled Failed")
+		t.FailNow()
+	}
+	testUser := []string{"user:user_u", "role:user_r", "type:user_t", "level:s0:c1,c15"}
+	plabel, mlabel, err = InitLabels(testUser)
+	if err != nil {
+		t.Log("InitLabels User Failed")
+		t.Fatal(err)
+	}
+	if plabel != "user_u:user_r:user_t:s0:c1,c15" || (mlabel != "user_u:object_r:container_file_t:s0:c1,c15" && mlabel != "user_u:object_r:svirt_sandbox_file_t:s0:c1,c15") {
+		t.Log("InitLabels User Match Failed")
+		t.Log(plabel, mlabel)
+		t.Fatal(err)
+	}
+
+	testBadData := []string{"user", "role:user_r", "type:user_t", "level:s0:c1,c15"}
+	if _, _, err = InitLabels(testBadData); err == nil {
+		t.Log("InitLabels Bad Failed")
+		t.Fatal(err)
+	}
+}
+func TestDuplicateLabel(t *testing.T) {
+	secopt := DupSecOpt("system_u:system_r:container_t:s0:c1,c2")
+	for _, opt := range secopt {
+		con := strings.SplitN(opt, ":", 2)
+		if con[0] == "user" {
+			if con[1] != "system_u" {
+				t.Errorf("DupSecOpt Failed user incorrect")
+			}
+			continue
+		}
+		if con[0] == "role" {
+			if con[1] != "system_r" {
+				t.Errorf("DupSecOpt Failed role incorrect")
+			}
+			continue
+		}
+		if con[0] == "type" {
+			if con[1] != "container_t" {
+				t.Errorf("DupSecOpt Failed type incorrect")
+			}
+			continue
+		}
+		if con[0] == "level" {
+			if con[1] != "s0:c1,c2" {
+				t.Errorf("DupSecOpt Failed level incorrect")
+			}
+			continue
+		}
+		t.Errorf("DupSecOpt Failed invalid field %q", con[0])
+	}
+	secopt = DisableSecOpt()
+	if secopt[0] != "disable" {
+		t.Errorf("DisableSecOpt Failed level incorrect %q", secopt[0])
+	}
+}
+func TestRelabel(t *testing.T) {
+	if !selinux.GetEnabled() {
+		return
+	}
+	testdir := "/tmp/test"
+	if err := os.Mkdir(testdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testdir)
+	label := "system_u:object_r:container_file_t:s0:c1,c2"
+	if err := Relabel(testdir, "", true); err != nil {
+		t.Fatalf("Relabel with no label failed: %v", err)
+	}
+	if err := Relabel(testdir, label, true); err != nil {
+		t.Fatalf("Relabel shared failed: %v", err)
+	}
+	if err := Relabel(testdir, label, false); err != nil {
+		t.Fatalf("Relabel unshared failed: %v", err)
+	}
+	if err := Relabel("/etc", label, false); err == nil {
+		t.Fatalf("Relabel /etc succeeded")
+	}
+	if err := Relabel("/", label, false); err == nil {
+		t.Fatalf("Relabel / succeeded")
+	}
+	if err := Relabel("/usr", label, false); err == nil {
+		t.Fatalf("Relabel /usr succeeded")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	if err := Validate("zZ"); err != ErrIncompatibleLabel {
+		t.Fatalf("Expected incompatible error, got %v", err)
+	}
+	if err := Validate("Z"); err != nil {
+		t.Fatal(err)
+	}
+	if err := Validate("z"); err != nil {
+		t.Fatal(err)
+	}
+	if err := Validate(""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIsShared(t *testing.T) {
+	if shared := IsShared("Z"); shared {
+		t.Fatalf("Expected label `Z` to not be shared, got %v", shared)
+	}
+	if shared := IsShared("z"); !shared {
+		t.Fatalf("Expected label `z` to be shared, got %v", shared)
+	}
+	if shared := IsShared("Zz"); !shared {
+		t.Fatalf("Expected label `Zz` to be shared, got %v", shared)
+	}
+
+}

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux.go
@@ -1,0 +1,593 @@
+// +build linux
+
+package selinux
+
+import (
+	"bufio"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+const (
+	// Enforcing constant indicate SELinux is in enforcing mode
+	Enforcing = 1
+	// Permissive constant to indicate SELinux is in permissive mode
+	Permissive = 0
+	// Disabled constant to indicate SELinux is disabled
+	Disabled         = -1
+	selinuxDir       = "/etc/selinux/"
+	selinuxConfig    = selinuxDir + "config"
+	selinuxTypeTag   = "SELINUXTYPE"
+	selinuxTag       = "SELINUX"
+	selinuxPath      = "/sys/fs/selinux"
+	xattrNameSelinux = "security.selinux"
+	stRdOnly         = 0x01
+)
+
+type selinuxState struct {
+	enabledSet   bool
+	enabled      bool
+	selinuxfsSet bool
+	selinuxfs    string
+	mcsList      map[string]bool
+	sync.Mutex
+}
+
+var (
+	assignRegex = regexp.MustCompile(`^([^=]+)=(.*)$`)
+	state       = selinuxState{
+		mcsList: make(map[string]bool),
+	}
+)
+
+// Context is a representation of the SELinux label broken into 4 parts
+type Context map[string]string
+
+func (s *selinuxState) setEnable(enabled bool) bool {
+	s.Lock()
+	defer s.Unlock()
+	s.enabledSet = true
+	s.enabled = enabled
+	return s.enabled
+}
+
+func (s *selinuxState) getEnabled() bool {
+	s.Lock()
+	enabled := s.enabled
+	enabledSet := s.enabledSet
+	s.Unlock()
+	if enabledSet {
+		return enabled
+	}
+
+	enabled = false
+	if fs := getSelinuxMountPoint(); fs != "" {
+		if con, _ := CurrentLabel(); con != "kernel" {
+			enabled = true
+		}
+	}
+	return s.setEnable(enabled)
+}
+
+// SetDisabled disables selinux support for the package
+func SetDisabled() {
+	state.setEnable(false)
+}
+
+func (s *selinuxState) setSELinuxfs(selinuxfs string) string {
+	s.Lock()
+	defer s.Unlock()
+	s.selinuxfsSet = true
+	s.selinuxfs = selinuxfs
+	return s.selinuxfs
+}
+
+func (s *selinuxState) getSELinuxfs() string {
+	s.Lock()
+	selinuxfs := s.selinuxfs
+	selinuxfsSet := s.selinuxfsSet
+	s.Unlock()
+	if selinuxfsSet {
+		return selinuxfs
+	}
+
+	selinuxfs = ""
+	f, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return selinuxfs
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		txt := scanner.Text()
+		// Safe as mountinfo encodes mountpoints with spaces as \040.
+		sepIdx := strings.Index(txt, " - ")
+		if sepIdx == -1 {
+			continue
+		}
+		if !strings.Contains(txt[sepIdx:], "selinuxfs") {
+			continue
+		}
+		fields := strings.Split(txt, " ")
+		if len(fields) < 5 {
+			continue
+		}
+		selinuxfs = fields[4]
+		break
+	}
+
+	if selinuxfs != "" {
+		var buf syscall.Statfs_t
+		syscall.Statfs(selinuxfs, &buf)
+		if (buf.Flags & stRdOnly) == 1 {
+			selinuxfs = ""
+		}
+	}
+	return s.setSELinuxfs(selinuxfs)
+}
+
+// getSelinuxMountPoint returns the path to the mountpoint of an selinuxfs
+// filesystem or an empty string if no mountpoint is found.  Selinuxfs is
+// a proc-like pseudo-filesystem that exposes the selinux policy API to
+// processes.  The existence of an selinuxfs mount is used to determine
+// whether selinux is currently enabled or not.
+func getSelinuxMountPoint() string {
+	return state.getSELinuxfs()
+}
+
+// GetEnabled returns whether selinux is currently enabled.
+func GetEnabled() bool {
+	return state.getEnabled()
+}
+
+func readConfig(target string) (value string) {
+	var (
+		val, key string
+		bufin    *bufio.Reader
+	)
+
+	in, err := os.Open(selinuxConfig)
+	if err != nil {
+		return ""
+	}
+	defer in.Close()
+
+	bufin = bufio.NewReader(in)
+
+	for done := false; !done; {
+		var line string
+		if line, err = bufin.ReadString('\n'); err != nil {
+			if err != io.EOF {
+				return ""
+			}
+			done = true
+		}
+		line = strings.TrimSpace(line)
+		if len(line) == 0 {
+			// Skip blank lines
+			continue
+		}
+		if line[0] == ';' || line[0] == '#' {
+			// Skip comments
+			continue
+		}
+		if groups := assignRegex.FindStringSubmatch(line); groups != nil {
+			key, val = strings.TrimSpace(groups[1]), strings.TrimSpace(groups[2])
+			if key == target {
+				return strings.Trim(val, "\"")
+			}
+		}
+	}
+	return ""
+}
+
+func getSELinuxPolicyRoot() string {
+	return selinuxDir + readConfig(selinuxTypeTag)
+}
+
+func readCon(name string) (string, error) {
+	var val string
+
+	in, err := os.Open(name)
+	if err != nil {
+		return "", err
+	}
+	defer in.Close()
+
+	_, err = fmt.Fscanf(in, "%s", &val)
+	return val, err
+}
+
+// SetFileLabel sets the SELinux label for this path or returns an error.
+func SetFileLabel(path string, label string) error {
+	return lsetxattr(path, xattrNameSelinux, []byte(label), 0)
+}
+
+// Filecon returns the SELinux label for this path or returns an error.
+func FileLabel(path string) (string, error) {
+	label, err := lgetxattr(path, xattrNameSelinux)
+	if err != nil {
+		return "", err
+	}
+	// Trim the NUL byte at the end of the byte buffer, if present.
+	if len(label) > 0 && label[len(label)-1] == '\x00' {
+		label = label[:len(label)-1]
+	}
+	return string(label), nil
+}
+
+/*
+SetFSCreateLabel tells kernel the label to create all file system objects
+created by this task. Setting label="" to return to default.
+*/
+func SetFSCreateLabel(label string) error {
+	return writeCon(fmt.Sprintf("/proc/self/task/%d/attr/fscreate", syscall.Gettid()), label)
+}
+
+/*
+FSCreateLabel returns the default label the kernel which the kernel is using
+for file system objects created by this task. "" indicates default.
+*/
+func FSCreateLabel() (string, error) {
+	return readCon(fmt.Sprintf("/proc/self/task/%d/attr/fscreate", syscall.Gettid()))
+}
+
+// CurrentLabel returns the SELinux label of the current process thread, or an error.
+func CurrentLabel() (string, error) {
+	return readCon(fmt.Sprintf("/proc/self/task/%d/attr/current", syscall.Gettid()))
+}
+
+// PidLabel returns the SELinux label of the given pid, or an error.
+func PidLabel(pid int) (string, error) {
+	return readCon(fmt.Sprintf("/proc/%d/attr/current", pid))
+}
+
+/*
+ExecLabel returns the SELinux label that the kernel will use for any programs
+that are executed by the current process thread, or an error.
+*/
+func ExecLabel() (string, error) {
+	return readCon(fmt.Sprintf("/proc/self/task/%d/attr/exec", syscall.Gettid()))
+}
+
+func writeCon(name string, val string) error {
+	out, err := os.OpenFile(name, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if val != "" {
+		_, err = out.Write([]byte(val))
+	} else {
+		_, err = out.Write(nil)
+	}
+	return err
+}
+
+/*
+SetExecLabel sets the SELinux label that the kernel will use for any programs
+that are executed by the current process thread, or an error.
+*/
+func SetExecLabel(label string) error {
+	return writeCon(fmt.Sprintf("/proc/self/task/%d/attr/exec", syscall.Gettid()), label)
+}
+
+// Get returns the Context as a string
+func (c Context) Get() string {
+	return fmt.Sprintf("%s:%s:%s:%s", c["user"], c["role"], c["type"], c["level"])
+}
+
+// NewContext creates a new Context struct from the specified label
+func NewContext(label string) Context {
+	c := make(Context)
+
+	if len(label) != 0 {
+		con := strings.SplitN(label, ":", 4)
+		c["user"] = con[0]
+		c["role"] = con[1]
+		c["type"] = con[2]
+		c["level"] = con[3]
+	}
+	return c
+}
+
+// ReserveLabel reserves the MLS/MCS level component of the specified label
+func ReserveLabel(label string) {
+	if len(label) != 0 {
+		con := strings.SplitN(label, ":", 4)
+		mcsAdd(con[3])
+	}
+}
+
+func selinuxEnforcePath() string {
+	return fmt.Sprintf("%s/enforce", selinuxPath)
+}
+
+// EnforceMode returns the current SELinux mode Enforcing, Permissive, Disabled
+func EnforceMode() int {
+	var enforce int
+
+	enforceS, err := readCon(selinuxEnforcePath())
+	if err != nil {
+		return -1
+	}
+
+	enforce, err = strconv.Atoi(string(enforceS))
+	if err != nil {
+		return -1
+	}
+	return enforce
+}
+
+/*
+SetEnforce sets the current SELinux mode Enforcing, Permissive.
+Disabled is not valid, since this needs to be set at boot time.
+*/
+func SetEnforceMode(mode int) error {
+	return writeCon(selinuxEnforcePath(), fmt.Sprintf("%d", mode))
+}
+
+/*
+DefaultEnforceMode returns the systems default SELinux mode Enforcing,
+Permissive or Disabled. Note this is is just the default at boot time.
+EnforceMode tells you the systems current mode.
+*/
+func DefaultEnforceMode() int {
+	switch readConfig(selinuxTag) {
+	case "enforcing":
+		return Enforcing
+	case "permissive":
+		return Permissive
+	}
+	return Disabled
+}
+
+func mcsAdd(mcs string) error {
+	state.Lock()
+	defer state.Unlock()
+	if state.mcsList[mcs] {
+		return fmt.Errorf("MCS Label already exists")
+	}
+	state.mcsList[mcs] = true
+	return nil
+}
+
+func mcsDelete(mcs string) {
+	state.Lock()
+	defer state.Unlock()
+	state.mcsList[mcs] = false
+}
+
+func intToMcs(id int, catRange uint32) string {
+	var (
+		SETSIZE = int(catRange)
+		TIER    = SETSIZE
+		ORD     = id
+	)
+
+	if id < 1 || id > 523776 {
+		return ""
+	}
+
+	for ORD > TIER {
+		ORD = ORD - TIER
+		TIER--
+	}
+	TIER = SETSIZE - TIER
+	ORD = ORD + TIER
+	return fmt.Sprintf("s0:c%d,c%d", TIER, ORD)
+}
+
+func uniqMcs(catRange uint32) string {
+	var (
+		n      uint32
+		c1, c2 uint32
+		mcs    string
+	)
+
+	for {
+		binary.Read(rand.Reader, binary.LittleEndian, &n)
+		c1 = n % catRange
+		binary.Read(rand.Reader, binary.LittleEndian, &n)
+		c2 = n % catRange
+		if c1 == c2 {
+			continue
+		} else {
+			if c1 > c2 {
+				c1, c2 = c2, c1
+			}
+		}
+		mcs = fmt.Sprintf("s0:c%d,c%d", c1, c2)
+		if err := mcsAdd(mcs); err != nil {
+			continue
+		}
+		break
+	}
+	return mcs
+}
+
+/*
+ReleaseLabel will unreserve the MLS/MCS Level field of the specified label.
+Allowing it to be used by another process.
+*/
+func ReleaseLabel(label string) {
+	if len(label) != 0 {
+		con := strings.SplitN(label, ":", 4)
+		mcsDelete(con[3])
+	}
+}
+
+var roFileLabel string
+
+// ROFileLabel returns the specified SELinux readonly file label
+func ROFileLabel() (fileLabel string) {
+	return roFileLabel
+}
+
+/*
+ContainerLabels returns an allocated processLabel and fileLabel to be used for
+container labeling by the calling process.
+*/
+func ContainerLabels() (processLabel string, fileLabel string) {
+	var (
+		val, key string
+		bufin    *bufio.Reader
+	)
+
+	if !GetEnabled() {
+		return "", ""
+	}
+	lxcPath := fmt.Sprintf("%s/contexts/lxc_contexts", getSELinuxPolicyRoot())
+	in, err := os.Open(lxcPath)
+	if err != nil {
+		return "", ""
+	}
+	defer in.Close()
+
+	bufin = bufio.NewReader(in)
+
+	for done := false; !done; {
+		var line string
+		if line, err = bufin.ReadString('\n'); err != nil {
+			if err == io.EOF {
+				done = true
+			} else {
+				goto exit
+			}
+		}
+		line = strings.TrimSpace(line)
+		if len(line) == 0 {
+			// Skip blank lines
+			continue
+		}
+		if line[0] == ';' || line[0] == '#' {
+			// Skip comments
+			continue
+		}
+		if groups := assignRegex.FindStringSubmatch(line); groups != nil {
+			key, val = strings.TrimSpace(groups[1]), strings.TrimSpace(groups[2])
+			if key == "process" {
+				processLabel = strings.Trim(val, "\"")
+			}
+			if key == "file" {
+				fileLabel = strings.Trim(val, "\"")
+			}
+			if key == "ro_file" {
+				roFileLabel = strings.Trim(val, "\"")
+			}
+		}
+	}
+
+	if processLabel == "" || fileLabel == "" {
+		return "", ""
+	}
+
+	if roFileLabel == "" {
+		roFileLabel = fileLabel
+	}
+exit:
+	mcs := uniqMcs(1024)
+	scon := NewContext(processLabel)
+	scon["level"] = mcs
+	processLabel = scon.Get()
+	scon = NewContext(fileLabel)
+	scon["level"] = mcs
+	fileLabel = scon.Get()
+	return processLabel, fileLabel
+}
+
+// SecurityCheckContext validates that the SELinux label is understood by the kernel
+func SecurityCheckContext(val string) error {
+	return writeCon(fmt.Sprintf("%s.context", selinuxPath), val)
+}
+
+/*
+CopyLevel returns a label with the MLS/MCS level from src label replaces on
+the dest label.
+*/
+func CopyLevel(src, dest string) (string, error) {
+	if src == "" {
+		return "", nil
+	}
+	if err := SecurityCheckContext(src); err != nil {
+		return "", err
+	}
+	if err := SecurityCheckContext(dest); err != nil {
+		return "", err
+	}
+	scon := NewContext(src)
+	tcon := NewContext(dest)
+	mcsDelete(tcon["level"])
+	mcsAdd(scon["level"])
+	tcon["level"] = scon["level"]
+	return tcon.Get(), nil
+}
+
+// Prevent users from relabing system files
+func badPrefix(fpath string) error {
+	var badprefixes = []string{"/usr"}
+
+	for _, prefix := range badprefixes {
+		if fpath == prefix || strings.HasPrefix(fpath, fmt.Sprintf("%s/", prefix)) {
+			return fmt.Errorf("relabeling content in %s is not allowed", prefix)
+		}
+	}
+	return nil
+}
+
+// Chcon changes the fpath file object to the SELinux label label.
+// If the fpath is a directory and recurse is true Chcon will walk the
+// directory tree setting the label
+func Chcon(fpath string, label string, recurse bool) error {
+	if label == "" {
+		return nil
+	}
+	if err := badPrefix(fpath); err != nil {
+		return err
+	}
+	callback := func(p string, info os.FileInfo, err error) error {
+		return SetFileLabel(p, label)
+	}
+
+	if recurse {
+		return filepath.Walk(fpath, callback)
+	}
+
+	return SetFileLabel(fpath, label)
+}
+
+// DupSecOpt takes an SELinux process label and returns security options that
+// can will set the SELinux Type and Level for future container processes
+func DupSecOpt(src string) []string {
+	if src == "" {
+		return nil
+	}
+	con := NewContext(src)
+	if con["user"] == "" ||
+		con["role"] == "" ||
+		con["type"] == "" ||
+		con["level"] == "" {
+		return nil
+	}
+	return []string{"user:" + con["user"],
+		"role:" + con["role"],
+		"type:" + con["type"],
+		"level:" + con["level"]}
+}
+
+// DisableSecOpt returns a security opt that can be used to disabling SELinux
+// labeling support for future container processes
+func DisableSecOpt() []string {
+	return []string{"disable"}
+}

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_test.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_test.go
@@ -1,0 +1,81 @@
+// +build linux,selinux
+
+package selinux
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSetFileLabel(t *testing.T) {
+	if GetEnabled() {
+		tmp := "selinux_test"
+		con := "system_u:object_r:bin_t:s0"
+		out, _ := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE, 0)
+		out.Close()
+		err := SetFileLabel(tmp, con)
+		if err != nil {
+			t.Log("Setfilecon failed")
+			t.Fatal(err)
+		}
+		filelabel, err := FileLabel(tmp)
+		if err != nil {
+			t.Log("FileLabel failed")
+			t.Fatal(err)
+		}
+		if con != filelabel {
+			t.Fatal("FileLabel failed, returned %s expected %s", filelabel, con)
+		}
+
+		os.Remove(tmp)
+	}
+}
+
+func TestSELinux(t *testing.T) {
+	var (
+		err            error
+		plabel, flabel string
+	)
+
+	if GetEnabled() {
+		t.Log("Enabled")
+		plabel, flabel = ContainerLabels()
+		t.Log(plabel)
+		t.Log(flabel)
+		ReleaseLabel(plabel)
+		plabel, flabel = ContainerLabels()
+		t.Log(plabel)
+		t.Log(flabel)
+		ReleaseLabel(plabel)
+		t.Log("Enforcing Mode", EnforceMode())
+		mode := DefaultEnforceMode()
+		t.Log("Default Enforce Mode ", mode)
+
+		defer SetEnforceMode(mode)
+		if err := SetEnforceMode(Enforcing); err != nil {
+			t.Fatalf("enforcing selinux failed: %v", err)
+		}
+		if err := SetEnforceMode(Permissive); err != nil {
+			t.Fatalf("setting selinux mode to permissive failed: %v", err)
+		}
+		SetEnforceMode(mode)
+
+		pid := os.Getpid()
+		t.Logf("PID:%d MCS:%s\n", pid, intToMcs(pid, 1023))
+		err = SetFSCreateLabel("unconfined_u:unconfined_r:unconfined_t:s0")
+		if err == nil {
+			t.Log(FSCreateLabel())
+		} else {
+			t.Log("SetFSCreateLabel failed", err)
+			t.Fatal(err)
+		}
+		err = SetFSCreateLabel("")
+		if err == nil {
+			t.Log(FSCreateLabel())
+		} else {
+			t.Log("SetFSCreateLabel failed", err)
+			t.Fatal(err)
+		}
+		t.Log(PidLabel(1))
+	}
+}

--- a/vendor/github.com/opencontainers/selinux/go-selinux/xattrs.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/xattrs.go
@@ -1,0 +1,78 @@
+// +build linux
+
+package selinux
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var _zero uintptr
+
+// Returns a []byte slice if the xattr is set and nil otherwise
+// Requires path and its attribute as arguments
+func lgetxattr(path string, attr string) ([]byte, error) {
+	var sz int
+	pathBytes, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	attrBytes, err := syscall.BytePtrFromString(attr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Start with a 128 length byte array
+	sz = 128
+	dest := make([]byte, sz)
+	destBytes := unsafe.Pointer(&dest[0])
+	_sz, _, errno := syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
+
+	switch {
+	case errno == syscall.ENODATA:
+		return nil, errno
+	case errno == syscall.ENOTSUP:
+		return nil, errno
+	case errno == syscall.ERANGE:
+		// 128 byte array might just not be good enough,
+		// A dummy buffer is used ``uintptr(0)`` to get real size
+		// of the xattrs on disk
+		_sz, _, errno = syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(unsafe.Pointer(nil)), uintptr(0), 0, 0)
+		sz = int(_sz)
+		if sz < 0 {
+			return nil, errno
+		}
+		dest = make([]byte, sz)
+		destBytes := unsafe.Pointer(&dest[0])
+		_sz, _, errno = syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
+		if errno != 0 {
+			return nil, errno
+		}
+	case errno != 0:
+		return nil, errno
+	}
+	sz = int(_sz)
+	return dest[:sz], nil
+}
+
+func lsetxattr(path string, attr string, data []byte, flags int) error {
+	pathBytes, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+	attrBytes, err := syscall.BytePtrFromString(attr)
+	if err != nil {
+		return err
+	}
+	var dataBytes unsafe.Pointer
+	if len(data) > 0 {
+		dataBytes = unsafe.Pointer(&data[0])
+	} else {
+		dataBytes = unsafe.Pointer(&_zero)
+	}
+	_, _, errno := syscall.Syscall6(syscall.SYS_LSETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(dataBytes), uintptr(len(data)), uintptr(flags), 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}


### PR DESCRIPTION
We have moved selinux support out of opencontainers/runc into its
own package.  This patch moves to using the new selinux go bindings.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>