### PR TITLE
tutorial: fix Kubernetes CRI interface link

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -1,6 +1,6 @@
 # cri-o Tutorial
 
-This tutorial will walk you through the installation of [cri-o](https://github.com/kubernetes-incubator/cri-o), an Open Container Initiative-based implementation of [Kubernetes Container Runtime Interface](https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/container-runtime-interface-v1.md), and the creation of [Redis](https://redis.io/) server running in a [Pod](http://kubernetes.io/docs/user-guide/pods/).
+This tutorial will walk you through the installation of [cri-o](https://github.com/kubernetes-incubator/cri-o), an Open Container Initiative-based implementation of [Kubernetes Container Runtime Interface](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/container-runtime-interface-v1.md), and the creation of [Redis](https://redis.io/) server running in a [Pod](http://kubernetes.io/docs/user-guide/pods/).
 
 ## Prerequisites
 


### PR DESCRIPTION
The Kubernetes Container Runtime Interface document was moved to https://github.com/kubernetes/community/blob/master/contributors/design-proposals/container-runtime-interface-v1.md. Adjust the URL in tutorial.md accordingly.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>