### PR TITLE
oci: fix type mismatch on some platform/arch

### DIFF
--- a/oci/finished.go
+++ b/oci/finished.go
@@ -1,0 +1,14 @@
+// +build !arm !386
+
+package oci
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func getFinishedTime(fi os.FileInfo) time.Time {
+	st := fi.Sys().(*syscall.Stat_t)
+	return time.Unix(st.Ctim.Sec, st.Ctim.Nsec)
+}

--- a/oci/finished_32.go
+++ b/oci/finished_32.go
@@ -1,0 +1,14 @@
+// +build arm 386
+
+package oci
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func getFinishedTime(fi os.FileInfo) time.Time {
+	st := fi.Sys().(*syscall.Stat_t)
+	return time.Unix(int64(st.Ctim.Sec), int64(st.Ctim.Nsec))
+}

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -585,9 +585,7 @@ func (r *Runtime) UpdateStatus(c *Container) error {
 			logrus.Warnf("failed to find container exit file: %v", err)
 			c.state.ExitCode = -1
 		} else {
-			st := fi.Sys().(*syscall.Stat_t)
-			c.state.Finished = time.Unix(st.Ctim.Sec, st.Ctim.Nsec)
-
+			c.state.Finished = getFinishedTime(fi)
 			statusCodeStr, err := ioutil.ReadFile(exitFilePath)
 			if err != nil {
 				return fmt.Errorf("failed to read exit file: %v", err)


### PR DESCRIPTION
Should fix #302 

@lsm5 @cyphar could you test this out in Fedora and Suse? Like using my cri-o remote github + this branch to test it out.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>