### PR TITLE
oci: more grep'able interface name

### DIFF
--- a/oci/container.go
+++ b/oci/container.go
@@ -1,0 +1,116 @@
+package oci
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/containernetworking/cni/pkg/ns"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"k8s.io/apimachinery/pkg/fields"
+	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+)
+
+// Container represents a runtime container.
+type Container struct {
+	id          string
+	name        string
+	bundlePath  string
+	logPath     string
+	labels      fields.Set
+	annotations fields.Set
+	image       *pb.ImageSpec
+	sandbox     string
+	netns       ns.NetNS
+	terminal    bool
+	privileged  bool
+	state       *ContainerState
+	metadata    *pb.ContainerMetadata
+	opLock      sync.Mutex
+}
+
+// ContainerState represents the status of a container.
+type ContainerState struct {
+	specs.State
+	Created  time.Time `json:"created"`
+	Started  time.Time `json:"started"`
+	Finished time.Time `json:"finished"`
+	ExitCode int32     `json:"exitCode"`
+}
+
+// NewContainer creates a container object.
+func NewContainer(id string, name string, bundlePath string, logPath string, netns ns.NetNS, labels map[string]string, annotations map[string]string, image *pb.ImageSpec, metadata *pb.ContainerMetadata, sandbox string, terminal bool, privileged bool) (*Container, error) {
+	c := &Container{
+		id:          id,
+		name:        name,
+		bundlePath:  bundlePath,
+		logPath:     logPath,
+		labels:      labels,
+		sandbox:     sandbox,
+		netns:       netns,
+		terminal:    terminal,
+		privileged:  privileged,
+		metadata:    metadata,
+		annotations: annotations,
+		image:       image,
+	}
+	return c, nil
+}
+
+// Name returns the name of the container.
+func (c *Container) Name() string {
+	return c.name
+}
+
+// ID returns the id of the container.
+func (c *Container) ID() string {
+	return c.id
+}
+
+// BundlePath returns the bundlePath of the container.
+func (c *Container) BundlePath() string {
+	return c.bundlePath
+}
+
+// LogPath returns the log path of the container.
+func (c *Container) LogPath() string {
+	return c.logPath
+}
+
+// Labels returns the labels of the container.
+func (c *Container) Labels() map[string]string {
+	return c.labels
+}
+
+// Annotations returns the annotations of the container.
+func (c *Container) Annotations() map[string]string {
+	return c.annotations
+}
+
+// Image returns the image of the container.
+func (c *Container) Image() *pb.ImageSpec {
+	return c.image
+}
+
+// Sandbox returns the sandbox name of the container.
+func (c *Container) Sandbox() string {
+	return c.sandbox
+}
+
+// NetNsPath returns the path to the network namespace of the container.
+func (c *Container) NetNsPath() (string, error) {
+	if c.state == nil {
+		return "", fmt.Errorf("container state is not populated")
+	}
+
+	if c.netns == nil {
+		return fmt.Sprintf("/proc/%d/ns/net", c.state.Pid), nil
+	}
+
+	return c.netns.Path(), nil
+}
+
+// Metadata returns the metadata of the container.
+func (c *Container) Metadata() *pb.ContainerMetadata {
+	return c.metadata
+}

--- a/oci/memory_store.go
+++ b/oci/memory_store.go
@@ -9,7 +9,7 @@ type memoryStore struct {
 }
 
 // NewMemoryStore initializes a new memory store.
