### PR TITLE
contrib: Set the OOM Score Adjust of cri-o service to be low

### DIFF
--- a/contrib/systemd/crio.service
+++ b/contrib/systemd/crio.service
@@ -16,6 +16,7 @@ TasksMax=8192
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity
+OOMScoreAdjust=-999
 TimeoutStartSec=0
 Restart=on-abnormal
 


### PR DESCRIPTION
We don't want cri-o to be OOM killed easily.

Signed-off-by: Mrunal Patel <mpatel@redhat.com>