### PR TITLE
all: Switch from package syscall to golang.org/x/sys/unix

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -9,13 +9,13 @@ import (
 	"os/signal"
 	"sort"
 	"strings"
-	"syscall"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/kubernetes-incubator/cri-o/server"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/urfave/cli"
+	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 	"k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
@@ -117,13 +117,13 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 
 func catchShutdown(gserver *grpc.Server, sserver *server.Server, signalled *bool) {
 	sig := make(chan os.Signal, 10)
-	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sig, unix.SIGINT, unix.SIGTERM)
 	go func() {
 		for s := range sig {
 			switch s {
-			case syscall.SIGINT:
+			case unix.SIGINT:
 				logrus.Debugf("Caught SIGINT")
-			case syscall.SIGTERM:
+			case unix.SIGTERM:
 				logrus.Debugf("Caught SIGTERM")
 			default:
 				continue

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -425,7 +425,7 @@ func (r *Runtime) ExecSync(c *Container, command []string, timeout int64) (resp 
 	err = cmd.Wait()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+			if status, ok := exitErr.Sys().(unix.WaitStatus); ok {
 				return nil, ExecSyncError{
 					Stdout:   stdoutBuf,
 					Stderr:   stderrBuf,
@@ -516,7 +516,7 @@ func (r *Runtime) StopContainer(c *Container, timeout int64) error {
 			default:
 				// Check if the process is still around
 				err := unix.Kill(c.state.Pid, 0)
-				if err == syscall.ESRCH {
+				if err == unix.ESRCH {
 					close(done)
 					return
 				}
@@ -529,8 +529,8 @@ func (r *Runtime) StopContainer(c *Container, timeout int64) error {
 		return nil
 	case <-time.After(time.Duration(timeout) * time.Second):
 		close(chControl)
-		err := unix.Kill(c.state.Pid, syscall.SIGKILL)
-		if err != nil && err != syscall.ESRCH {
+		err := unix.Kill(c.state.Pid, unix.SIGKILL)
+		if err != nil && err != unix.ESRCH {
 			return fmt.Errorf("failed to kill process: %v", err)
 		}
 	}
@@ -617,7 +617,7 @@ func (r *Runtime) ContainerStatus(c *Container) *ContainerState {
 
 // newPipe creates a unix socket pair for communication
 func newPipe() (parent *os.File, child *os.File, err error) {
-	fds, err := syscall.Socketpair(syscall.AF_LOCAL, syscall.SOCK_STREAM|syscall.SOCK_CLOEXEC, 0)
+	fds, err := unix.Socketpair(unix.AF_LOCAL, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/container_attach.go
+++ b/server/container_attach.go
@@ -6,12 +6,12 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"syscall"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/kubernetes-incubator/cri-o/oci"
 	"github.com/kubernetes-incubator/cri-o/utils"
 	"golang.org/x/net/context"
+	"golang.org/x/sys/unix"
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/util/term"
@@ -54,7 +54,7 @@ func (ss streamService) Attach(containerID string, inputStream io.Reader, output
 	}
 
 	controlPath := filepath.Join(c.BundlePath(), "ctl")
-	controlFile, err := os.OpenFile(controlPath, syscall.O_WRONLY, 0)
+	controlFile, err := os.OpenFile(controlPath, unix.O_WRONLY, 0)
 	if err != nil {
 		return fmt.Errorf("failed to open container ctl file: %v", err)
 	}

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -25,6 +24,7 @@ import (
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"golang.org/x/net/context"
+	"golang.org/x/sys/unix"
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
 
@@ -60,7 +60,7 @@ func addOCIBindMounts(sb *sandbox, containerConfig *pb.ContainerConfig, specgen 
 
 		if mount.SelinuxRelabel {
 			// Need a way in kubernetes to determine if the volume is shared or private
-			if err := label.Relabel(src, sb.mountLabel, true); err != nil && err != syscall.ENOTSUP {
+			if err := label.Relabel(src, sb.mountLabel, true); err != nil && err != unix.ENOTSUP {
 				return fmt.Errorf("relabel failed %s: %v", src, err)
 			}
 		}

--- a/server/seccomp/seccomp.go
+++ b/server/seccomp/seccomp.go
@@ -6,12 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"syscall"
 
 	"github.com/docker/docker/pkg/stringutils"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	libseccomp "github.com/seccomp/libseccomp-golang"
+	"golang.org/x/sys/unix"
 )
 
 // IsEnabled returns true if seccomp is enabled for the host.
@@ -21,9 +21,9 @@ func IsEnabled() bool {
 
 	enabled := false
 	// Check if Seccomp is supported, via CONFIG_SECCOMP.
-	if _, _, err := syscall.RawSyscall(syscall.SYS_PRCTL, syscall.PR_GET_SECCOMP, 0, 0); err != syscall.EINVAL {
+	if _, _, err := unix.RawSyscall(unix.SYS_PRCTL, unix.PR_GET_SECCOMP, 0, 0); err != unix.EINVAL {
 		// Make sure the kernel has CONFIG_SECCOMP_FILTER.
-		if _, _, err := syscall.RawSyscall(syscall.SYS_PRCTL, syscall.PR_SET_SECCOMP, seccompModeFilter, 0); err != syscall.EINVAL {
+		if _, _, err := unix.RawSyscall(unix.SYS_PRCTL, unix.PR_SET_SECCOMP, seccompModeFilter, 0); err != unix.EINVAL {
 			enabled = true
 		}
 	}

--- a/test/checkseccomp/checkseccomp.go
+++ b/test/checkseccomp/checkseccomp.go
@@ -2,19 +2,20 @@ package main
 
 import (
 	"os"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
-	// SeccompModeFilter refers to the syscall argument SECCOMP_MODE_FILTER.
+	// SeccompModeFilter refers to the unix argument SECCOMP_MODE_FILTER.
 	SeccompModeFilter = uintptr(2)
 )
 
 func main() {
 	// Check if Seccomp is supported, via CONFIG_SECCOMP.
-	if _, _, err := syscall.RawSyscall(syscall.SYS_PRCTL, syscall.PR_GET_SECCOMP, 0, 0); err != syscall.EINVAL {
+	if _, _, err := unix.RawSyscall(unix.SYS_PRCTL, unix.PR_GET_SECCOMP, 0, 0); err != unix.EINVAL {
 		// Make sure the kernel has CONFIG_SECCOMP_FILTER.
-		if _, _, err := syscall.RawSyscall(syscall.SYS_PRCTL, syscall.PR_SET_SECCOMP, SeccompModeFilter, 0); err != syscall.EINVAL {
+		if _, _, err := unix.RawSyscall(unix.SYS_PRCTL, unix.PR_SET_SECCOMP, SeccompModeFilter, 0); err != unix.EINVAL {
 			os.Exit(0)
 		}
 	}


### PR DESCRIPTION
The syscall package is locked down and the comment in [1] advises to
switch code to use the corresponding package from golang.org/x/sys. Do
so and replace usage of package syscall where possible (leave
syscall.SysProcAttr as per the comment).

  [1] https://github.com/golang/go/blob/master/src/syscall/syscall.go#L21-L24

This will also allow to get updates and fixes just by re-vendoring
golang.org/x/sys/unix instead of having to update to a new go version.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>