### PR TITLE
cmd/kpod/images.go: Add JSON output option

### DIFF
--- a/cmd/kpod/formats/formats.go
+++ b/cmd/kpod/formats/formats.go
@@ -1,0 +1,54 @@
+package formats
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+	"os"
+	"text/template"
+)
+
+// Writer interface for outputs
+type Writer interface {
+	Out() error
+}
+
+// JSONstruct for JSON output
+type JSONstruct struct {
+	Output []interface{}
+}
+
+// StdoutTemplate for Go template output
+type StdoutTemplate struct {
+	Output   []interface{}
+	Template string
+}
+
+// Out method for JSON
+func (j JSONstruct) Out() error {
+	data, err := json.MarshalIndent(j.Output, "", "    ")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", data)
+	return nil
+}
+
+// Out method for Go templates
+func (t StdoutTemplate) Out() error {
+
+	tmpl, err := template.New("image").Parse(t.Template)
+	if err != nil {
+		return errors.Wrapf(err, "Template parsing error")
+	}
+
+	for _, img := range t.Output {
+		err = tmpl.Execute(os.Stdout, img)
+		if err != nil {
+			return err
+		}
+		fmt.Println()
+	}
+	return nil
+
+}

--- a/completions/bash/kpod
+++ b/completions/bash/kpod
@@ -14,7 +14,6 @@ _kpod_history() {
      --human -H
      --no-trunc
      --quiet -q
-     --json
      "
      _complete_ "$options_with_args" "$boolean_options"
 
@@ -38,11 +37,11 @@ _kpod_images() {
      -n
      --no-trunc
      --digests
-     --format
      --filter
      -f
      "
     local options_with_args="
+    --format
   "
 
     local all_options="$options_with_args $boolean_options"

--- a/docs/kpod-images.1.md
+++ b/docs/kpod-images.1.md
@@ -21,9 +21,10 @@ Show image digests
 
 Filter output based on conditions provided (default [])
 
-**--format="TEMPLATE"**
+**--format**
 
-Pretty-print images using a Go template.  Will override --quiet
+Change the default output format.  This can be of a supported type like 'json'
+or a Go template.
 
 **--noheading, -n**
 
@@ -45,6 +46,10 @@ kpod images
 kpod images --quiet
 
 kpod images -q --noheading --notruncate
+
+kpod images --format json
+
+kpod images --format "{{.ID}}"
 
 ## SEE ALSO
 kpod(1)

--- a/libkpod/common/output_interfaces.go
+++ b/libkpod/common/output_interfaces.go
@@ -1,0 +1,1 @@
+package common

--- a/test/kpod.bats
+++ b/test/kpod.bats
@@ -201,6 +201,7 @@ function teardown() {
 }
     run ${KPOD_BINARY} $KPOD_OPTIONS rmi redis:alpine
 
+
 @test "kpod inspect non-existent container" {
     run ${KPOD_BINARY} $KPOD_OPTIONS inspect 14rcole/non-existent
     echo "$output"
@@ -226,4 +227,24 @@ function teardown() {
     echo "$output"
     [ "$status" -eq 0]
     run ${KPOD_BINARY} $KPOD_OPTIONS rmi redis:alpine
+}
+
+@test "kpod images" {
+    run ${KPOD_BINARY} $KPOD_OPTIONS pull debian:6.0.10
+    run ${KPOD_BINARY} $KPOD_OPTIONS images
+    [ "$status" -eq 0 ]
+}
+
+@test "kpod images test valid json" {
+    run ${KPOD_BINARY} $KPOD_OPTIONS pull debian:6.0.10
+    run ${KPOD_BINARY} $KPOD_OPTIONS images --format json
+    echo "$output" | python -m json.tool
+    [ "$status" -eq 0 ]
+}
+
+@test "kpod images check name json output" {
+    run ${KPOD_BINARY} $KPOD_OPTIONS pull debian:6.0.10
+    run ${KPOD_BINARY} $KPOD_OPTIONS images --format json
+    name=$(echo $output | python -c 'import sys; import json; print(json.loads(sys.stdin.read())[0])["names"][0]')
+    [ "$name" == "docker.io/library/debian:6.0.10" ]
 }


### PR DESCRIPTION
For kpod images, we need to output in JSON format so that consumers
(programatic) have structured input to work with.

Signed-off-by: baude <bbaude@redhat.com>