### PR TITLE
Add labels/annotations to container status

### DIFF
--- a/server/container_status.go
+++ b/server/container_status.go
@@ -24,9 +24,11 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 	image := c.Image()
 	resp := &pb.ContainerStatusResponse{
 		Status: &pb.ContainerStatus{
-			Id:       containerID,
-			Metadata: c.Metadata(),
-			Image:    image,
+			Id:          containerID,
+			Metadata:    c.Metadata(),
+			Labels:      c.Labels(),
+			Annotations: c.Annotations(),
+			Image:       image,
 		},
 	}
 


### PR DESCRIPTION
Found this one while testing kubectl logs with #162 

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>