### PR TITLE
Make the README.md more useful in links to man page documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ The plan is to use OCI projects and best of breed libraries for different aspect
 
 It is currently in active development in the Kubernetes community through the [design proposal](https://github.com/kubernetes/kubernetes/pull/26788).  Questions and issues should be raised in the Kubernetes [sig-node Slack channel](https://kubernetes.slack.com/archives/sig-node).
 
+## Commands
+| Command                                              | Description                                                                                          |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [crio(8)](/docs/crio.8.md)                 | Enable OCI Kubernetes Container Runtime daemon |
+| [kpod(1)](/docs/kpod.1.md)                 | Simple management tool for pods and images |
+| [kpod-images(1)](/docs/kpod-images.1.md)   | List images in local storage |
+| [kpod-pull(1)](/docs/kpod-pull.1.md)       | Pull an image from a registry |
+| [kpod-rmi(1)](/docs/kpod-rmi.1.md)         | Removes one or more images   |
+| [kpod-tag(1)](/docs/kpod-tag.1.md)         | Add an additional name to a local image |
+| [kpod-version(1)](/docs/kpod-version.1.md) | Display the Kpod Version Information |
+
+## Configuration
+| File                                       | Description                                                                                          |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [crio.conf(5)](/docs/crio.conf.5.md)       | CRI-O Configuation file |
+
 ## Communication
 
 For async communication and long running discussions please use issues and pull requests on the github repo. This will be the best place to discuss design and implementation.

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -2,7 +2,7 @@
 % Dan Walsh
 % SEPTEMBER 2016
 # NAME
-crio - Enable OCI Kubernetes Container Runtime daemon
+crio - OCI Kubernetes Container Runtime daemon
 
 # SYNOPSIS
 **crio**

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -3,10 +3,10 @@
 % OCTOBER 2016
 
 # NAME
-crio.conf - Syntax of CRIO configuration file
+crio.conf - CRI-O configuration file
 
 # DESCRIPTION
-The CRIO configuration file specifies all of the available command-line options
+The CRI-O configuration file specifies all of the available command-line options
 for the crio(8) program, but in a TOML format that can be more easily modified
 and versioned.
 

--- a/docs/kpod-images.1.md
+++ b/docs/kpod-images.1.md
@@ -1,4 +1,6 @@
-## kpod-images "1" "March 2017" "kpod"
+% kpod(1) kpod-images - List images in local storage.
+% Dan Walsh
+# kpod-images "1" "March 2017" "kpod"
 
 ## NAME
 kpod images - List images in local storage.
@@ -46,3 +48,6 @@ kpod images -q --noheading --notruncate
 
 ## SEE ALSO
 kpod(1)
+
+## HISTORY
+March 2017, Originally compiled by Dan Walsh <dwalsh@redhat.com>

--- a/docs/kpod-pull.1.md
+++ b/docs/kpod-pull.1.md
@@ -1,15 +1,16 @@
-% kpod(8) # kpod-pull - Simple tool to pull an image from a registry
+% kpod(1) kpod-pull - Simple tool to pull an image from a registry
 % Urvashi Mohnani
-% JULY 2017
-# NAME
+# kpod-pull "1" "July 2017" "kpod"
+
+## NAME
 kpod-pull - Pull an image from a registry
 
-# SYNOPSIS
+## SYNOPSIS
 **kpod pull**
 **NAME[:TAG|@DISGEST]**
 [**--help**|**-h**]
 
-# DESCRIPTION
+## DESCRIPTION
 Copies an image from a registry onto the local machine. **kpod pull** pulls an
 image from Docker Hub if a registry is not specified in the command line argument.
 If an image tag is not specified, **kpod pull** defaults to the image with the
@@ -22,18 +23,13 @@ using its digest **kpod pull [image]@[digest]**.
 
 **kpod pull NAME[:TAG|@DIGEST] [GLOBAL OPTIONS]**
 
-# GLOBAL OPTIONS
+## GLOBAL OPTIONS
 
 **--help, -h**
   Print usage statement
 
-# COMMANDS
-
-## pull
-Pull an image from a registry
-
-# SEE ALSO
+## SEE ALSO
 kpod(1), crio(8), crio.conf(5)
 
-# HISTORY
+## HISTORY
 July 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/kpod-rmi.1.md
+++ b/docs/kpod-rmi.1.md
@@ -1,4 +1,6 @@
-## kpod-rmi "1" "March 2017" "kpod"
+% kpod(1) kpod-rmi - Removes one or more images
+% Dan Walsh
+# kpod-rmi "1" "March 2017" "kpod"
 
 ## NAME
 kpod rmi - Removes one or more images.
@@ -25,3 +27,6 @@ kpod rmi imageID1 imageID2 imageID3
 
 ## SEE ALSO
 kpod(1)
+
+## HISTORY
+March 2017, Originally compiled by Dan Walsh <dwalsh@redhat.com>

--- a/docs/kpod-tag.1.md
+++ b/docs/kpod-tag.1.md
@@ -1,29 +1,34 @@
-## kpod-tag "1" "June 2017" "kpod"
+% kpod(1) kpod-tag - add tags to an image
+% Ryan Cole
+# kpod-tag "1" "July 2017" "kpod"
 
-# NAME
-kpod tag - add tags to an image
+## NAME
+kpod tag - Add an additional name to a local image
 
-# SYNOPSIS
+## SYNOPSIS
 **kpod tag**
 [**--help**|**-h**]
 
-# DESCRIPTION
+## DESCRIPTION
 Assigns a new alias to an image in a registry.  An alias refers to the entire image name, including the optional **TAG** after the ':'
 
 **kpod [GLOBAL OPTIONS]**
 
 **kpod [GLOBAL OPTIONS] tag [OPTIONS]**
 
-# GLOBAL OPTIONS
+## GLOBAL OPTIONS
 
 **--help, -h**
   Print usage statement
 
-# EXAMPLES
+## EXAMPLES
 
   kpod tag 0e3bbc2 fedora:latest
 
   kpod tag httpd myregistryhost:5000/fedora/httpd:v2
 
-# SEE ALSO
+## SEE ALSO
 kpod(1), crio(8), crio.conf(5)
+
+## HISTORY
+July 2017, Originally compiled by Ryan Cole <rycole@redhat.com>

--- a/docs/kpod-version.1.md
+++ b/docs/kpod-version.1.md
@@ -1,14 +1,14 @@
-% kpod(8) # kpod-version - Simple tool to view version information
-% Dan Walsh
-% SEPTEMBER 2016
-# NAME
+% kpod(1) kpod-version - Simple tool to view version information
+% Urvashi Mohnani
+# kpod-version "1" "July 2017" "kpod"
+## NAME
 kpod-version - Display the KPOD Version Information
 
-# SYNOPSIS
+## SYNOPSIS
 **kpod version**
 [**--help**|**-h**]
 
-# DESCRIPTION
+## DESCRIPTION
 Shows the the following information: Version, Go Version, Git Commit, Build Time,
 OS, and Architecture.
 
@@ -16,18 +16,13 @@ OS, and Architecture.
 
 **kpod [GLOBAL OPTIONS] version [OPTIONS]**
 
-# GLOBAL OPTIONS
+## GLOBAL OPTIONS
 
 **--help, -h**
   Print usage statement
 
-# COMMANDS
-
-## version
-Display the KPOD Version Information
-
-# SEE ALSO
+## SEE ALSO
 kpod(1), crio(8), crio.conf(5)
 
-# HISTORY
-Dec 2016, Originally compiled by Dan Walsh <dwalsh@redhat.com>
+## HISTORY
+July 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/kpod.1.md
+++ b/docs/kpod.1.md
@@ -1,10 +1,10 @@
-% kpod(8) # kpod - Simple management tool for pods and images
+% kpod(1) kpod - Simple management tool for pods and images
 % Dan Walsh
-% SEPTEMBER 2016
-# NAME
-kpod
+# kpod "1" "September 2016" "kpod"
+## NAME
+kpod - Simple management tool for containers and images
 
-# SYNOPSIS
+## SYNOPSIS
 **kpod**
 [**--help**|**-h**]
 
@@ -19,7 +19,7 @@ has the capability to debug pods/images created by crio.
 
 **kpod [GLOBAL OPTIONS]**
 
-# GLOBAL OPTIONS
+## GLOBAL OPTIONS
 
 **--help, -h**
   Print usage statement
@@ -27,19 +27,19 @@ has the capability to debug pods/images created by crio.
 **--version, -v**
   Print the version
 
-# COMMANDS
+## COMMANDS
 
-## images
+### images
 List images in local storage
 
-## rmi
+### rmi
 Removes one or more locally stored images
 
-## tag
+### tag
 Add one or more additional names to locally-stored image
 
-# SEE ALSO
+## SEE ALSO
 crio(8), crio.conf(5)
 
-# HISTORY
+## HISTORY
 Dec 2016, Originally compiled by Dan Walsh <dwalsh@redhat.com>


### PR DESCRIPTION
This patch will allow people who go to the github page to easily read
man pages.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>