### PR TITLE
conmon: Fix Ubuntu build failure

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -516,7 +516,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* Open the log path file. */
-	logfd = open(log_path, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC);
+	logfd = open(log_path, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC, 0600);
 	if (logfd < 0)
 		pexit("Failed to open log file");
 


### PR DESCRIPTION
conmon.c fails to build on Ubuntu:

cc -std=c99 -Os -Wall -Wextra -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include   -c -o conmon.o conmon.c
In file included from /usr/include/fcntl.h:289:0,
                 from conmon.c:4:
In function ‘open’,
    inlined from ‘main’ at conmon.c:519:10:
/usr/include/x86_64-linux-gnu/bits/fcntl2.h:50:4: error: call to ‘__open_missing_mode’ declared with attribute error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments
    __open_missing_mode ();
    ^
<builtin>: recipe for target 'conmon.o' failed
make[1]: *** [conmon.o] Error 1

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>