### PR TITLE
Change default runc location

### DIFF
--- a/docs/ocid.8.md
+++ b/docs/ocid.8.md
@@ -87,7 +87,7 @@ ocid is meant to provide an integration path between OCI conformant runtimes and
   OCID state dir (default: "/var/run/containers/storage")
 
 **--runtime**=""
-  OCI runtime path (default: "/usr/bin/runc")
+  OCI runtime path (default: "/usr/local/sbin/runc")
 
 **--selinux**=*true*|*false*
   Enable selinux support (default: false)

--- a/docs/ocid.conf.5.md
+++ b/docs/ocid.conf.5.md
@@ -55,7 +55,7 @@ The `ocid` table supports the following options:
   Environment variable list for conmon process (default: ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",])
 
 **runtime**=""
-  OCI runtime path (default: "/usr/bin/runc")
+  OCI runtime path (default: "/usr/local/sbin/runc")
 
 **selinux**=*true*|*false*
   Enable selinux support (default: false)

--- a/server/config.go
+++ b/server/config.go
@@ -207,7 +207,7 @@ func DefaultConfig() *Config {
 			Listen: "/var/run/ocid.sock",
 		},
 		RuntimeConfig: RuntimeConfig{
-			Runtime:               "/usr/bin/runc",
+			Runtime:               "/usr/local/sbin/runc",
 			RuntimeHostPrivileged: "",
 			Conmon:                conmonPath,
 			ConmonEnv: []string{

--- a/tutorial.md
+++ b/tutorial.md
@@ -46,7 +46,7 @@ chmod +x runc-linux-amd64
 ```
 
 ```
-sudo mv runc-linux-amd64 /usr/bin/runc
+sudo mv runc-linux-amd64 /usr/local/sbin/runc
 ```
 
 Print the `runc` version:


### PR DESCRIPTION
With the current supported version of runc(1.0.0-rc3) in cri-o the default installation location is `/usr/local/sbin/runc` as opposed to `/usr/bin/runc` so changing that everywhere.