### PR TITLE
Need to be consistent in out nameing of OCI

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -35,7 +35,7 @@ const (
 	seccompLocalhostPrefix = "localhost/"
 )
 
-func addOciBindMounts(sb *sandbox, containerConfig *pb.ContainerConfig, specgen *generate.Generator) error {
+func addOCIBindMounts(sb *sandbox, containerConfig *pb.ContainerConfig, specgen *generate.Generator) error {
 	mounts := containerConfig.GetMounts()
 	for _, mount := range mounts {
 		dest := mount.ContainerPath
@@ -337,7 +337,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	specgen := generate.New()
 	specgen.HostSpecific = true
 
-	if err := addOciBindMounts(sb, containerConfig, &specgen); err != nil {
+	if err := addOCIBindMounts(sb, containerConfig, &specgen); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
It should always be captitalized.

Signed-off-by: Dan Walsh <dwalsh@redhat.com>