### PR TITLE
server: fix set caps on container create

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -400,11 +400,17 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		}
 
 		capabilities := linux.GetSecurityContext().GetCapabilities()
+		toCAPPrefixed := func(cap string) string {
+			if !strings.HasPrefix(strings.ToLower(cap), "cap_") {
+				return "CAP_" + cap
+			}
+			return cap
+		}
 		if capabilities != nil {
 			addCaps := capabilities.AddCapabilities
 			if addCaps != nil {
 				for _, cap := range addCaps {
-					if err := specgen.AddProcessCapability(cap); err != nil {
+					if err := specgen.AddProcessCapability(toCAPPrefixed(cap)); err != nil {
 						return nil, err
 					}
 				}
@@ -413,7 +419,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 			dropCaps := capabilities.DropCapabilities
 			if dropCaps != nil {
 				for _, cap := range dropCaps {
-					if err := specgen.DropProcessCapability(cap); err != nil {
+					if err := specgen.DropProcessCapability(toCAPPrefixed(cap)); err != nil {
 						return nil, err
 					}
 				}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -68,7 +68,7 @@ PATH=$PATH:$TESTDIR
 # Make sure we have a copy of the redis:latest image.
 if ! [ -d "$ARTIFACTS_PATH"/redis-image ]; then
     mkdir -p "$ARTIFACTS_PATH"/redis-image
-    if ! "$COPYIMG_BINARY" --import-from=docker://redis --export-to=dir:"$ARTIFACTS_PATH"/redis-image --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
+    if ! "$COPYIMG_BINARY" --import-from=docker://redis:alpine --export-to=dir:"$ARTIFACTS_PATH"/redis-image --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
         echo "Error pulling docker://redis"
         rm -fr "$ARTIFACTS_PATH"/redis-image
         exit 1
@@ -145,7 +145,7 @@ function start_ocid() {
 	if ! [ "$3" = "--no-pause-image" ] ; then
 		"$BIN2IMG_BINARY" --root "$TESTDIR/ocid" $STORAGE_OPTS --runroot "$TESTDIR/ocid-run" --source-binary "$PAUSE_BINARY"
 	fi
-	"$COPYIMG_BINARY" --root "$TESTDIR/ocid" $STORAGE_OPTS --runroot "$TESTDIR/ocid-run" --image-name=redis --import-from=dir:"$ARTIFACTS_PATH"/redis-image --add-name=docker://docker.io/library/redis:latest --signature-policy="$INTEGRATION_ROOT"/policy.json
+	"$COPYIMG_BINARY" --root "$TESTDIR/ocid" $STORAGE_OPTS --runroot "$TESTDIR/ocid-run" --image-name=redis:alpine --import-from=dir:"$ARTIFACTS_PATH"/redis-image --add-name=docker://docker.io/library/redis:alpine --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$OCID_BINARY" --conmon "$CONMON_BINARY" --listen "$OCID_SOCKET" --runtime "$RUNTIME_BINARY" --root "$TESTDIR/ocid" --runroot "$TESTDIR/ocid-run" $STORAGE_OPTS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$OCID_CNI_CONFIG" --signature-policy "$INTEGRATION_ROOT"/policy.json --config /dev/null config >$OCID_CONFIG
 
 	# Prepare the CNI configuration files, we're running with non host networking by default
@@ -154,11 +154,11 @@ function start_ocid() {
 	"$OCID_BINARY" --debug --config "$OCID_CONFIG" & OCID_PID=$!
 	wait_until_reachable
 
-	run ocic image status --id=redis
+	run ocic image status --id=redis:alpine
 	if [ "$status" -ne 0 ] ; then
-		ocic image pull redis:latest
+		ocic image pull redis:alpine
 	fi
-	REDIS_IMAGEID=$(ocic image status --id=redis | head -1 | sed -e "s/ID: //g")
+	REDIS_IMAGEID=$(ocic image status --id=redis:alpine | head -1 | sed -e "s/ID: //g")
 	run ocic image status --id=busybox
 	if [ "$status" -ne 0 ] ; then
 		ocic image pull busybox:latest

--- a/test/testdata/container_config.json
+++ b/test/testdata/container_config.json
@@ -4,7 +4,7 @@
 		"attempt": 1
 	},
 	"image": {
-		"image": "docker://redis:latest"
+		"image": "redis:alpine"
 	},
 	"command": [
 		"/bin/ls"

--- a/test/testdata/container_config.json
+++ b/test/testdata/container_config.json
@@ -51,30 +51,22 @@
 			"memory_limit_in_bytes": 88000000,
 			"oom_score_adj": 30
 		},
-		"capabilities": {
-			"add_capabilities": [
-				"setuid",
-				"setgid"
-			],
-			"drop_capabilities": [
-				"audit_write",
-				"audit_read"
-			]
-		},
-		"selinux_options": {
-			"user": "system_u",
-			"role": "system_r",
-			"type": "container_t",
-			"level": "s0:c4,c5"
-		},
-		"user": {
-			"uid": 5,
-			"gid": 300,
-			"additional_gids": [
-				400,
-				401,
-				402
-			]
+		"security_context": {
+			"capabilities": {
+				"add_capabilities": [
+					"setuid",
+					"setgid"
+				],
+				"drop_capabilities": [
+					"audit_read"
+				]
+			},
+			"selinux_options": {
+				"user": "system_u",
+				"role": "system_r",
+				"type": "container_t",
+				"level": "s0:c4,c5"
+			}
 		}
 	}
 }

--- a/test/testdata/container_config_by_imageid.json
+++ b/test/testdata/container_config_by_imageid.json
@@ -7,11 +7,9 @@
 		"image": "%VALUE%"
 	},
 	"command": [
-		"/bin/bash"
-	],
-	"args": [
 		"/bin/ls"
 	],
+	"args": [],
 	"working_dir": "/",
 	"envs": [
 		{

--- a/test/testdata/container_config_by_imageid.json
+++ b/test/testdata/container_config_by_imageid.json
@@ -51,30 +51,22 @@
 			"memory_limit_in_bytes": 88000000,
 			"oom_score_adj": 30
 		},
-		"capabilities": {
-			"add_capabilities": [
-				"setuid",
-				"setgid"
-			],
-			"drop_capabilities": [
-				"audit_write",
-				"audit_read"
-			]
-		},
-		"selinux_options": {
-			"user": "system_u",
-			"role": "system_r",
-			"type": "container_t",
-			"level": "s0:c4,c5"
-		},
-		"user": {
-			"uid": 5,
-			"gid": 300,
-			"additional_gids": [
-				400,
-				401,
-				402
-			]
+		"security_context": {
+			"capabilities": {
+				"add_capabilities": [
+					"setuid",
+					"setgid"
+				],
+				"drop_capabilities": [
+					"audit_read"
+				]
+			},
+			"selinux_options": {
+				"user": "system_u",
+				"role": "system_r",
+				"type": "container_t",
+				"level": "s0:c4,c5"
+			}
 		}
 	}
 }

--- a/test/testdata/container_config_logging.json
+++ b/test/testdata/container_config_logging.json
@@ -4,7 +4,7 @@
 		"attempt": 1
 	},
 	"image": {
-		"image": "docker://busybox:latest"
+		"image": "busybox:latest"
 	},
 	"command": [
 		"/bin/sh", "-c"
@@ -53,30 +53,22 @@
 			"memory_limit_in_bytes": 88000000,
 			"oom_score_adj": 30
 		},
-		"capabilities": {
-			"add_capabilities": [
-				"setuid",
-				"setgid"
-			],
-			"drop_capabilities": [
-				"audit_write",
-				"audit_read"
-			]
-		},
-		"selinux_options": {
-			"user": "system_u",
-			"role": "system_r",
-			"type": "container_t",
-			"level": "s0:c4,c5"
-		},
-		"user": {
-			"uid": 5,
-			"gid": 300,
-			"additional_gids": [
-				400,
-				401,
-				402
-			]
+		"security_context": {
+			"capabilities": {
+				"add_capabilities": [
+					"setuid",
+					"setgid"
+				],
+				"drop_capabilities": [
+					"audit_read"
+				]
+			},
+			"selinux_options": {
+				"user": "system_u",
+				"role": "system_r",
+				"type": "container_t",
+				"level": "s0:c4,c5"
+			}
 		}
 	}
 }

--- a/test/testdata/container_config_seccomp.json
+++ b/test/testdata/container_config_seccomp.json
@@ -4,7 +4,7 @@
 		"attempt": 1
 	},
 	"image": {
-		"image": "docker://redis:latest"
+		"image": "redis:alpine"
 	},
 	"command": [
 		"/bin/bash"

--- a/test/testdata/container_config_seccomp.json
+++ b/test/testdata/container_config_seccomp.json
@@ -53,30 +53,22 @@
 			"memory_limit_in_bytes": 88000000,
 			"oom_score_adj": 30
 		},
-		"capabilities": {
-			"add_capabilities": [
-				"setuid",
-				"setgid"
-			],
-			"drop_capabilities": [
-				"audit_write",
-				"audit_read"
-			]
-		},
-		"selinux_options": {
-			"user": "system_u",
-			"role": "system_r",
-			"type": "svirt_lxc_net_t",
-			"level": "s0:c4-c5"
-		},
-		"user": {
-			"uid": 5,
-			"gid": 300,
-			"additional_gids": [
-				400,
-				401,
-				402
-			]
+		"security_context": {
+			"capabilities": {
+				"add_capabilities": [
+					"setuid",
+					"setgid"
+				],
+				"drop_capabilities": [
+					"audit_read"
+				]
+			},
+			"selinux_options": {
+				"user": "system_u",
+				"role": "system_r",
+				"type": "svirt_lxc_net_t",
+				"level": "s0:c4-c5"
+			}
 		}
 	}
 }

