### PR TITLE
Update the default conmonPath

### DIFF
--- a/docs/ocid.8.md
+++ b/docs/ocid.8.md
@@ -54,7 +54,7 @@ ocid is meant to provide an integration path between OCI conformant runtimes and
   path to configuration file
 
 **--conmon**=""
-  path to the conmon executable (default: "/usr/libexec/ocid/conmon")
+  path to the conmon executable (default: "/usr/local/libexec/ocid/conmon")
 
 **--debug**
   Enable debug output for logging

--- a/docs/ocid.conf.5.md
+++ b/docs/ocid.conf.5.md
@@ -49,7 +49,7 @@ The `ocid` table supports the following options:
 ## OCID.RUNTIME TABLE
 
 **conmon**=""
-  Path to the conmon executable (default: "/usr/libexec/ocid/conmon")
+  Path to the conmon executable (default: "/usr/local/libexec/ocid/conmon")
 
 **conmon_env**=[]
   Environment variable list for conmon process (default: ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",])

--- a/kubernetes.md
+++ b/kubernetes.md
@@ -15,15 +15,15 @@ Below, you can find an instruction how to switch one or more nodes on running ku
 
 You must prepare and install `ocid` on each node you would like to switch. Here's the list of files that must be provided:
 
-| File path                            | Description                | Location                                            |
-|--------------------------------------|----------------------------|-----------------------------------------------------|
-| `/etc/ocid/ocid.conf`                | ocid configuration         | Generated on cri-o `make install`                   |
-| `/etc/ocid/seccomp.conf`             | seccomp config             | Example stored in cri-o repository                  |
-| `/etc/containers/policy.json`        | containers policy          | Example stored in cri-o repository                  |
-| `/bin/{ocid, runc}`                  | `ocid` and `runc` binaries | Built from cri-o repository                         |
-| `/usr/libexec/ocid/conmon`           | `conmon` binary            | Built from cri-o repository                         |
-| `/opt/cni/bin/{flannel, bridge,...}` | CNI plugins binaries       | Can be built from sources `containernetworking/cni` |
-| `/etc/cni/net.d/10-mynet.conf`       | Network config             | Example stored in [README file](README.md)          |
+| File path                                  | Description                | Location                                            |
+|--------------------------------------------|----------------------------|-----------------------------------------------------|
+| `/etc/ocid/ocid.conf`                      | ocid configuration         | Generated on cri-o `make install`                   |
+| `/etc/ocid/seccomp.conf`                   | seccomp config             | Example stored in cri-o repository                  |
+| `/etc/containers/policy.json`              | containers policy          | Example stored in cri-o repository                  |
+| `/bin/{ocid, runc}`                        | `ocid` and `runc` binaries | Built from cri-o repository                         |
+| `/usr/local/libexec/ocid/conmon`           | `conmon` binary            | Built from cri-o repository                         |
+| `/opt/cni/bin/{flannel, bridge,...}`       | CNI plugins binaries       | Can be built from sources `containernetworking/cni` |
+| `/etc/cni/net.d/10-mynet.conf`             | Network config             | Example stored in [README file](README.md)          |
 
 `ocid` binary can be executed directly on host, inside the container or in any way.
 However, recommended way is to set it as a systemd service.

--- a/server/config.go
+++ b/server/config.go
@@ -12,7 +12,7 @@ import (
 const (
 	ocidRoot            = "/var/lib/containers/storage"
 	ocidRunRoot         = "/var/run/containers/storage"
-	conmonPath          = "/usr/libexec/ocid/conmon"
+	conmonPath          = "/usr/local/libexec/ocid/conmon"
 	pauseImage          = "kubernetes/pause"
 	pauseCommand        = "/pause"
 	defaultTransport    = "docker://"

--- a/tutorial.md
+++ b/tutorial.md
@@ -132,7 +132,7 @@ Output:
 install -D -m 755 kpod /usr/bin/kpod
 install -D -m 755 ocid /usr/bin/ocid
 install -D -m 755 ocic /usr/bin/ocic
-install -D -m 755 conmon/conmon /usr/libexec/ocid/conmon
+install -D -m 755 conmon/conmon /usr/local/libexec/ocid/conmon
 install -D -m 755 pause/pause /usr/libexec/ocid/pause
 install -d -m 755 /usr/share/man/man{1,5,8}
 install -m 644 docs/kpod.1 docs/kpod-launch.1 -t /usr/share/man/man1


### PR DESCRIPTION
After change in `Makefile` at #304 where `PREFIX` has changed from `/usr` to `/usr/local` these changes has to be reflected in default `conmonPath`.