### PR TITLE
Change path of CNI build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,11 +56,13 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install CNI plugins
+ENV CNI_COMMIT d4bbce1865270cd2d2be558d6a23e63d314fe769
 RUN set -x \
        && export GOPATH="$(mktemp -d)" \
        && git clone https://github.com/containernetworking/cni.git "$GOPATH/src/github.com/containernetworking/cni" \
        && cd "$GOPATH/src/github.com/containernetworking/cni" \
-       && ./build \
+       && git checkout -q "$CNI_COMMIT" \
+       && ./build.sh \
        && mkdir -p /opt/cni/bin \
        && cp bin/* /opt/cni/bin/ \
        && rm -rf "$GOPATH"

--- a/tutorial.md
+++ b/tutorial.md
@@ -207,7 +207,7 @@ cd $GOPATH/src/github.com/containernetworking/cni
 Build the `cni` binaries:
 
 ```
-./build
+./build.sh
 ```
 
 Output:


### PR DESCRIPTION
As of containernetworking/cni commit 1b9caefba5670c59e0ccbf0b008d88da52a7d498,
the script to build has changed from `build` to `build.sh` which broke our
integration tests. Update path to fix them.
