### PR TITLE
Decouple kubernetes-dependent and non-dependent parts of server

### DIFF
--- a/libkpod/containerserver.go
+++ b/libkpod/containerserver.go
@@ -1,0 +1,62 @@
+package libkpod
+
+import (
+	"github.com/containers/image/types"
+	cstorage "github.com/containers/storage"
+	"github.com/docker/docker/pkg/registrar"
+	"github.com/docker/docker/pkg/truncindex"
+	"github.com/kubernetes-incubator/cri-o/oci"
+	"github.com/kubernetes-incubator/cri-o/pkg/storage"
+)
+
+// ContainerServer implements the ImageServer
+type ContainerServer struct {
+	runtime            *oci.Runtime
+	store              cstorage.Store
+	storageImageServer storage.ImageServer
+	ctrNameIndex       *registrar.Registrar
+	ctrIDIndex         *truncindex.TruncIndex
+	imageContext       *types.SystemContext
+}
+
+// Runtime returns the oci runtime for the ContainerServer
+func (c *ContainerServer) Runtime() *oci.Runtime {
+	return c.runtime
+}
+
+// Store returns the Store for the ContainerServer
+func (c *ContainerServer) Store() cstorage.Store {
+	return c.store
+}
+
+// StorageImageServer returns the ImageServer for the ContainerServer
+func (c *ContainerServer) StorageImageServer() storage.ImageServer {
+	return c.storageImageServer
+}
+
+// CtrNameIndex returns the Registrar for the ContainerServer
+func (c *ContainerServer) CtrNameIndex() *registrar.Registrar {
+	return c.ctrNameIndex
+}
+
+// CtrIDIndex returns the TruncIndex for the ContainerServer
+func (c *ContainerServer) CtrIDIndex() *truncindex.TruncIndex {
+	return c.ctrIDIndex
+}
+
+// ImageContext returns the SystemContext for the ContainerServer
+func (c *ContainerServer) ImageContext() *types.SystemContext {
+	return c.imageContext
+}
+
+// New creates a new ContainerServer
+func New(runtime *oci.Runtime, store cstorage.Store, storageImageServer storage.ImageServer, ctrNameIndex *registrar.Registrar, ctrIDIndex *truncindex.TruncIndex, imageContext *types.SystemContext) *ContainerServer {
+	return &ContainerServer{
+		runtime:            runtime,
+		store:              store,
+		storageImageServer: storageImageServer,
+		ctrNameIndex:       ctrNameIndex,
+		ctrIDIndex:         ctrIDIndex,
+		imageContext:       imageContext,
+	}
+}

--- a/server/container.go
+++ b/server/container.go
@@ -11,7 +11,7 @@ func (s *Server) getContainerFromRequest(cid string) (*oci.Container, error) {
 		return nil, fmt.Errorf("container ID should not be empty")
 	}
 
-	containerID, err := s.ctrIDIndex.Get(cid)
+	containerID, err := s.CtrIDIndex().Get(cid)
 	if err != nil {
 		return nil, fmt.Errorf("container with ID starting with %s not found: %v", cid, err)
 	}

--- a/server/container_attach.go
+++ b/server/container_attach.go
@@ -44,11 +44,11 @@ func (ss streamService) Attach(containerID string, inputStream io.Reader, output
 		return fmt.Errorf("could not find container %q", containerID)
 	}
 
-	if err := ss.runtimeServer.runtime.UpdateStatus(c); err != nil {
+	if err := ss.runtimeServer.Runtime().UpdateStatus(c); err != nil {
 		return err
 	}
 
-	cState := ss.runtimeServer.runtime.ContainerStatus(c)
+	cState := ss.runtimeServer.Runtime().ContainerStatus(c)
 	if !(cState.Status == oci.ContainerStateRunning || cState.Status == oci.ContainerStateCreated) {
 		return fmt.Errorf("container is not created or running")
 	}

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -319,17 +319,17 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 		}
 	}()
 
