### PR TITLE
We need to support the name cri-o and crio for rpm and systemd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,7 @@ install.completions:
 install.systemd:
 	install -D -m 644 contrib/systemd/crio.service $(PREFIX)/lib/systemd/system/crio.service
 	install -D -m 644 contrib/systemd/crio-shutdown.service $(PREFIX)/lib/systemd/system/crio-shutdown.service
+	ln -s crio.service $(PREFIX)/lib/systemd/system/cri-o.service
 
 uninstall:
 	rm -f $(BINDIR)/crio

--- a/contrib/rpm/crio.spec
+++ b/contrib/rpm/crio.spec
@@ -18,6 +18,7 @@ Group:          Applications/Text
 License:        Apache 2.0
 URL:            https://%{provider_prefix}
 Source0:        https://%{provider_prefix}/archive/%{commit}/%{repo}-%{shortcommit}.tar.gz
+Provides:       %{repo}
 
 BuildRequires:  golang-github-cpuguy83-go-md2man
 


### PR DESCRIPTION
Adding these aliases will make it easier for users who forget to
use crio or cri-o.
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>