### PR TITLE
Add step to restart crio after setting up CNI

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -60,6 +60,92 @@ commit: c91b5bea4830a57eac7882d7455d59518cdf70ec
 spec: 1.0.0-rc2-dev
 ```
 
+### cni
+
+This tutorial will use the latest version of `cni` from the master branch and build it from source.
+
+Download the `cni` source tree:
+
+```
+go get -d github.com/containernetworking/cni
+```
+
+```
+cd $GOPATH/src/github.com/containernetworking/cni
+```
+
+Build the `cni` binaries:
+
+```
+./build.sh
+```
+
+Output:
+
+```
+Building API
+Building reference CLI
+Building plugins
+   flannel
+   tuning
+   bridge
+   ipvlan
+   loopback
+   macvlan
+   ptp
+   dhcp
+   host-local
+   noop
+```
+
+Install the `cni` binaries:
+
+```
+sudo mkdir -p /opt/cni/bin
+```
+
+```
+sudo cp bin/* /opt/cni/bin/
+```
+
+#### Configure CNI
+
+```
+sudo mkdir -p /etc/cni/net.d
+```
+
+```
+sudo sh -c 'cat >/etc/cni/net.d/10-mynet.conf <<-EOF
+{
+    "cniVersion": "0.2.0",
+    "name": "mynet",
+    "type": "bridge",
+    "bridge": "cni0",
+    "isGateway": true,
+    "ipMasq": true,
+    "ipam": {
+        "type": "host-local",
+        "subnet": "10.88.0.0/16",
+        "routes": [
+            { "dst": "0.0.0.0/0"  }
+        ]
+    }
+}
+EOF'
+```
+
+```
+sudo sh -c 'cat >/etc/cni/net.d/99-loopback.conf <<-EOF
+{
+    "cniVersion": "0.2.0",
+    "type": "loopback"
+}
+EOF'
+```
+
+At this point `cni` is installed and configured to allocation IP address to containers from the `10.88.0.0/16` subnet.
+
+
 ### crio
 
 The `crio` project does not ship binary releases so you'll need to build it from source.
@@ -190,94 +276,6 @@ sudo crioctl runtimeversion
 VersionResponse: Version: 0.1.0, RuntimeName: runc, RuntimeVersion: 1.0.0-rc2, RuntimeApiVersion: v1alpha1
 ```
 
-### cni
-
-This tutorial will use the latest version of `cni` from the master branch and build it from source.
-
-Download the `cni` source tree:
-
-```
-go get -d github.com/containernetworking/cni
-```
-
-```
-cd $GOPATH/src/github.com/containernetworking/cni
-```
-
-Build the `cni` binaries:
-
-```
-./build.sh
-```
-
-Output:
-
-```
-Building API
-Building reference CLI
-Building plugins
-   flannel
-   tuning
-   bridge
-   ipvlan
-   loopback
-   macvlan
-   ptp
-   dhcp
-   host-local
-   noop
-```
-
-Install the `cni` binaries:
-
-```
-sudo mkdir -p /opt/cni/bin
-```
-
-```
-sudo cp bin/* /opt/cni/bin/
-```
-
-#### Configure CNI
-
-```
-sudo mkdir -p /etc/cni/net.d
-```
-
-```
-sudo sh -c 'cat >/etc/cni/net.d/10-mynet.conf <<-EOF
-{
-    "cniVersion": "0.2.0",
-    "name": "mynet",
-    "type": "bridge",
-    "bridge": "cni0",
-    "isGateway": true,
-    "ipMasq": true,
-    "ipam": {
-        "type": "host-local",
-        "subnet": "10.88.0.0/16",
-        "routes": [
-            { "dst": "0.0.0.0/0"  }
-        ]
-    }
-}
-EOF'
-```
-
-```
-sudo sh -c 'cat >/etc/cni/net.d/99-loopback.conf <<-EOF
-{
-    "cniVersion": "0.2.0",
-    "type": "loopback"
-}
-EOF'
-```
-
-```
-sudo systemctl restart crio
-```
-
-At this point `cni` is installed and configured to allocation IP address to containers from the `10.88.0.0/16` subnet.
 
 ## Pod Tutorial
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -273,6 +273,10 @@ sudo sh -c 'cat >/etc/cni/net.d/99-loopback.conf <<-EOF
 EOF'
 ```
 
+```
+sudo systemctl restart crio
+```
+
 At this point `cni` is installed and configured to allocation IP address to containers from the `10.88.0.0/16` subnet.
 
 ## Pod Tutorial


### PR DESCRIPTION
Pod ID creation was failing with error message "cni config uninitialized." Restarting crio after the CNI setup helped fixed this.