--- a/test/testdata/container_exit_test.json
+++ b/test/testdata/container_exit_test.json
@@ -18,11 +18,5 @@
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
-	"tty": false,
-	"linux": {
-		"user": {
-			"uid": 0,
-			"gid": 0
-		}
-	}
+	"tty": false
 }

--- a/test/testdata/container_redis.json
+++ b/test/testdata/container_redis.json
@@ -3,7 +3,7 @@
 		"name": "podsandbox1-redis"
 	},
 	"image": {
-		"image": "docker://redis:latest"
+		"image": "redis:alpine"
 	},
 	"args": [
                 "docker-entrypoint.sh",

--- a/test/testdata/container_redis.json
+++ b/test/testdata/container_redis.json
@@ -51,14 +51,12 @@
 			"memory_limit_in_bytes": 88000000,
 			"oom_score_adj": 30
 		},
-		"capabilities": {
-			"add_capabilities": [
-				"sys_admin"
-			]
-		},
-		"user": {
-			"uid": 0,
-			"gid": 0
+		"security_context": {
+			"capabilities": {
+				"add_capabilities": [
+					"sys_admin"
+				]
+			}
 		}
 	}
 }


### PR DESCRIPTION
Found while integrating CRI-O with OpenShift Origin:
```
Events:
  FirstSeen     LastSeen        Count   From                            SubObjectPath         Type             Reason          Message
  ---------     --------        -----   ----                            -------------         -------- ------          -------
  3s            3s              1       default-scheduler                                     Normal           Scheduled       Successfully assigned nginx10-1-deploy to 192.168.122.186
  3s            2s              2       kubelet, 192.168.122.186        spec.containers{deployment}    Normal          Pulled          Container image "openshift/origin-deployer:d98ef74" already present on machine
  3s            2s              2       kubelet, 192.168.122.186        spec.containers{deployment}    Warning         Failed          Failed to create container with error: rpc error: code = 2 desc = capability KILL must start with CAP_
  3s            2s              2       kubelet, 192.168.122.186                              Warning          FailedSync      Error syncing pod, skipping: failed to "StartContainer" for "deployment" with rpc error: code = 2 desc = capability KILL must start with CAP_: "Create Container Failed"
```

@mrunalp @sameo PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>