### PR TITLE
test: add a test for /etc/resolv.conf in rw/ro mode

### DIFF
--- a/test/testdata/container_config_resolvconf.json
+++ b/test/testdata/container_config_resolvconf.json
@@ -7,7 +7,9 @@
 		"image": "redis:alpine"
 	},
 	"command": [
-		"/bin/ls"
+		"sh",
+		"-c",
+		"echo test >> /etc/resolv.conf"
 	],
 	"args": [],
 	"working_dir": "/",

--- a/test/testdata/container_config_resolvconf_ro.json
+++ b/test/testdata/container_config_resolvconf_ro.json
@@ -7,7 +7,9 @@
 		"image": "redis:alpine"
 	},
 	"command": [
-		"/bin/ls"
+		"sh",
+		"-c",
+		"echo test >> /etc/resolv.conf"
 	],
 	"args": [],
 	"working_dir": "/",
@@ -50,7 +52,7 @@
 			"oom_score_adj": 30
 		},
 		"security_context": {
-			"readonly_rootfs": false,
+			"readonly_rootfs": true,
 			"capabilities": {
 				"add_capabilities": [
 					"setuid",

--- a/test/testdata/sandbox_config.json
+++ b/test/testdata/sandbox_config.json
@@ -7,11 +7,7 @@
 	},
 	"hostname": "crioctl_host",
 	"log_directory": "",
-	"dns_options": {
-		"servers": [
-			"server1.redhat.com",
-			"server2.redhat.com"
-		],
+	"dns_config": {
 		"searches": [
 			"8.8.8.8"
 		]


### PR DESCRIPTION
This patch isn't adding a test for /etc/hosts as that requires host
network and we don't want to play with host's /etc/hosts when running
make localintegration on our laptops. That may change in the future
moving to some sort of in-container testing.

smoke test for https://github.com/kubernetes-incubator/cri-o/pull/599

Signed-off-by: Antonio Murdaca <runcom@redhat.com>