### PR TITLE
network: hook net plugin Status() up to NetworkReady and runtime status

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -454,16 +454,18 @@ func New(config *Config) (*Server, error) {
 		return nil, err
 	}
 
-	r, err := oci.New(config.Runtime, config.RuntimeHostPrivileged, config.Conmon, config.ConmonEnv, config.CgroupManager)
-	if err != nil {
-		return nil, err
-	}
 	sandboxes := make(map[string]*sandbox)
 	containers := oci.NewMemoryStore()
 	netPlugin, err := ocicni.InitCNI(config.NetworkDir, config.PluginDir)
 	if err != nil {
 		return nil, err
 	}
+
+	r, err := oci.New(config.Runtime, config.RuntimeHostPrivileged, config.Conmon, config.ConmonEnv, config.CgroupManager, netPlugin)
+	if err != nil {
+		return nil, err
+	}
+
 	s := &Server{
 		runtime:   r,
 		store:     store,


### PR DESCRIPTION
Port https://github.com/kubernetes/kubernetes/pull/43474 over to CRI-O
and hook network plugin status up to the runtime NetworkReady() call so
the plugin's status is accurately reported back to the orchestrator.

@rajatchopra gotta be a bit careful about this one RE https://github.com/kubernetes/kubernetes/issues/43815 since I'm not sure kubelet correctly differentiates between runtime readiness reasons.

And in fact it does fail:

  11s		4s		5	default-scheduler			Warning		FailedScheduling	no nodes available to schedule pods

So it seems CRI-O and kubelet remote runtimes need finer grained scheduling decisions.  Which is pretty odd, since I've even tried with `hostNetwork:true` and usually the scheduler allows that with local runtimes...