### PR TITLE
conmon: Don't leave zombies and fix cgroup race

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -69,8 +69,16 @@ func RunUnderSystemdScope(pid int, slice string, unitName string) error {
 	properties = append(properties, newProp("PIDs", []uint32{uint32(pid)}))
 	properties = append(properties, newProp("Delegate", true))
 	properties = append(properties, newProp("DefaultDependencies", false))
-	_, err = conn.StartTransientUnit(unitName, "replace", properties, nil)
-	return err
+	ch := make(chan string)
+	_, err = conn.StartTransientUnit(unitName, "replace", properties, ch)
+	if err != nil {
+		return err
+	}
+
+	// Block until job is started
+	<-ch
+
+	return nil
 }
 
 func newProp(name string, units interface{}) systemdDbus.Property {


### PR DESCRIPTION
Currently, when creating containers we never call Wait on the
conmon exec.Command, which means that the child hangs around
forever as a zombie after it dies.

However, instead of doing this waitpid() in the parent we instead
do a double-fork in conmon, to daemonize it. That makes a lot of
sense, as conmon really is not tied to the launcher, but needs
to outlive it if e.g. the cri-o daemon restarts.

However, this makes even more obvious a race condition which we
already have. When crio-d puts the conmon pid in a cgroup there
is a race where conmon could already have spawned a child, and
it would then not be part of the cgroup. In order to fix this
we add another synchronization pipe to conmon, which we block
on before we create any children. The parent then makes sure the
pid is in the cgroup before letting it continue.