### PR TITLE
contrib/cni: Fix README link

### DIFF
--- a/contrib/cni/README.md
+++ b/contrib/cni/README.md
@@ -13,4 +13,4 @@ In addition, you need to install the [CNI plugins][cni] necessary into
 two plugins necessary for the example CNI configurations are `loopback` and
 `bridge`.
 
-[cni]: https://github.com/containernetworking/cni
+[cni]: https://github.com/containernetworking/plugins


### PR DESCRIPTION
The CNI plugins are now living in a repo of their own.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>