### PR TITLE
Add flag --cpu-profile to enable pprof

### DIFF
--- a/docs/ocid.8.md
+++ b/docs/ocid.8.md
@@ -110,6 +110,9 @@ ocid is meant to provide an integration path between OCI conformant runtimes and
 **--cni-plugin-dir**=""
   CNI plugin binaries directory (default: "/opt/cni/bin/")
 
+**--cpu-profile**
+  Set the CPU profile file path
+
 **--version, -v**
   Print the version
 


### PR DESCRIPTION
To collect CPU profile information added a flag `--cpu-profile` which is a path to file where this collected information will be dumped.

~~This flag is valid only in debug mode or when `--debug` flag is applied.~~

Fixes #464