### PR TITLE
container_create: fix OCI processArgs assemblement

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -666,7 +666,7 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	pod_id="$output"
-	volumesconfig=$(cat "$TESTDATA"/container_redis.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["image"]["image"] = "gcr.io/k8s-testimages/redis:e2e"; json.dump(obj, sys.stdout)')
+	volumesconfig=$(cat "$TESTDATA"/container_redis.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["image"]["image"] = "gcr.io/k8s-testimages/redis:e2e"; obj["args"] = []; json.dump(obj, sys.stdout)')
 	echo "$volumesconfig" > "$TESTDIR"/container_config_volumes.json
 	run crioctl ctr create --config "$TESTDIR"/container_config_volumes.json --pod "$pod_id"
 	echo "$output"


### PR DESCRIPTION
This patch fixes the following command:

kubectl run -i --tty centos --image=centos -- sh

The command above use to fail with:

/usr/bin/sh: /usr/bin/sh: cannot execute binary file

That's because we were wrongly assembling the OCI processArgs.

Thanks @alexlarsson for spotting this.

This patch basically replicates what docker does when merging container
config and image config. It also replicates how docker sets processArgs
for the OCI runtime.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>