### PR TITLE
ocicni: Handle create and write events

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -48,7 +48,8 @@ func (plugin *cniNetworkPlugin) monitorNetDir() {
 			select {
 			case event := <-watcher.Events:
 				logrus.Debugf("CNI monitoring event %v", event)
-				if event.Op&fsnotify.Create != fsnotify.Create {
+				if event.Op&fsnotify.Create != fsnotify.Create &&
+					event.Op&fsnotify.Write != fsnotify.Write {
 					continue
 				}
 


### PR DESCRIPTION
By only handling create events, we are breaking plugins that don't
create and write atomically, like weave for example.
The Weave plugin creates the file first and later writes to it. We are
missing the second part and never see the final CNI config file.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>