### PR TITLE
server: add RO and masked paths on container creation

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -462,6 +462,27 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		specgen.SetProcessSelinuxLabel(sb.processLabel)
 		specgen.SetLinuxMountLabel(sb.mountLabel)
 
+		for _, mp := range []string{
+			"/proc/kcore",
+			"/proc/latency_stats",
+			"/proc/timer_list",
+			"/proc/timer_stats",
+			"/proc/sched_debug",
+			"/sys/firmware",
+		} {
+			specgen.AddLinuxMaskedPaths(mp)
+		}
+
+		for _, rp := range []string{
+			"/proc/asound",
+			"/proc/bus",
+			"/proc/fs",
+			"/proc/irq",
+			"/proc/sys",
+			"/proc/sysrq-trigger",
+		} {
+			specgen.AddLinuxReadonlyPaths(rp)
+		}
 	}
 	// Join the namespace paths for the pod sandbox container.
 	podInfraState := s.runtime.ContainerStatus(sb.infraContainer)


### PR DESCRIPTION
For features parity with docker

@mrunalp @rhatdan @sameo PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>