### PR TITLE
server: Fix RunPodSandbox error path

### DIFF
--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -282,18 +282,19 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		hostname:     hostname,
 	}
 
-	s.addSandbox(sb)
-	if err = s.podIDIndex.Add(id); err != nil {
-		return nil, err
-	}
-
 	defer func() {
 		if err != nil {
+			s.removeSandbox(id)
 			if err2 := s.podIDIndex.Delete(id); err2 != nil {
 				logrus.Warnf("couldn't delete pod id %s from idIndex", id)
 			}
 		}
 	}()
+
+	s.addSandbox(sb)
+	if err = s.podIDIndex.Add(id); err != nil {
+		return nil, err
+	}
 
 	for k, v := range annotations {
 		g.AddAnnotation(k, v)


### PR DESCRIPTION
When RunPodSandbox fails after calling s.addSandbox(sb),
we're left with a sandbox in s.state.sandboxes although the
sandbox is not created.

We fix that by adding removeSandbox() to the deferred cleanup
call

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>