### PR TITLE
OOM handling

### DIFF
--- a/cmd/crioctl/container.go
+++ b/cmd/crioctl/container.go
@@ -460,6 +460,7 @@ func ContainerStatus(client pb.RuntimeServiceClient, ID string) error {
 	ftm := time.Unix(0, r.Status.FinishedAt)
 	fmt.Printf("Finished: %v\n", ftm)
 	fmt.Printf("Exit Code: %v\n", r.Status.ExitCode)
+	fmt.Printf("Reason: %v\n", r.Status.Reason)
 	if r.Status.Image != nil {
 		fmt.Printf("Image: %v\n", r.Status.Image.Image)
 	}

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -59,6 +59,12 @@ static inline void closep(int *fd)
 	*fd = -1;
 }
 
+static inline void fclosep(FILE **fp) {
+	if (*fp)
+		fclose(*fp);
+	*fp = NULL;
+}
+
 static inline void gstring_free_cleanup(GString **string)
 {
 	if (*string)
@@ -67,6 +73,7 @@ static inline void gstring_free_cleanup(GString **string)
 
 #define _cleanup_free_ _cleanup_(freep)
 #define _cleanup_close_ _cleanup_(closep)
+#define _cleanup_fclose_ _cleanup_(fclosep)
 #define _cleanup_gstring_ _cleanup_(gstring_free_cleanup)
 
 #define BUF_SIZE 256

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -668,6 +668,11 @@ int main(int argc, char *argv[])
 		num_stdio_fds++;
 	}
 
+	/* Add the OOM event fd to epoll */
+	ev.data.fd = efd;
+	if (epoll_ctl(epfd, EPOLL_CTL_ADD, ev.data.fd, &ev) < 0)
+		pexit("Failed to add OOM eventfd to epoll");
+
 	/* Log all of the container's output. */
 	while (num_stdio_fds > 0) {
 		int ready = epoll_wait(epfd, evlist, MAX_EVENTS, -1);

--- a/oci/container.go
+++ b/oci/container.go
@@ -38,10 +38,11 @@ type Container struct {
 // ContainerState represents the status of a container.
 type ContainerState struct {
 	specs.State
-	Created  time.Time `json:"created"`
-	Started  time.Time `json:"started,omitempty"`
-	Finished time.Time `json:"finished,omitempty"`
-	ExitCode int32     `json:"exitCode,omitempty"`
+	Created   time.Time `json:"created"`
+	Started   time.Time `json:"started,omitempty"`
+	Finished  time.Time `json:"finished,omitempty"`
+	ExitCode  int32     `json:"exitCode,omitempty"`
+	OOMKilled bool      `json:"oomKilled,omitempty"`
 }
 
 // NewContainer creates a container object.

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -552,6 +552,11 @@ func (r *Runtime) UpdateStatus(c *Container) error {
 			}
 			c.state.ExitCode = int32(statusCode)
 		}
+
+		oomFilePath := filepath.Join(c.bundlePath, "oom")
+		if _, err = os.Stat(oomFilePath); err == nil {
+			c.state.OOMKilled = true
+		}
 	}
 
 	return nil

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -98,6 +98,9 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 		finished := cState.Finished.UnixNano()
 		resp.Status.FinishedAt = finished
 		resp.Status.ExitCode = cState.ExitCode
+		if cState.OOMKilled {
+			resp.Status.Reason = "OOMKilled"
+		}
 	}
 
 	resp.Status.State = rStatus


### PR DESCRIPTION
Fixes #515

This adds event notification for OOM for the container process. We set it up as described here https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt and add the eventfd to the epoll loop.
When the event is received, we touch a file called oom and then use that to populate the status in ContainerStatus CRI API. 

