### PR TITLE
cmd/crio: fix reading insecure-registry flags

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -63,7 +63,7 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 		config.StorageOptions = ctx.GlobalStringSlice("storage-opt")
 	}
 	if ctx.GlobalIsSet("insecure-registry") {
-		config.InsecureRegistries = ctx.GlobalStringSlice("insecure-registries")
+		config.InsecureRegistries = ctx.GlobalStringSlice("insecure-registry")
 	}
 	if ctx.GlobalIsSet("default-transport") {
 		config.DefaultTransport = ctx.GlobalString("default-transport")


### PR DESCRIPTION
can't actually add a test for now as that would require a custom registry in our test infra.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>