-func NewMemoryStore() Store {
+func NewMemoryStore() ContainerStorer {
 	return &memoryStore{
 		s: make(map[string]*Container),
 	}
@@ -89,4 +89,4 @@ func (c *memoryStore) all() []*Container {
 	return containers
 }
 
-var _ Store = &memoryStore{}
+var _ ContainerStorer = &memoryStore{}

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -10,18 +10,12 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
-	specs "github.com/opencontainers/runtime-spec/specs-go"
-
 	"github.com/Sirupsen/logrus"
-	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/kubernetes-incubator/cri-o/utils"
 	"golang.org/x/sys/unix"
-	"k8s.io/apimachinery/pkg/fields"
-	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
 
 const (
@@ -518,110 +512,6 @@ func (r *Runtime) ContainerStatus(c *Container) *ContainerState {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 	return c.state
-}
-
-// Container respresents a runtime container.
-type Container struct {
-	id          string
-	name        string
-	bundlePath  string
-	logPath     string
-	labels      fields.Set
-	annotations fields.Set
-	image       *pb.ImageSpec
-	sandbox     string
-	netns       ns.NetNS
-	terminal    bool
-	privileged  bool
-	state       *ContainerState
-	metadata    *pb.ContainerMetadata
-	opLock      sync.Mutex
-}
-
-// ContainerState represents the status of a container.
-type ContainerState struct {
-	specs.State
-	Created  time.Time `json:"created"`
-	Started  time.Time `json:"started"`
-	Finished time.Time `json:"finished"`
-	ExitCode int32     `json:"exitCode"`
-}
-
-// NewContainer creates a container object.
-func NewContainer(id string, name string, bundlePath string, logPath string, netns ns.NetNS, labels map[string]string, annotations map[string]string, image *pb.ImageSpec, metadata *pb.ContainerMetadata, sandbox string, terminal bool, privileged bool) (*Container, error) {
-	c := &Container{
-		id:          id,
-		name:        name,
-		bundlePath:  bundlePath,
-		logPath:     logPath,
-		labels:      labels,
-		sandbox:     sandbox,
-		netns:       netns,
-		terminal:    terminal,
-		privileged:  privileged,
-		metadata:    metadata,
-		annotations: annotations,
-		image:       image,
-	}
-	return c, nil
-}
-
-// Name returns the name of the container.
-func (c *Container) Name() string {
-	return c.name
-}
-
-// ID returns the id of the container.
-func (c *Container) ID() string {
-	return c.id
-}
-
-// BundlePath returns the bundlePath of the container.
-func (c *Container) BundlePath() string {
-	return c.bundlePath
-}
-
-// LogPath returns the log path of the container.
-func (c *Container) LogPath() string {
-	return c.logPath
-}
-
-// Labels returns the labels of the container.
-func (c *Container) Labels() map[string]string {
-	return c.labels
-}
-
-// Annotations returns the annotations of the container.
-func (c *Container) Annotations() map[string]string {
-	return c.annotations
-}
-
-// Image returns the image of the container.
-func (c *Container) Image() *pb.ImageSpec {
-	return c.image
-}
-
-// Sandbox returns the sandbox name of the container.
-func (c *Container) Sandbox() string {
-	return c.sandbox
-}
-
-// NetNsPath returns the path to the network namespace of the container.
-func (c *Container) NetNsPath() (string, error) {
-	if c.state == nil {
-		return "", fmt.Errorf("container state is not populated")
-	}
-
-	if c.netns == nil {
-		return fmt.Sprintf("/proc/%d/ns/net", c.state.Pid), nil
-	}
-
-	return c.netns.Path(), nil
-}
-
-// Metadata returns the metadata of the container.
-func (c *Container) Metadata() *pb.ContainerMetadata {
-	return c.metadata
 }
 
 // newPipe creates a unix socket pair for communication

--- a/oci/store.go
+++ b/oci/store.go
@@ -8,9 +8,8 @@ type StoreFilter func(*Container) bool
 // manipulate containers in the store
 type StoreReducer func(*Container)
 
-// Store defines an interface that
-// any container store must implement.
-type Store interface {
+// ContainerStorer defines an interface that any container store must implement.
+type ContainerStorer interface {
 	// Add appends a new container to the store.
 	Add(string, *Container)
 	// Get returns a container from the store by the identifier it was stored with.

--- a/server/sandbox.go
+++ b/server/sandbox.go
@@ -131,7 +131,7 @@ type sandbox struct {
 	labels         fields.Set
 	annotations    map[string]string
 	infraContainer *oci.Container
-	containers     oci.Store
+	containers     oci.ContainerStorer
 	processLabel   string
 	mountLabel     string
 	netns          *sandboxNetNs

--- a/server/server.go
+++ b/server/server.go
@@ -519,7 +519,7 @@ func New(config *Config) (*Server, error) {
 
 type serverState struct {
 	sandboxes  map[string]*sandbox
-	containers oci.Store
+	containers oci.ContainerStorer
 }
 
 func (s *Server) addSandbox(sb *sandbox) {


### PR DESCRIPTION
`git grep -wi store` is not nearly useful enough. Taking steps for
readability.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>