### PR TITLE
sandbox: Adjust OOM score of infra container to a low value

### DIFF
--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -22,6 +22,14 @@ import (
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
 
+const (
+	// PodInfraOOMAdj is the value that we set for oom score adj for
+	// the pod infra container.
+	// TODO: Remove this const once this value is provided over CRI
+	// See https://github.com/kubernetes/kubernetes/issues/47938
+	PodInfraOOMAdj int = -998
+)
+
 // privilegedSandbox returns true if the sandbox configuration
 // requires additional host privileges for the sandbox.
 func (s *Server) privilegedSandbox(req *pb.RunPodSandboxRequest) bool {
@@ -386,6 +394,10 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 			sb.cgroupParent = cgroupParent
 		}
 	}
+
+	// Set OOM score adjust of the infra container to be very low
+	// so it doesn't get killed.
+	g.SetLinuxResourcesOOMScoreAdj(PodInfraOOMAdj)
 
 	hostNetwork := req.GetConfig().GetLinux().GetSecurityContext().GetNamespaceOptions().HostNetwork
 


### PR DESCRIPTION
This matches the current kube behavior. This will probably
be provided over the CRI at which point we won't have to
define a constant in cri-o code.

Signed-off-by: Mrunal Patel <mpatel@redhat.com>