### PR TITLE
Replace sync.Mutex with sync.Locker to allow different locks

### DIFF
--- a/oci/container.go
+++ b/oci/container.go
@@ -37,7 +37,7 @@ type Container struct {
 	trusted     bool
 	state       *ContainerState
 	metadata    *pb.ContainerMetadata
-	opLock      sync.Mutex
+	opLock      sync.Locker
 	// this is the /var/run/storage/... directory, erased on reboot
 	bundlePath string
 	// this is the /var/lib/storage/... directory
@@ -79,6 +79,7 @@ func NewContainer(id string, name string, bundlePath string, logPath string, net
 		dir:         dir,
 		state:       state,
 		stopSignal:  stopSignal,
+		opLock:      new(sync.Mutex),
 	}
 	return c, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -57,7 +57,7 @@ type Server struct {
 	store                sstorage.Store
 	storageImageServer   storage.ImageServer
 	storageRuntimeServer storage.RuntimeServer
-	stateLock            sync.Mutex
+	stateLock            sync.Locker
 	updateLock           sync.RWMutex
 	state                *serverState
 	netPlugin            ocicni.CNIPlugin
@@ -589,6 +589,7 @@ func New(config *Config) (*Server, error) {
 		store:                store,
 		storageImageServer:   imageService,
 		storageRuntimeServer: storageRuntimeService,
+		stateLock:            new(sync.Mutex),
 		netPlugin:            netPlugin,
 		hostportManager:      hostportManager,
 		config:               *config,


### PR DESCRIPTION
Once kpod is allowed to create and modify pods & containers, we will need to be able to lock shared state to prevent the two from trampling each other. This PR begins the process of allowing file-based locks to enable this.