### PR TITLE
server: add --bind-address flag

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -35,6 +35,12 @@ storage_option = [
 # listen is the path to the AF_LOCAL socket on which crio will listen.
 listen = "{{ .Listen }}"
 
+# stream_address is the IP address on which the stream server will listen
+stream_address = "{{ .StreamAddress }}"
+
+# stream_port is the port on which the stream server will listen
+stream_port = "{{ .StreamPort }}"
+
 # The "crio.runtime" table contains settings pertaining to the OCI
 # runtime used and options for how to set up and manage the OCI runtime.
 [crio.runtime]

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -71,6 +71,12 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("listen") {
 		config.Listen = ctx.GlobalString("listen")
 	}
+	if ctx.GlobalIsSet("stream-address") {
+		config.StreamAddress = ctx.GlobalString("stream-address")
+	}
+	if ctx.GlobalIsSet("stream-port") {
+		config.StreamPort = ctx.GlobalString("stream-port")
+	}
 	if ctx.GlobalIsSet("runtime") {
 		config.Runtime = ctx.GlobalString("runtime")
 	}
@@ -144,6 +150,14 @@ func main() {
 		cli.StringFlag{
 			Name:  "listen",
 			Usage: "path to crio socket",
+		},
+		cli.StringFlag{
+			Name:  "stream-address",
+			Usage: "bind address for streaming socket",
+		},
+		cli.StringFlag{
+			Name:  "stream-port",
+			Usage: "bind port for streaming socket (default: \"10010\")",
 		},
 		cli.StringFlag{
 			Name:  "log",

--- a/server/config.go
+++ b/server/config.go
@@ -65,6 +65,12 @@ type APIConfig struct {
 	// This may support proto://addr formats later, but currently this is just
 	// a path.
 	Listen string `toml:"listen"`
+
+	// StreamAddress is the IP address on which the stream server will listen.
+	StreamAddress string `toml:"stream_address"`
+
+	// StreamPort is the port on which the stream server will listen.
+	StreamPort string `toml:"stream_port"`
 }
 
 // RuntimeConfig represents the "crio.runtime" TOML config table.
@@ -207,7 +213,9 @@ func DefaultConfig() *Config {
 			LogDir:  "/var/log/crio/pods",
 		},
 		APIConfig: APIConfig{
-			Listen: "/var/run/crio.sock",
+			Listen:        "/var/run/crio.sock",
+			StreamAddress: "",
+			StreamPort:    "10010",
 		},
 		RuntimeConfig: RuntimeConfig{
 			Runtime:               "/usr/bin/runc",


### PR DESCRIPTION
This makes the lack of an IPv4 address a warning instead of a failure. We run IPv6 only backend nodes. Kubernetes mostly works in this configuration. After #557, cri-o fails to start with  `Unable to select an IP.`