### PR TITLE
fixes for tests and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@
 *.orig
 /pause/pause
 /pause/pause.o
-*.rej
 /test/bin2img/bin2img
 /test/checkseccomp/checkseccomp
 /test/copyimg/copyimg
-/test/testdata/redis-image


### PR DESCRIPTION
@mrunalp PTAL some of our tests are failing with network timeouts (on slow networks) since we pull redis:alpine by digest in each test (slowing tests time down also)