### PR TITLE
Update vendor for containers/image

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -5,7 +5,7 @@ k8s.io/apimachinery release-1.6 https://github.com/kubernetes/apimachinery
 k8s.io/apiserver release-1.6 https://github.com/kubernetes/apiserver
 #
 github.com/Sirupsen/logrus v0.11.5
-github.com/containers/image b36d6535410088370aaaee7ec8522863b5e43489
+github.com/containers/image cd150088f25d1ac81c6dff3a0bf458725cb8b339
 github.com/containers/storage 2c75d14b978bff468e7d5ec3ff8a003eca443209
 github.com/containernetworking/cni v0.4.0
 google.golang.org/grpc v1.0.1-GA https://github.com/grpc/grpc-go

--- a/vendor/github.com/containers/image/MAINTAINERS
+++ b/vendor/github.com/containers/image/MAINTAINERS
@@ -1,0 +1,3 @@
+Antonio Murdaca <runcom@redhat.com> (@runcom)
+Brandon Philips <brandon.philips@coreos.com> (@philips)
+Miloslav Trmac <mitr@redhat.com> (@mtrmac)

--- a/vendor/github.com/containers/image/Makefile
+++ b/vendor/github.com/containers/image/Makefile
@@ -1,0 +1,72 @@
+.PHONY: all tools test validate lint
+
+# Which github repostiory and branch to use for testing with skopeo
+SKOPEO_REPO = projectatomic/skopeo
+SKOPEO_BRANCH = master
+# Set SUDO=sudo to run container integration tests using sudo.
+SUDO =
+BUILDTAGS   = btrfs_noversion libdm_no_deferred_remove
+BUILDFLAGS := -tags "$(BUILDTAGS)"
+
+PACKAGES := $(shell go list ./... | grep -v github.com/containers/image/vendor)
+
+all: tools .gitvalidation test validate
+
+tools: tools.timestamp
+
+tools.timestamp: Makefile
+	@go get -u $(BUILDFLAGS) github.com/golang/lint/golint
+	@go get $(BUILDFLAGS) github.com/vbatts/git-validation
+	@go get -u github.com/rancher/trash
+	@touch tools.timestamp
+
+vendor: tools.timestamp vendor.conf
+	@trash
+	@touch vendor
+
+clean:
+	rm -rf vendor tools.timestamp
+
+test: vendor
+	@go test $(BUILDFLAGS) -cover $(PACKAGES)
+
+# This is not run as part of (make all), but Travis CI does run this.
+# Demonstarting a working version of skopeo (possibly with modified SKOPEO_REPO/SKOPEO_BRANCH, e.g.
+#    make test-skopeo SKOPEO_REPO=runcom/skopeo-1 SKOPEO_BRANCH=oci-3 SUDO=sudo
+# ) is a requirement before merging; note that Travis will only test
+# the master branch of the upstream repo.
+test-skopeo:
+	@echo === Testing skopeo build
+	@export GOPATH=$$(mktemp -d) && \
+		skopeo_path=$${GOPATH}/src/github.com/projectatomic/skopeo && \
+		vendor_path=$${skopeo_path}/vendor/github.com/containers/image && \
+		git clone -b $(SKOPEO_BRANCH) https://github.com/$(SKOPEO_REPO) $${skopeo_path} && \
+		rm -rf $${vendor_path} && cp -r . $${vendor_path} && rm -rf $${vendor_path}/vendor && \
+		cd $${skopeo_path} && \
+		make BUILDTAGS="$(BUILDTAGS)" binary-local test-all-local && \
+		$(SUDO) make BUILDTAGS="$(BUILDTAGS)" check && \
+		rm -rf $${skopeo_path}
+
+validate: lint
+	@go vet $(PACKAGES)
+	@test -z "$$(gofmt -s -l . | grep -ve '^vendor' | tee /dev/stderr)"
+
+lint:
+	@out="$$(golint $(PACKAGES))"; \
+	if [ -n "$$out" ]; then \
+		echo "$$out"; \
+		exit 1; \
+	fi
+
+.PHONY: .gitvalidation
+
+EPOCH_TEST_COMMIT ?= e68e0e1110e64f906f9b482e548f17d73e02e6b1
+
+# When this is running in travis, it will only check the travis commit range
+.gitvalidation:
+	@which git-validation > /dev/null 2>/dev/null || (echo "ERROR: git-validation not found. Consider 'make clean && make tools'" && false)
+ifeq ($(TRAVIS),true)
+	@git-validation -q -run DCO,short-subject,dangling-whitespace
+else
+	@git-validation -q -run DCO,short-subject,dangling-whitespace -range $(EPOCH_TEST_COMMIT)..HEAD
+endif

