### PR TITLE
test: Tighten the grep for logging with tty

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -241,7 +241,7 @@ function teardown() {
 	logpath="$DEFAULT_LOG_PATH/$pod_id/$ctr_id.log"
 	[ -f "$logpath" ]
 	echo "$logpath :: $(cat "$logpath")"
-	grep -E "^[^\n]+ stdout here is some output" "$logpath"
+	grep --binary -P "^[^\n]+ stdout here is some output\x0d$" "$logpath"
 
 	run crioctl pod stop --id "$pod_id"
 	echo "$output"


### PR DESCRIPTION
This tests that our ONLCR takes effect as we match \r\n
in the logs

Signed-off-by: Mrunal Patel <mpatel@redhat.com>