### PR TITLE
conmon: Fix logic for enabling systemd cgroups

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -358,7 +358,7 @@ int main(int argc, char *argv[])
 	cmd = g_string_new(runtime_path);
 
 	/* Generate the cmdline. */
-	if (exec && systemd_cgroup)
+	if (!exec && systemd_cgroup)
 		g_string_append_printf(cmd, " --systemd-cgroup");
 
 	if (exec)


### PR DESCRIPTION
We reversed the logic inadvertently while getting in the logging changes.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>