--- a/vendor/github.com/containers/image/README.md
+++ b/vendor/github.com/containers/image/README.md
@@ -20,27 +20,49 @@ to another, for example docker container images to OCI images. It also allows
 you to copy container images between various registries, possibly converting
 them as necessary, and to sign and verify images.
 
+## Command-line usage
+
+The containers/image project is only a library with no user interface;
+you can either incorporate it into your Go programs, or use the `skopeo` tool:
+
 The [skopeo](https://github.com/projectatomic/skopeo) tool uses the
-containers/image library and takes advantage of its many features.
+containers/image library and takes advantage of many of its features,
+e.g. `skopeo copy` exposes the `containers/image/copy.Image` functionality.
 
 ## Dependencies
 
-Dependencies that this library prefers will not be found in the `vendor`
-directory. This is so you can make well-informed decisions about which
-libraries you should use with this package in your own projects.
+This library does not ship a committed version of its dependencies in a `vendor`
+subdirectory.  This is so you can make well-informed decisions about which
+libraries you should use with this package in your own projects, and because
+types defined in the `vendor` directory would be impossible to use from your projects.
 
 What this project tests against dependencies-wise is located
-[here](https://github.com/containers/image/blob/master/vendor.conf).
+[in vendor.conf](https://github.com/containers/image/blob/master/vendor.conf).
 
 ## Building
 
-For ordinary use, `go build ./...` is sufficient.
+If you want to see what the library can do, or an example of how it is called,
+consider starting with the [skopeo](https://github.com/projectatomic/skopeo) tool
+instead.
 
-When developing this library, please use `make` to take advantage of the tests and validation.
+To integrate this library into your project, put it into `$GOPATH` or use
+your preferred vendoring tool to include a copy in your project.
+Ensure that the dependencies documented [in vendor.conf](https://github.com/containers/image/blob/master/vendor.conf)
+are also available
+(using those exact versions or different versions of your choosing).
 
-Optionally, you can use the `containers_image_openpgp` build tag (using `go build -tags …`, or `make … BUILDTAGS=…`).
+This library, by default, also depends on the GpgME C library. Either install it:
+```sh
+Fedora$ dnf install gpgme-devel libassuan-devel
+macOS$ brew install gpgme
+```
+or use the `containers_image_openpgp` build tag (e.g. using `go build -tags …`)
 This will use a Golang-only OpenPGP implementation for signature verification instead of the default cgo/gpgme-based implementation;
 the primary downside is that creating new signatures with the Golang-only implementation is not supported.
+
+## Contributing
+
+When developing this library, please use `make` (or `make … BUILDTAGS=…`) to take advantage of the tests and validation.
 
 ## License
 

--- a/vendor/github.com/containers/image/doc.go
+++ b/vendor/github.com/containers/image/doc.go
@@ -1,0 +1,29 @@
+// Package image provides libraries and commands to interact with containers images.
+//
+// 	package main
+//
+// 	import (
+// 		"fmt"
+//
+// 		"github.com/containers/image/docker"
+// 	)
+//
+// 	func main() {
+// 		ref, err := docker.ParseReference("//fedora")
+// 		if err != nil {
+// 			panic(err)
+// 		}
+// 		img, err := ref.NewImage(nil)
+// 		if err != nil {
+// 			panic(err)
+// 		}
+// 		defer img.Close()
+// 		b, _, err := img.Manifest()
+// 		if err != nil {
+// 			panic(err)
+// 		}
+// 		fmt.Printf("%s", string(b))
+// 	}
+//
+// TODO(runcom)
+package image

--- a/vendor/github.com/containers/image/vendor.conf
+++ b/vendor/github.com/containers/image/vendor.conf
@@ -1,5 +1,5 @@
 github.com/Sirupsen/logrus 7f4b1adc791766938c29457bed0703fb9134421a
-github.com/containers/storage 29d2c86eadb88a0cbfbbedec8762126a3987d4c3
+github.com/containers/storage 989b1c1d85f5dfe2076c67b54289cc13dc836c8c
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution df5327f76fb6468b84a87771e361762b8be23fdb
 github.com/docker/docker 75843d36aa5c3eaade50da005f9e0ff2602f3d5e
@@ -34,3 +34,4 @@ github.com/xeipuuv/gojsonpointer master
 github.com/tchap/go-patricia v2.2.6
 github.com/opencontainers/selinux ba1aefe8057f1d0cfb8e88d0ec1dc85925ef987d
 github.com/BurntSushi/toml b26d9c308763d68093482582cea63d69be07a0f0
+github.com/ostreedev/ostree-go 61532f383f1f48e5c27080b0b9c8b022c3706a97


### PR DESCRIPTION
Update the vendored commit for containers/image, because the previous version did not include the function ListNames() in transports.  This is needed for #636 