### PR TITLE
Propagate the sandbox DNS mount point to pod containers

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -407,6 +407,11 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	// bind mount the pod shm
 	specgen.AddBindMount(sb.shmPath, "/dev/shm", []string{"rw"})
 
+	if sb.resolvPath != "" {
+		// bind mount the pod resolver file
+		specgen.AddBindMount(sb.resolvPath, "/etc/resolv.conf", []string{"ro"})
+	}
+
 	specgen.AddAnnotation("ocid/name", containerName)
 	specgen.AddAnnotation("ocid/sandbox_id", sb.id)
 	specgen.AddAnnotation("ocid/sandbox_name", sb.infraContainer.Name())

--- a/server/sandbox.go
+++ b/server/sandbox.go
@@ -140,6 +140,7 @@ type sandbox struct {
 	shmPath        string
 	cgroupParent   string
 	privileged     bool
+	resolvPath     string
 }
 
 const (

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -66,7 +66,7 @@ func (s *Server) runContainer(container *oci.Container, cgroupParent string) err
 // RunPodSandbox creates and runs a pod-level sandbox.
 func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest) (resp *pb.RunPodSandboxResponse, err error) {
 	logrus.Debugf("RunPodSandboxRequest %+v", req)
-	var processLabel, mountLabel, netNsPath string
+	var processLabel, mountLabel, netNsPath, resolvPath string
 	// process req.Name
 	name := req.GetConfig().GetMetadata().Name
 	if name == "" {
@@ -160,7 +160,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		dnsServers := req.GetConfig().GetDnsConfig().Servers
 		dnsSearches := req.GetConfig().GetDnsConfig().Searches
 		dnsOptions := req.GetConfig().GetDnsConfig().Options
-		resolvPath := fmt.Sprintf("%s/resolv.conf", podContainer.RunDir)
+		resolvPath = fmt.Sprintf("%s/resolv.conf", podContainer.RunDir)
 		err = parseDNSOptions(dnsServers, dnsSearches, dnsOptions, resolvPath)
 		if err != nil {
 			err1 := removeFile(resolvPath)
@@ -258,6 +258,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	g.AddAnnotation("ocid/container_id", id)
 	g.AddAnnotation("ocid/shm_path", shmPath)
 	g.AddAnnotation("ocid/privileged_runtime", fmt.Sprintf("%v", privileged))
+	g.AddAnnotation("ocid/resolv_path", resolvPath)
 
 	sb := &sandbox{
 		id:           id,
@@ -271,6 +272,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		metadata:     metadata,
 		shmPath:      shmPath,
 		privileged:   privileged,
+		resolvPath:   resolvPath,
 	}
 
 	s.addSandbox(sb)

--- a/server/server.go
+++ b/server/server.go
@@ -187,6 +187,7 @@ func (s *Server) loadSandbox(id string) error {
 		metadata:     &metadata,
 		shmPath:      m.Annotations["ocid/shm_path"],
 		privileged:   privileged,
+		resolvPath:   m.Annotations["ocid/resolv_path"],
 	}
 
 	// We add a netNS only if we can load a permanent one.


### PR DESCRIPTION
When pod sandboxes come with DNS settings, we build and bind mount a `resolv.conf` file into the pod sandbox rootfs.
In order for pod internal DNS to work, we have to propagate that mount point to all pod containers.

Fixes #402 