### PR TITLE
server: standardize on naming

### DIFF
--- a/server/naming.go
+++ b/server/naming.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/pkg/stringid"
+	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+)
+
+const (
+	kubePrefix    = "k8s"
+	infraName     = "infra"
+	nameDelimiter = "_"
+)
+
+func makeSandboxName(sandboxConfig *pb.PodSandboxConfig) string {
+	return strings.Join([]string{
+		kubePrefix,
+		sandboxConfig.Metadata.Name,
+		sandboxConfig.Metadata.Namespace,
+		sandboxConfig.Metadata.Uid,
+		fmt.Sprintf("%d", sandboxConfig.Metadata.Attempt),
+	}, nameDelimiter)
+}
+
+func makeSandboxContainerName(sandboxConfig *pb.PodSandboxConfig) string {
+	return strings.Join([]string{
+		kubePrefix,
+		infraName,
+		sandboxConfig.Metadata.Name,
+		sandboxConfig.Metadata.Namespace,
+		sandboxConfig.Metadata.Uid,
+		fmt.Sprintf("%d", sandboxConfig.Metadata.Attempt),
+	}, nameDelimiter)
+}
+
+func makeContainerName(sandboxMetadata *pb.PodSandboxMetadata, containerConfig *pb.ContainerConfig) string {
+	return strings.Join([]string{
+		kubePrefix,
+		containerConfig.Metadata.Name,
+		sandboxMetadata.Name,
+		sandboxMetadata.Namespace,
+		sandboxMetadata.Uid,
+		fmt.Sprintf("%d", containerConfig.Metadata.Attempt),
+	}, nameDelimiter)
+}
+
+func (s *Server) generatePodIDandName(sandboxConfig *pb.PodSandboxConfig) (string, string, error) {
+	var (
+		err error
+		id  = stringid.GenerateNonCryptoID()
+	)
+	if sandboxConfig.Metadata.Namespace == "" {
+		return "", "", fmt.Errorf("cannot generate pod ID without namespace")
+	}
+	name, err := s.reservePodName(id, makeSandboxName(sandboxConfig))
+	if err != nil {
+		return "", "", err
+	}
+	return id, name, err
+}
+
+func (s *Server) generateContainerIDandNameForSandbox(sandboxConfig *pb.PodSandboxConfig) (string, string, error) {
+	var (
+		err error
+		id  = stringid.GenerateNonCryptoID()
+	)
+	name, err := s.reserveContainerName(id, makeSandboxContainerName(sandboxConfig))
+	if err != nil {
+		return "", "", err
+	}
+	return id, name, err
+}
+
+func (s *Server) generateContainerIDandName(sandboxMetadata *pb.PodSandboxMetadata, containerConfig *pb.ContainerConfig) (string, string, error) {
+	var (
+		err error
+		id  = stringid.GenerateNonCryptoID()
+	)
+	name, err := s.reserveContainerName(id, makeContainerName(sandboxMetadata, containerConfig))
+	if err != nil {
+		return "", "", err
+	}
+	return id, name, err
+}

--- a/server/sandbox.go
+++ b/server/sandbox.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/docker/docker/pkg/mount"
-	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/kubernetes-incubator/cri-o/oci"
 	"golang.org/x/sys/unix"
