### PR TITLE
conmon: Set ONLCR for console

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -17,6 +17,7 @@
 #include <sys/stat.h>
 #include <sys/uio.h>
 #include <sys/ioctl.h>
+#include <termios.h>
 #include <syslog.h>
 #include <unistd.h>
 
@@ -640,6 +641,7 @@ static gboolean terminal_accept_cb(int fd, G_GNUC_UNUSED GIOCondition condition,
 	const char *csname = user_data;
 	struct file_t console;
 	int connfd = -1;
+	struct termios tset;
 
 	ninfo("about to accept from csfd: %d", fd);
 	connfd = accept4(fd, NULL, NULL, SOCK_CLOEXEC);
@@ -656,6 +658,15 @@ static gboolean terminal_accept_cb(int fd, G_GNUC_UNUSED GIOCondition condition,
 
 	ninfo("console = {.name = '%s'; .fd = %d}", console.name, console.fd);
 	free(console.name);
+
+	/* We change the terminal settings to match kube settings */
+	if (tcgetattr(console.fd, &tset) == -1)
+		pexit("Failed to get console terminal settings");
+
+	tset.c_oflag |= ONLCR;
+
+	if (tcsetattr(console.fd, TCSANOW, &tset) == -1)
+		pexit("Failed to set console terminal settings");
 
 	/* We only have a single fd for both pipes, so we just treat it as
 	 * stdout. stderr is ignored. */

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -241,7 +241,7 @@ function teardown() {
 	logpath="$DEFAULT_LOG_PATH/$pod_id/$ctr_id.log"
 	[ -f "$logpath" ]
 	echo "$logpath :: $(cat "$logpath")"
-	grep -E "^[^\n]+ stdout here is some output$" "$logpath"
+	grep -E "^[^\n]+ stdout here is some output" "$logpath"
 
 	run crioctl pod stop --id "$pod_id"
 	echo "$output"


### PR DESCRIPTION
runc has ONCLR unset while kube doesn't have OPOST enabled
so we get our lines shifted without \r in a tty.
Also, we need to take out \r from a \r\n sequence before
writing to log file.

Signed-off-by: Mrunal Patel <mpatel@redhat.com>