### PR TITLE
Preserve the tag of the pulled image's name

### DIFF
--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"github.com/containers/image/copy"
+	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/signature"
 	istorage "github.com/containers/image/storage"
 	"github.com/containers/image/transports/alltransports"
@@ -132,6 +133,9 @@ func (svc *imageService) PullImage(systemContext *types.SystemContext, imageName
 	dest := imageName
 	if srcRef.DockerReference() != nil {
 		dest = srcRef.DockerReference().Name()
+		if tagged, ok := srcRef.DockerReference().(reference.NamedTagged); ok {
+			dest = dest + ":" + tagged.Tag()
+		}
 	}
 	destRef, err := istorage.Transport.ParseStoreReference(svc.store, dest)
 	if err != nil {


### PR DESCRIPTION
When we pull an image, preserve the tag portion of the name that we were asked to use for pulling it, instead of unconditionally replacing it with "latest".  This aims to fix #403.