### PR TITLE
server: container_create: make the spec hostspecific

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -330,6 +330,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 
 	// creates a spec Generator with the default spec.
 	specgen := generate.New()
+	specgen.HostSpecific = true
 
 	if err := addOciBindMounts(sb, containerConfig, &specgen); err != nil {
 		return nil, err
@@ -456,7 +457,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 			if dropCaps != nil {
 				for _, cap := range dropCaps {
 					if err := specgen.DropProcessCapability(toCAPPrefixed(cap)); err != nil {
-						return nil, err
+						logrus.Debugf("failed to drop cap %s: %v", toCAPPrefixed(cap), err)
 					}
 				}
 			}


### PR DESCRIPTION
node-e2e tests were failing in RHEL because, if running a privileged
container, we get all capability in the spec. The spec generator wasn't
filtering caps based on actual host caps, it was just adding _everything_.
This patch makes spec generator host specific.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>