### PR TITLE
conmon: handle multi-line logging

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -380,15 +380,6 @@ func (r *Runtime) ExecSync(c *Container, command []string, timeout int64) (resp 
 
 	logrus.Infof("Received container exit code: %v", ec.ExitCode)
 
-	if ec.ExitCode != 0 {
-		return nil, ExecSyncError{
-			Stdout:   stdoutBuf,
-			Stderr:   stderrBuf,
-			ExitCode: ec.ExitCode,
-			Err:      fmt.Errorf("container workload exited with error %v", ec.ExitCode),
-		}
-	}
-
 	// The actual logged output is not the same as stdoutBuf and stderrBuf,
 	// which are used for getting error information. For the actual
 	// ExecSyncResponse we have to read the logfile.
@@ -408,7 +399,7 @@ func (r *Runtime) ExecSync(c *Container, command []string, timeout int64) (resp 
 	return &ExecSyncResponse{
 		Stdout:   outputBytes,
 		Stderr:   nil,
-		ExitCode: 0,
+		ExitCode: ec.ExitCode,
 	}, nil
 }
 

--- a/test/seccomp.bats
+++ b/test/seccomp.bats
@@ -71,7 +71,8 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	run ocic ctr execsync --id "$ctr_id" chmod 777 .
 	echo "$output"
-	[ "$status" -ne 0 ]
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "Exit code: 1" ]]
 	[[ "$output" =~ "Operation not permitted" ]]
 
 	cleanup_ctrs
@@ -158,7 +159,8 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	run ocic ctr execsync --id "$ctr_id" chmod 777 .
 	echo "$output"
-	[ "$status" -ne 0 ]
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "Exit code: 1" ]]
 	[[ "$output" =~ "Operation not permitted" ]]
 
 	cleanup_ctrs
@@ -269,7 +271,8 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	run ocic ctr execsync --id "$ctr_id" chmod 777 .
 	echo "$output"
-	[ "$status" -ne 0 ]
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "Exit code: 1" ]]
 	[[ "$output" =~ "Operation not permitted" ]]
 
 	cleanup_ctrs


### PR DESCRIPTION
The CRI requires us to prepend (timestamp, stream) to every line of the
output, and it's quite likely (especially in the !terminal case) that we
will read more than one line of output in the read loop.

So, we need to write out each line separately with the prepended
timestamps. Doing this the simple way (the final part of the buffer is
written partially if it doesn't end in a newline) makes the code much
simpler, with the downside that if we ever switch to multiple streams
for output we'll have to rewrite parts of this.

Alternative to #430.

Fixes: 1dc4c87c93cd ("conmon: add timestamps to logs")
Signed-off-by: Aleksa Sarai <asarai@suse.de>