### PR TITLE
sandbox_status: Infof->Debugf response

### DIFF
--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -317,13 +317,13 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		hostname:     hostname,
 	}
 
+	s.addSandbox(sb)
 	defer func() {
 		if err != nil {
 			s.removeSandbox(id)
 		}
 	}()
 
-	s.addSandbox(sb)
 	if err = s.podIDIndex.Add(id); err != nil {
 		return nil, err
 	}

--- a/server/sandbox_status.go
+++ b/server/sandbox_status.go
@@ -56,6 +56,6 @@ func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusR
 		},
 	}
 
-	logrus.Infof("PodSandboxStatusResponse: %+v", resp)
+	logrus.Debugf("PodSandboxStatusResponse: %+v", resp)
 	return resp, nil
 }


### PR DESCRIPTION
This was cluttering the logs on my clusters. The log should be just in
debug mode as we do for every request/response flow.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>