### PR TITLE
Remove repeated app.Flags in cmd/kpod/main.go

### DIFF
--- a/cmd/kpod/main.go
+++ b/cmd/kpod/main.go
@@ -47,24 +47,6 @@ func main() {
 			Usage: "used to pass an option to the storage driver",
 		},
 	}
-	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:  "root",
-			Usage: "path to the root directory in which data, including images,  is stored",
-		},
-		cli.StringFlag{
-			Name:  "runroot",
-			Usage: "path to the 'run directory' where all state information is stored",
-		},
-		cli.StringFlag{
-			Name:  "storage-driver, s",
-			Usage: "select which storage driver is used to manage storage of images and containers (default is overlay2)",
-		},
-		cli.StringSliceFlag{
-			Name:  "storage-opt",
-			Usage: "used to pass an option to the storage driver",
-		},
-	}
 
 	if err := app.Run(os.Args); err != nil {
 		logrus.Fatal(err)


### PR DESCRIPTION
cmd/kpod/main.go had the apps.Flag repeated, probably something messed up during merge. This fixes that by deleting the repeated portion.
Signed-off-by: umohnani8 <umohnani@redhat.com>