### PR TITLE
test: Make sure to have a running container before calling into "exec"

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -614,12 +614,15 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"$(printf "Stdout:\nhello0 stdout")"* ]]
 
-	stderrconfig=$(cat "$TESTDATA"/container_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["image"]["image"] = "runcom/stderr-test"; json.dump(obj, sys.stdout)')
+	stderrconfig=$(cat "$TESTDATA"/container_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["image"]["image"] = "runcom/stderr-test"; obj["command"] = ["/bin/sleep", "600"]; json.dump(obj, sys.stdout)')
 	echo "$stderrconfig" > "$TESTDIR"/container_config_stderr.json
 	run crioctl ctr create --config "$TESTDIR"/container_config_stderr.json --pod "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	ctr_id="$output"
+	run crioctl ctr start --id "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
 	run crioctl ctr execsync --id "$ctr_id" stderr
 	echo "$output"
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
The test "ctr execsync std{out,err}" from ctr.bats works with runc,
but the semantics behind is wrong.

We should not be able to execute a new process on a container which
has not been previously started. That's why this patch adds a call
to start the container.

Moreover, we don't want to be able to execute a new process on a
container that has already returned because its workload is done.
For that reason, we need to force the container workload to be a
"sleep 10" to ensure it is still running when the call to "exec"
is issued.