### PR TITLE
crio now requires runc rc3 or greater

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -33,31 +33,17 @@ This section will walk you through installing the following components:
 
 ### runc
 
-Download the `runc` release binary:
+CRI-O requires the version of runc below or newer.
 
-```
-wget https://github.com/opencontainers/runc/releases/download/v1.0.0-rc2/runc-linux-amd64
-```
-
-Set the executable bit and copy the `runc` binary into your PATH:
-
-```
-chmod +x runc-linux-amd64
-```
-
-```
-sudo mv runc-linux-amd64 /usr/bin/runc
-```
-
-Print the `runc` version:
+You can check your `runc` version:
 
 ```
 runc -version
 ```
 ```
-runc version 1.0.0-rc2
-commit: c91b5bea4830a57eac7882d7455d59518cdf70ec
-spec: 1.0.0-rc2-dev
+runc version 1.0.0-rc3
+commit: 75f8da7c889acc4509a0cf6f0d3a8f9584778375
+spec: 1.0.0-rc5
 ```
 
 ### crio
@@ -187,7 +173,7 @@ sudo systemctl start crio
 sudo crioctl runtimeversion
 ```
 ```
-VersionResponse: Version: 0.1.0, RuntimeName: runc, RuntimeVersion: 1.0.0-rc2, RuntimeApiVersion: v1alpha1
+VersionResponse: Version: 0.1.0, RuntimeName: runc, RuntimeVersion: 1.0.0-rc3, RuntimeApiVersion: v1alpha1
 ```
 
 ### CNI plugins
@@ -216,15 +202,6 @@ Output:
 Building API
 Building reference CLI
 Building plugins
-   flannel
-   tuning
-   bridge
-   ipvlan
-   loopback
-   macvlan
-   ptp
-   dhcp
-   host-local
    noop
 ```
 
@@ -233,6 +210,42 @@ Install the `CNI` plugins:
 ```
 sudo mkdir -p /opt/cni/bin
 ```
+
+```
+sudo cp bin/* /opt/cni/bin/
+```
+
+Plugins
+
+```
+cd $GOPATH/src/github.com/containernetworking/plugins
+```
+
+Build the `plugin` binaries:
+
+```
+./build.sh
+```
+
+Output:
+
+```
+Building plugins
+  flannel
+  portmap
+  tuning
+  bridge
+  ipvlan
+  loopback
+  macvlan
+  ptp
+  vlan
+  dhcp
+  host-local
+  sample
+```
+
+Install the `plugin` binaries:
 
 ```
 sudo cp bin/* /opt/cni/bin/


### PR DESCRIPTION
Also fix tutorial for updated cni and plugins packages

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>