### PR TITLE
server: containers inherit rlimits from server

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -317,6 +317,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	// creates a spec Generator with the default spec.
 	specgen := generate.New()
 	specgen.HostSpecific = true
+	specgen.ClearProcessRlimits()
 
 	if err := addOCIBindMounts(sb, containerConfig, &specgen); err != nil {
 		return nil, err


### PR DESCRIPTION
The default container config generated by runtime tools sets RLIMIT_NOFILE to 1024. This is too restrictive for many applications. Kubernetes doesn't support setting rlimits per container (see: kubernetes/kubernetes#3595). For now, we shouldn't set rlimits on the containers. This allows the administrator to configure the default rlimits using the normal config files. (This also matches the default behavior of docker.)