### PR TITLE
sandbox: pass correct pod Namespace/Name to network plugins and fix id/name ordering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,8 @@ RUN set -x \
        && cp bin/* /opt/cni/bin/ \
        && rm -rf "$GOPATH"
 
+COPY test/plugin_test_args.bash /opt/cni/bin/plugin_test_args.bash
+
 # Make sure we have some policy for pulling images
 RUN mkdir -p /etc/containers
 COPY test/policy.json /etc/containers/policy.json

--- a/server/sandbox_status.go
+++ b/server/sandbox_status.go
@@ -27,8 +27,7 @@ func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusR
 	if err != nil {
 		return nil, err
 	}
-	podNamespace := ""
-	ip, err := s.netPlugin.GetContainerNetworkStatus(netNsPath, podNamespace, sb.id, podInfraContainer.Name())
+	ip, err := s.netPlugin.GetContainerNetworkStatus(netNsPath, sb.namespace, sb.kubeName, sb.id)
 	if err != nil {
 		// ignore the error on network status
 		ip = ""

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -19,20 +19,19 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 		return nil, err
 	}
 
-	podNamespace := ""
 	podInfraContainer := sb.infraContainer
 	netnsPath, err := podInfraContainer.NetNsPath()
 	if err != nil {
 		return nil, err
 	}
 	if _, err := os.Stat(netnsPath); err == nil {
-		if err2 := s.netPlugin.TearDownPod(netnsPath, podNamespace, sb.id, podInfraContainer.Name()); err2 != nil {
+		if err2 := s.netPlugin.TearDownPod(netnsPath, sb.namespace, sb.kubeName, sb.id); err2 != nil {
 			return nil, fmt.Errorf("failed to destroy network for container %s in sandbox %s: %v",
 				podInfraContainer.Name(), sb.id, err2)
 		}
 	} else if !os.IsNotExist(err) { // it's ok for netnsPath to *not* exist
 		return nil, fmt.Errorf("failed to stat netns path for container %s in sandbox %s before tearing down the network: %v",
-			podInfraContainer.Name(), sb.id, err)
+			sb.name, sb.id, err)
 	}
 
 	// Close the sandbox networking namespace.

--- a/test/network.bats
+++ b/test/network.bats
@@ -51,3 +51,19 @@ load helpers
 	cleanup_pods
 	stop_ocid
 }
+
+@test "Ensure correct CNI plugin namespace/name/container-id arguments" {
+	start_ocid "" "" "" "prepare_plugin_test_args_network_conf"
+	run ocic pod run --config "$TESTDATA"/sandbox_config.json
+	[ "$status" -eq 0 ]
+
+	. /tmp/plugin_test_args.out
+
+	[ "$FOUND_CNI_CONTAINERID" != "redhat.test.ocid" ]
+	[ "$FOUND_CNI_CONTAINERID" != "podsandbox1" ]
+	[ "$FOUND_K8S_POD_NAMESPACE" = "redhat.test.ocid" ]
+	[ "$FOUND_K8S_POD_NAME" = "podsandbox1" ]
+
+	cleanup_pods
+	stop_ocid
+}

--- a/test/plugin_test_args.bash
+++ b/test/plugin_test_args.bash
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+if [[ -z "${CNI_ARGS}" ]]; then
+	exit 1
+fi
+
+IFS=';' read -ra array <<< "${CNI_ARGS}"
+for arg in "${array[@]}"; do
+	IFS='=' read -ra item <<< "${arg}"
+	if [[ "${item[0]}" = "K8S_POD_NAMESPACE" ]]; then
+		K8S_POD_NAMESPACE="${item[1]}"
+	elif [[ "${item[0]}" = "K8S_POD_NAME" ]]; then
+		K8S_POD_NAME="${item[1]}"
+	fi
+done
+
+if [[ -z "${CNI_CONTAINERID}" ]]; then
+	exit 1
+elif [[ -z "${K8S_POD_NAMESPACE}" ]]; then
+	exit 1
+elif [[ -z "${K8S_POD_NAME}" ]]; then
+	exit 1
+fi
+
+echo "FOUND_CNI_CONTAINERID=${CNI_CONTAINERID}" >> /tmp/plugin_test_args.out
+echo "FOUND_K8S_POD_NAMESPACE=${K8S_POD_NAMESPACE}" >> /tmp/plugin_test_args.out
+echo "FOUND_K8S_POD_NAME=${K8S_POD_NAME}" >> /tmp/plugin_test_args.out
+
+cat <<-EOF
+{
+  "cniVersion": "0.2.0",
+  "ip4": {
+    "ip": "1.1.1.1/24"
+  }
+}
+EOF
+


### PR DESCRIPTION
Two issues:
1) pod Namespace was always set to "", which prevents plugins from figuring out
what the actual pod is, and from getting more info about that pod from the
runtime via out-of-band mechanisms

2) the pod Name and ID arguments were switched, further preventing #1

@runcom @mrunalp 