### PR TITLE
Implement non-terminal attach

### DIFF
--- a/oci/container.go
+++ b/oci/container.go
@@ -31,6 +31,8 @@ type Container struct {
 	sandbox     string
 	netns       ns.NetNS
 	terminal    bool
+	stdin       bool
+	stdinOnce   bool
 	privileged  bool
 	state       *ContainerState
 	metadata    *pb.ContainerMetadata
@@ -54,7 +56,7 @@ type ContainerState struct {
 }
 
 // NewContainer creates a container object.
-func NewContainer(id string, name string, bundlePath string, logPath string, netns ns.NetNS, labels map[string]string, annotations map[string]string, image *pb.ImageSpec, metadata *pb.ContainerMetadata, sandbox string, terminal bool, privileged bool, dir string, created time.Time, stopSignal string) (*Container, error) {
+func NewContainer(id string, name string, bundlePath string, logPath string, netns ns.NetNS, labels map[string]string, annotations map[string]string, image *pb.ImageSpec, metadata *pb.ContainerMetadata, sandbox string, terminal bool, stdin bool, stdinOnce bool, privileged bool, dir string, created time.Time, stopSignal string) (*Container, error) {
 	state := &ContainerState{}
 	state.Created = created
 	c := &Container{
@@ -66,6 +68,8 @@ func NewContainer(id string, name string, bundlePath string, logPath string, net
 		sandbox:     sandbox,
 		netns:       netns,
 		terminal:    terminal,
+		stdin:       stdin,
+		stdinOnce:   stdinOnce,
 		privileged:  privileged,
 		metadata:    metadata,
 		annotations: annotations,

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -121,6 +121,8 @@ func (r *Runtime) CreateContainer(c *Container, cgroupParent string) error {
 	args = append(args, "-l", c.logPath)
 	if c.terminal {
 		args = append(args, "-t")
+	} else if c.stdin {
+		args = append(args, "-i")
 	}
 	logrus.WithFields(logrus.Fields{
 		"args": args,

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -54,6 +54,12 @@ const (
 
 	// TTY is the terminal path annotation
 	TTY = "io.kubernetes.cri-o.TTY"
+
+	// Stdin is the stdin annotation
+	Stdin = "io.kubernetes.cri-o.Stdin"
+
+	// StdinOnce is the stdin_once annotation
+	StdinOnce = "io.kubernetes.cri-o.StdinOnce"
 )
 
 // ContainerType values

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -531,6 +531,8 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	specgen.AddAnnotation(annotations.ContainerType, annotations.ContainerTypeContainer)
 	specgen.AddAnnotation(annotations.LogPath, logPath)
 	specgen.AddAnnotation(annotations.TTY, fmt.Sprintf("%v", containerConfig.Tty))
+	specgen.AddAnnotation(annotations.Stdin, fmt.Sprintf("%v", containerConfig.Stdin))
+	specgen.AddAnnotation(annotations.StdinOnce, fmt.Sprintf("%v", containerConfig.StdinOnce))
 	specgen.AddAnnotation(annotations.Image, image)
 
 	created := time.Now()
@@ -660,7 +662,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		return nil, err
 	}
 
-	container, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, sb.netNs(), labels, kubeAnnotations, imageSpec, metadata, sb.id, containerConfig.Tty, sb.privileged, containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
+	container, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, sb.netNs(), labels, kubeAnnotations, imageSpec, metadata, sb.id, containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.privileged, containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -438,7 +438,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, fmt.Errorf("failed to write runtime configuration for pod sandbox %s(%s): %v", sb.name, id, err)
 	}
 
-	container, err := oci.NewContainer(id, containerName, podContainer.RunDir, logPath, sb.netNs(), labels, kubeAnnotations, nil, nil, id, false, sb.privileged, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
+	container, err := oci.NewContainer(id, containerName, podContainer.RunDir, logPath, sb.netNs(), labels, kubeAnnotations, nil, nil, id, false, false, false, sb.privileged, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We use a SOCK_SEQPACKET socket for the attach unix domain socket, which
means the kernel will ensure that the reading side only ever get the
data from one write operation. We use this for frameing, where the
first byte is the pipe that the next bytes are for. We have to make sure
that all reads from the socket are using at least the same size of buffer
as the write side, because otherwise the extra data in the message
will be dropped.

This also adds a stdin pipe for the container, similar to the ones we
use for stdout/err, because we need a way for an attached client
to write to stdin, even if not using a tty.

This fixes #569

Note: This depends on #571 (and thus contains those commits), only the last commit is actually new. Once #571 is merged i'll update the PR with that.