-	if err = s.runtime.CreateContainer(container, sb.cgroupParent); err != nil {
+	if err = s.Runtime().CreateContainer(container, sb.cgroupParent); err != nil {
 		return nil, err
 	}
 
-	if err = s.runtime.UpdateStatus(container); err != nil {
+	if err = s.Runtime().UpdateStatus(container); err != nil {
 		return nil, err
 	}
 
 	s.addContainer(container)
 
-	if err = s.ctrIDIndex.Add(containerID); err != nil {
+	if err = s.CtrIDIndex().Add(containerID); err != nil {
 		s.removeContainer(container)
 		return nil, err
 	}
@@ -522,7 +522,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		}
 	}
 	// Join the namespace paths for the pod sandbox container.
-	podInfraState := s.runtime.ContainerStatus(sb.infraContainer)
+	podInfraState := s.Runtime().ContainerStatus(sb.infraContainer)
 
 	logrus.Debugf("pod container state %+v", podInfraState)
 
@@ -611,7 +611,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 
 	metaname := metadata.Name
 	attempt := metadata.Attempt
-	containerInfo, err := s.storageRuntimeServer.CreateContainer(s.imageContext,
+	containerInfo, err := s.storageRuntimeServer.CreateContainer(s.ImageContext(),
 		sb.name, sb.id,
 		image, image,
 		containerName, containerID,

--- a/server/container_exec.go
+++ b/server/container_exec.go
@@ -36,11 +36,11 @@ func (ss streamService) Exec(containerID string, cmd []string, stdin io.Reader, 
 		return fmt.Errorf("could not find container %q", containerID)
 	}
 
-	if err := ss.runtimeServer.runtime.UpdateStatus(c); err != nil {
+	if err := ss.runtimeServer.Runtime().UpdateStatus(c); err != nil {
 		return err
 	}
 
-	cState := ss.runtimeServer.runtime.ContainerStatus(c)
+	cState := ss.runtimeServer.Runtime().ContainerStatus(c)
 	if !(cState.Status == oci.ContainerStateRunning || cState.Status == oci.ContainerStateCreated) {
 		return fmt.Errorf("container is not created or running")
 	}
@@ -51,7 +51,7 @@ func (ss streamService) Exec(containerID string, cmd []string, stdin io.Reader, 
 	}
 	args = append(args, c.ID())
 	args = append(args, cmd...)
-	execCmd := exec.Command(ss.runtimeServer.runtime.Path(c), args...)
+	execCmd := exec.Command(ss.runtimeServer.Runtime().Path(c), args...)
 	var cmdErr error
 	if tty {
 		p, err := kubecontainer.StartPty(execCmd)

--- a/server/container_execsync.go
+++ b/server/container_execsync.go
@@ -17,11 +17,11 @@ func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (*pb.Exe
 		return nil, err
 	}
 
-	if err = s.runtime.UpdateStatus(c); err != nil {
+	if err = s.Runtime().UpdateStatus(c); err != nil {
 		return nil, err
 	}
 
-	cState := s.runtime.ContainerStatus(c)
+	cState := s.Runtime().ContainerStatus(c)
 	if !(cState.Status == oci.ContainerStateRunning || cState.Status == oci.ContainerStateCreated) {
 		return nil, fmt.Errorf("container is not created or running")
 	}
@@ -31,7 +31,7 @@ func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (*pb.Exe
 		return nil, fmt.Errorf("exec command cannot be empty")
 	}
 
-	execResp, err := s.runtime.ExecSync(c, cmd, req.Timeout)
+	execResp, err := s.Runtime().ExecSync(c, cmd, req.Timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -36,7 +36,7 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 	// Filter using container id and pod id first.
 	if filter != nil {
 		if filter.Id != "" {
-			id, err := s.ctrIDIndex.Get(filter.Id)
+			id, err := s.CtrIDIndex().Get(filter.Id)
 			if err != nil {
 				return nil, err
 			}
@@ -66,12 +66,12 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 	}
 
 	for _, ctr := range ctrList {
-		if err := s.runtime.UpdateStatus(ctr); err != nil {
+		if err := s.Runtime().UpdateStatus(ctr); err != nil {
 			return nil, err
 		}
 
 		podSandboxID := ctr.Sandbox()
-		cState := s.runtime.ContainerStatus(ctr)
+		cState := s.Runtime().ContainerStatus(ctr)
 		created := cState.Created.UnixNano()
 		rState := pb.ContainerState_CONTAINER_UNKNOWN
 		cID := ctr.ID()

--- a/server/container_portforward.go
+++ b/server/container_portforward.go
@@ -34,11 +34,11 @@ func (ss streamService) PortForward(podSandboxID string, port int32, stream io.R
 		return fmt.Errorf("could not find container for sandbox %q", podSandboxID)
 	}
 
-	if err := ss.runtimeServer.runtime.UpdateStatus(c); err != nil {
+	if err := ss.runtimeServer.Runtime().UpdateStatus(c); err != nil {
 		return err
 	}
 
-	cState := ss.runtimeServer.runtime.ContainerStatus(c)
+	cState := ss.runtimeServer.Runtime().ContainerStatus(c)
 	if !(cState.Status == oci.ContainerStateRunning || cState.Status == oci.ContainerStateCreated) {
 		return fmt.Errorf("container is not created or running")
 	}

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -18,13 +18,13 @@ func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerReq
 		return nil, err
 	}
 
-	if err := s.runtime.UpdateStatus(c); err != nil {
+	if err := s.Runtime().UpdateStatus(c); err != nil {
 		return nil, fmt.Errorf("failed to update container state: %v", err)
 	}
 
-	cState := s.runtime.ContainerStatus(c)
+	cState := s.Runtime().ContainerStatus(c)
 	if cState.Status == oci.ContainerStateCreated || cState.Status == oci.ContainerStateRunning {
-		if err := s.runtime.StopContainer(c, -1); err != nil {
+		if err := s.Runtime().StopContainer(c, -1); err != nil {
 			return nil, fmt.Errorf("failed to stop container %s: %v", c.ID(), err)
 		}
 		if err := s.storageRuntimeServer.StopContainer(c.ID()); err != nil {
@@ -32,7 +32,7 @@ func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerReq
 		}
 	}
 
-	if err := s.runtime.DeleteContainer(c); err != nil {
+	if err := s.Runtime().DeleteContainer(c); err != nil {
 		return nil, fmt.Errorf("failed to delete container %s: %v", c.ID(), err)
 	}
 
@@ -44,7 +44,7 @@ func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerReq
 
 	s.releaseContainerName(c.Name())
 
-	if err := s.ctrIDIndex.Delete(c.ID()); err != nil {
+	if err := s.CtrIDIndex().Delete(c.ID()); err != nil {
 		return nil, err
 	}
 

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -16,7 +16,7 @@ func (s *Server) StartContainer(ctx context.Context, req *pb.StartContainerReque
 	if err != nil {
 		return nil, err
 	}
-	state := s.runtime.ContainerStatus(c)
+	state := s.Runtime().ContainerStatus(c)
 	if state.Status != oci.ContainerStateCreated {
 		return nil, fmt.Errorf("container %s is not in created state: %s", c.ID(), state.Status)
 	}
@@ -27,12 +27,12 @@ func (s *Server) StartContainer(ctx context.Context, req *pb.StartContainerReque
 		// adjust container started/finished time and set an error to be
 		// returned in the Reason field for container status call.
 		if err != nil {
-			s.runtime.SetStartFailed(c, err)
+			s.Runtime().SetStartFailed(c, err)
 		}
 		s.containerStateToDisk(c)
 	}()
 
-	err = s.runtime.StartContainer(c)
+	err = s.Runtime().StartContainer(c)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start container %s: %v", c.ID(), err)
 	}

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -26,7 +26,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 		return nil, err
 	}
 
-	if err = s.runtime.UpdateStatus(c); err != nil {
+	if err = s.Runtime().UpdateStatus(c); err != nil {
 		return nil, err
 	}
 	s.containerStateToDisk(c)
@@ -48,7 +48,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 	resp.Status.Mounts = mounts
 
 	imageName := c.Image()
-	status, err := s.storageImageServer.ImageStatus(s.imageContext, imageName)
+	status, err := s.StorageImageServer().ImageStatus(s.ImageContext(), imageName)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 	}
 	resp.Status.Image = &pb.ImageSpec{Image: imageName}
 
-	cState := s.runtime.ContainerStatus(c)
+	cState := s.Runtime().ContainerStatus(c)
 	rStatus := pb.ContainerState_CONTAINER_UNKNOWN
 
 	switch cState.Status {
@@ -122,7 +122,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 }
 
 func (s *Server) getMounts(id string) ([]*pb.Mount, error) {
-	config, err := s.store.FromContainerDirectory(id, "config.json")
+	config, err := s.Store().FromContainerDirectory(id, "config.json")
 	if err != nil {
 		return nil, err
 	}

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -17,12 +17,12 @@ func (s *Server) StopContainer(ctx context.Context, req *pb.StopContainerRequest
 		return nil, err
 	}
 
-	if err := s.runtime.UpdateStatus(c); err != nil {
+	if err := s.Runtime().UpdateStatus(c); err != nil {
 		return nil, err
 	}
-	cStatus := s.runtime.ContainerStatus(c)
+	cStatus := s.Runtime().ContainerStatus(c)
 	if cStatus.Status != oci.ContainerStateStopped {
-		if err := s.runtime.StopContainer(c, req.Timeout); err != nil {
+		if err := s.Runtime().StopContainer(c, req.Timeout); err != nil {
 			return nil, fmt.Errorf("failed to stop container %s: %v", c.ID(), err)
 		}
 		if err := s.storageRuntimeServer.StopContainer(c.ID()); err != nil {

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -17,7 +17,7 @@ func (s *Server) ListImages(ctx context.Context, req *pb.ListImagesRequest) (*pb
 			filter = filterImage.Image
 		}
 	}
-	results, err := s.storageImageServer.ListImages(filter)
+	results, err := s.StorageImageServer().ListImages(filter)
 	if err != nil {
 		return nil, err
 	}

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -51,19 +51,19 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (*pb.P
 		}
 	}
 
-	canPull, err := s.storageImageServer.CanPull(image, options)
+	canPull, err := s.StorageImageServer().CanPull(image, options)
 	if err != nil && !canPull {
 		return nil, err
 	}
 
 	// let's be smart, docker doesn't repull if image already exists.
-	if _, err := s.storageImageServer.ImageStatus(s.imageContext, image); err == nil {
+	if _, err := s.StorageImageServer().ImageStatus(s.ImageContext(), image); err == nil {
 		return &pb.PullImageResponse{
 			ImageRef: image,
 		}, nil
 	}
 
-	if _, err := s.storageImageServer.PullImage(s.imageContext, image, options); err != nil {
+	if _, err := s.StorageImageServer().PullImage(s.ImageContext(), image, options); err != nil {
 		return nil, err
 	}
 	resp := &pb.PullImageResponse{

--- a/server/image_remove.go
+++ b/server/image_remove.go
@@ -19,7 +19,7 @@ func (s *Server) RemoveImage(ctx context.Context, req *pb.RemoveImageRequest) (*
 	if image == "" {
 		return nil, fmt.Errorf("no image specified")
 	}
-	err := s.storageImageServer.RemoveImage(s.imageContext, image)
+	err := s.StorageImageServer().RemoveImage(s.ImageContext(), image)
 	if err != nil {
 		return nil, err
 	}

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -20,7 +20,7 @@ func (s *Server) ImageStatus(ctx context.Context, req *pb.ImageStatusRequest) (*
 	if image == "" {
 		return nil, fmt.Errorf("no image specified")
 	}
-	status, err := s.storageImageServer.ImageStatus(s.imageContext, image)
+	status, err := s.StorageImageServer().ImageStatus(s.ImageContext(), image)
 	if err != nil {
 		if err == storage.ErrImageUnknown {
 			return &pb.ImageStatusResponse{}, nil

--- a/server/runtime_status.go
+++ b/server/runtime_status.go
@@ -9,11 +9,11 @@ import (
 func (s *Server) Status(ctx context.Context, req *pb.StatusRequest) (*pb.StatusResponse, error) {
 
 	// Deal with Runtime conditions
-	runtimeReady, err := s.runtime.RuntimeReady()
+	runtimeReady, err := s.Runtime().RuntimeReady()
 	if err != nil {
 		return nil, err
 	}
-	networkReady, err := s.runtime.NetworkReady()
+	networkReady, err := s.Runtime().NetworkReady()
 	if err != nil {
 		return nil, err
 	}

--- a/server/sandbox_list.go
+++ b/server/sandbox_list.go
@@ -59,11 +59,11 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxReque
 			// it's better not to panic
 			continue
 		}
-		if err := s.runtime.UpdateStatus(podInfraContainer); err != nil {
+		if err := s.Runtime().UpdateStatus(podInfraContainer); err != nil {
 			return nil, err
 		}
 
-		cState := s.runtime.ContainerStatus(podInfraContainer)
+		cState := s.Runtime().ContainerStatus(podInfraContainer)
 		created := cState.Created.UnixNano()
 		rStatus := pb.PodSandboxState_SANDBOX_NOTREADY
 		if cState.Status == oci.ContainerStateRunning {

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -36,19 +36,19 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 
 	// Delete all the containers in the sandbox
 	for _, c := range containers {
-		if err := s.runtime.UpdateStatus(c); err != nil {
+		if err := s.Runtime().UpdateStatus(c); err != nil {
 			return nil, fmt.Errorf("failed to update container state: %v", err)
 		}
 
-		cState := s.runtime.ContainerStatus(c)
+		cState := s.Runtime().ContainerStatus(c)
 		if cState.Status == oci.ContainerStateCreated || cState.Status == oci.ContainerStateRunning {
-			if err := s.runtime.StopContainer(c, -1); err != nil {
+			if err := s.Runtime().StopContainer(c, -1); err != nil {
 				// Assume container is already stopped
 				logrus.Warnf("failed to stop container %s: %v", c.Name(), err)
 			}
 		}
 
-		if err := s.runtime.DeleteContainer(c); err != nil {
+		if err := s.Runtime().DeleteContainer(c); err != nil {
 			return nil, fmt.Errorf("failed to delete container %s in pod sandbox %s: %v", c.Name(), sb.id, err)
 		}
 
@@ -66,7 +66,7 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 
 		s.releaseContainerName(c.Name())
 		s.removeContainer(c)
-		if err := s.ctrIDIndex.Delete(c.ID()); err != nil {
+		if err := s.CtrIDIndex().Delete(c.ID()); err != nil {
 			return nil, fmt.Errorf("failed to delete container %s in pod sandbox %s from index: %v", c.Name(), sb.id, err)
 		}
 	}
@@ -82,7 +82,7 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 	}
 
 	s.releaseContainerName(podInfraContainer.Name())
-	if err := s.ctrIDIndex.Delete(podInfraContainer.ID()); err != nil {
+	if err := s.CtrIDIndex().Delete(podInfraContainer.ID()); err != nil {
 		return nil, fmt.Errorf("failed to delete infra container %s in pod sandbox %s from index: %v", podInfraContainer.ID(), sb.id, err)
 	}
 

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -73,19 +73,19 @@ func (s *Server) trustedSandbox(req *pb.RunPodSandboxRequest) bool {
 }
 
 func (s *Server) runContainer(container *oci.Container, cgroupParent string) error {
-	if err := s.runtime.CreateContainer(container, cgroupParent); err != nil {
+	if err := s.Runtime().CreateContainer(container, cgroupParent); err != nil {
 		return err
 	}
 
-	if err := s.runtime.UpdateStatus(container); err != nil {
+	if err := s.Runtime().UpdateStatus(container); err != nil {
 		return err
 	}
 
-	if err := s.runtime.StartContainer(container); err != nil {
+	if err := s.Runtime().StartContainer(container); err != nil {
 		return err
 	}
 
-	if err := s.runtime.UpdateStatus(container); err != nil {
+	if err := s.Runtime().UpdateStatus(container); err != nil {
 		return err
 	}
 
@@ -152,7 +152,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 	}()
 
-	podContainer, err := s.storageRuntimeServer.CreatePodSandbox(s.imageContext,
+	podContainer, err := s.storageRuntimeServer.CreatePodSandbox(s.ImageContext(),
 		name, id,
 		s.config.PauseImage, "",
 		containerName,
@@ -283,13 +283,13 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, err
 	}
 
-	if err = s.ctrIDIndex.Add(id); err != nil {
+	if err = s.CtrIDIndex().Add(id); err != nil {
 		return nil, err
 	}
 
 	defer func() {
 		if err != nil {
-			if err2 := s.ctrIDIndex.Delete(id); err2 != nil {
+			if err2 := s.CtrIDIndex().Delete(id); err2 != nil {
 				logrus.Warnf("couldn't delete ctr id %s from idIndex", id)
 			}
 		}

--- a/server/sandbox_status.go
+++ b/server/sandbox_status.go
@@ -16,12 +16,12 @@ func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusR
 	}
 
 	podInfraContainer := sb.infraContainer
-	if err = s.runtime.UpdateStatus(podInfraContainer); err != nil {
+	if err = s.Runtime().UpdateStatus(podInfraContainer); err != nil {
 		return nil, err
 	}
 	s.containerStateToDisk(podInfraContainer)
 
-	cState := s.runtime.ContainerStatus(podInfraContainer)
+	cState := s.Runtime().ContainerStatus(podInfraContainer)
 
 	netNsPath, err := podInfraContainer.NetNsPath()
 	if err != nil {

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -68,12 +68,12 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 	containers = append(containers, podInfraContainer)
 
 	for _, c := range containers {
-		if err := s.runtime.UpdateStatus(c); err != nil {
+		if err := s.Runtime().UpdateStatus(c); err != nil {
 			return nil, err
 		}
-		cStatus := s.runtime.ContainerStatus(c)
+		cStatus := s.Runtime().ContainerStatus(c)
 		if cStatus.Status != oci.ContainerStateStopped {
-			if err := s.runtime.StopContainer(c, -1); err != nil {
+			if err := s.Runtime().StopContainer(c, -1); err != nil {
 				return nil, fmt.Errorf("failed to stop container %s in pod sandbox %s: %v", c.Name(), sb.id, err)
 			}
 			if c.ID() == podInfraContainer.ID() {

--- a/server/version.go
+++ b/server/version.go
@@ -8,7 +8,7 @@ import (
 // Version returns the runtime name, runtime version and runtime API version
 func (s *Server) Version(ctx context.Context, req *pb.VersionRequest) (*pb.VersionResponse, error) {
 
-	runtimeVersion, err := s.runtime.Version()
+	runtimeVersion, err := s.Runtime().Version()
 	if err != nil {
 		return nil, err
 	}
@@ -18,7 +18,7 @@ func (s *Server) Version(ctx context.Context, req *pb.VersionRequest) (*pb.Versi
 
 	// taking const address
 	rav := runtimeAPIVersion
-	runtimeName := s.runtime.Name()
+	runtimeName := s.Runtime().Name()
 
 	return &pb.VersionResponse{
 		Version:           version,


### PR DESCRIPTION
Move non-kubernetes-dependent portions of server struct to libkpod.  So far, only the struct fields have been moved and not their dependent functions