### PR TITLE
vendor: update kube to v1.6.5

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,4 +1,4 @@
-k8s.io/kubernetes v1.6.4 https://github.com/kubernetes/kubernetes
+k8s.io/kubernetes v1.6.5 https://github.com/kubernetes/kubernetes
 # https://github.com/kubernetes/client-go#compatibility-matrix
 k8s.io/client-go v3.0.0-beta.0 https://github.com/kubernetes/client-go
 k8s.io/apimachinery release-1.6 https://github.com/kubernetes/apimachinery


### PR DESCRIPTION
Nothing changed in the vendor we're using :)

Signed-off-by: Antonio Murdaca <runcom@redhat.com>