@@ -262,21 +261,6 @@ func (s *sandbox) netNsRemove() error {
 
 	s.netns.closed = true
 	return nil
-}
-
-func (s *Server) generatePodIDandName(name string, namespace string, attempt uint32) (string, string, error) {
-	var (
-		err error
-		id  = stringid.GenerateNonCryptoID()
-	)
-	if namespace == "" {
-		return "", "", fmt.Errorf("cannot generate pod ID without namespace")
-	}
-
-	if name, err = s.reservePodName(id, fmt.Sprintf("%s-%s-%v", namespace, name, attempt)); err != nil {
-		return "", "", err
-	}
-	return id, name, err
 }
 
 func (s *Server) getPodSandboxFromRequest(podSandboxID string) (*sandbox, error) {

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -101,7 +101,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	namespace := req.GetConfig().GetMetadata().Namespace
 	attempt := req.GetConfig().GetMetadata().Attempt
 
-	id, name, err := s.generatePodIDandName(kubeName, namespace, attempt)
+	id, name, err := s.generatePodIDandName(req.GetConfig())
 	if err != nil {
 		if strings.Contains(err.Error(), "already reserved for pod") {
 			matches := conflictRE.FindStringSubmatch(err.Error())
@@ -115,7 +115,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 			if _, err := s.RemovePodSandbox(ctx, &pb.RemovePodSandboxRequest{PodSandboxId: dupID}); err != nil {
 				return nil, err
 			}
-			id, name, err = s.generatePodIDandName(kubeName, namespace, attempt)
+			id, name, err = s.generatePodIDandName(req.GetConfig())
 			if err != nil {
 				return nil, err
 			}
@@ -130,7 +130,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 	}()
 
-	_, containerName, err := s.generateContainerIDandName(name, "infra", attempt)
+	_, containerName, err := s.generateContainerIDandNameForSandbox(req.GetConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/test/seccomp.bats
+++ b/test/seccomp.bats
@@ -21,7 +21,7 @@ function teardown() {
 
 	start_crio "$TESTDIR"/seccomp_profile1.json
 
-	sed -e 's/%VALUE%/,"security\.alpha\.kubernetes\.io\/seccomp\/container\/redhat\.test\.crio-seccomp1-1-testname-0": "unconfined"/g' "$TESTDATA"/sandbox_config_seccomp.json > "$TESTDIR"/seccomp1.json
+	sed -e 's/%VALUE%/,"security\.alpha\.kubernetes\.io\/seccomp\/container\/k8s_testname_seccomp_1_redhat\.test\.crio_redhat-test-crio_0": "unconfined"/g' "$TESTDATA"/sandbox_config_seccomp.json > "$TESTDIR"/seccomp1.json
 	run crioctl pod run --name seccomp1 --config "$TESTDIR"/seccomp1.json
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -57,7 +57,7 @@ function teardown() {
 
 	start_crio "$TESTDIR"/seccomp_profile1.json
 
-	sed -e 's/%VALUE%/,"security\.alpha\.kubernetes\.io\/seccomp\/container\/redhat\.test\.crio-seccomp2-1-testname2-0": "runtime\/default"/g' "$TESTDATA"/sandbox_config_seccomp.json > "$TESTDIR"/seccomp2.json
+	sed -e 's/%VALUE%/,"security\.alpha\.kubernetes\.io\/seccomp\/container\/k8s_testname2_seccomp2_redhat\.test\.crio_redhat-test-crio_0": "runtime\/default"/g' "$TESTDATA"/sandbox_config_seccomp.json > "$TESTDIR"/seccomp2.json
 	run crioctl pod run --name seccomp2 --config "$TESTDIR"/seccomp2.json
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -94,7 +94,7 @@ function teardown() {
 
 	start_crio "$TESTDIR"/seccomp_profile1.json
 
-	sed -e 's/%VALUE%/,"security\.alpha\.kubernetes\.io\/seccomp\/container\/redhat\.test\.crio-seccomp3-1-testname3-1": "notgood"/g' "$TESTDATA"/sandbox_config_seccomp.json > "$TESTDIR"/seccomp3.json
+	sed -e 's/%VALUE%/,"security\.alpha\.kubernetes\.io\/seccomp\/container\/k8s_testname3_seccomp3_redhat\.test\.crio_redhat-test-crio_1": "notgood"/g' "$TESTDATA"/sandbox_config_seccomp.json > "$TESTDIR"/seccomp3.json
 	run crioctl pod run --name seccomp3 --config "$TESTDIR"/seccomp3.json
 	echo "$output"
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
Fix https://github.com/kubernetes-incubator/cri-o/issues/617

This patch rewrites the way we generate container/pod names following what upstream kube does for the dockershim. Including the sandbox UID is also fixing potential naming collisions as we trust k8s.

@alexlarsson @mrunalp PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>