### PR TITLE
server: mock ExecResponse

### DIFF
--- a/server/container_exec.go
+++ b/server/container_exec.go
@@ -7,5 +7,5 @@ import (
 
 // Exec prepares a streaming endpoint to execute a command in the container.
 func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (*pb.ExecResponse, error) {
-	return nil, nil
+	return &pb.ExecResponse{}, nil
 }


### PR DESCRIPTION
This patch prevents k8s's e2e_node tests from killing CRI-O (because of
a panic in marshaling nil responses). This will ensure tests keep
running and just logging the failure.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>