### PR TITLE
[e2e fix] server: correctly fill ctr termination reason

### DIFF
--- a/server/container.go
+++ b/server/container.go
@@ -13,14 +13,14 @@ const (
 	containerTypeContainer = "container"
 )
 
-func (s *Server) getContainerFromRequest(containerID string) (*oci.Container, error) {
-	if containerID == "" {
+func (s *Server) getContainerFromRequest(cid string) (*oci.Container, error) {
+	if cid == "" {
 		return nil, fmt.Errorf("container ID should not be empty")
 	}
 
-	containerID, err := s.ctrIDIndex.Get(containerID)
+	containerID, err := s.ctrIDIndex.Get(cid)
 	if err != nil {
-		return nil, fmt.Errorf("container with ID starting with %s not found: %v", containerID, err)
+		return nil, fmt.Errorf("container with ID starting with %s not found: %v", cid, err)
 	}
 
 	c := s.state.containers.Get(containerID)

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -98,8 +98,13 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 		finished := cState.Finished.UnixNano()
 		resp.Status.FinishedAt = finished
 		resp.Status.ExitCode = cState.ExitCode
-		if cState.OOMKilled {
+		switch {
+		case cState.OOMKilled:
 			resp.Status.Reason = "OOMKilled"
+		case cState.ExitCode == 0:
+			resp.Status.Reason = "Completed"
+		default:
+			resp.Status.Reason = "Error"
 		}
 	}
 

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -6,6 +6,16 @@ function teardown() {
 	cleanup_test
 }
 
+@test "ctr not found correct error message" {
+	start_crio
+	run crioctl ctr status --id randomid
+	echo "$output"
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "container with ID starting with randomid not found" ]]
+
+	stop_crio
+}
+
 @test "ctr termination reason Completed" {
 	start_crio
 	run crioctl pod run --config "$TESTDATA"/sandbox_config.json


### PR DESCRIPTION
This patch fixes all port forwarding e2e tests. Those tests were
specifically looking for a termination reason to say that a given
container has finished running. CRI-O wasn't actually returning any
reason field for an exited container.

-> https://github.com/kubernetes/kubernetes/blob/master/test/e2e/portforward.go#L116
   -> https://github.com/kubernetes/kubernetes/blob/master/test/utils/conditions.go#L97

Signed-off-by: Antonio Murdaca <runcom@redhat.com>