### PR TITLE
test: fix bats dealing with std* streams

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -292,9 +292,10 @@ function check_pod_cidr() {
         fullnetns=`ocic pod status --id $1 | grep namespace | cut -d ' ' -f 3`
 	netns=`basename $fullnetns`
 
-	ip netns exec $netns ip addr show dev eth0 scope global | grep $POD_CIDR_MASK
-
-	echo $?
+	run ip netns exec $netns ip addr show dev eth0 scope global 2>&1
+	echo "$output"
+	[ "$status" -eq 0  ]
+	[[ "$output" =~ $POD_CIDR_MASK  ]]
 }
 
 function parse_pod_ip() {


### PR DESCRIPTION
@sameo @mrunalp fix tests on RHEL where `ip` prints garbage on stderr

Signed-off-by: Antonio Murdaca <runcom@redhat.com>