### PR TITLE
Remove ImageSpec dependency from server

### DIFF
--- a/oci/container.go
+++ b/oci/container.go
@@ -27,7 +27,7 @@ type Container struct {
 	logPath     string
 	labels      fields.Set
 	annotations fields.Set
-	image       *pb.ImageSpec
+	image       string
 	sandbox     string
 	netns       ns.NetNS
 	terminal    bool
@@ -57,7 +57,7 @@ type ContainerState struct {
 }
 
 // NewContainer creates a container object.
-func NewContainer(id string, name string, bundlePath string, logPath string, netns ns.NetNS, labels map[string]string, annotations map[string]string, image *pb.ImageSpec, metadata *pb.ContainerMetadata, sandbox string, terminal bool, stdin bool, stdinOnce bool, privileged bool, trusted bool, dir string, created time.Time, stopSignal string) (*Container, error) {
+func NewContainer(id string, name string, bundlePath string, logPath string, netns ns.NetNS, labels map[string]string, annotations map[string]string, image string, metadata *pb.ContainerMetadata, sandbox string, terminal bool, stdin bool, stdinOnce bool, privileged bool, trusted bool, dir string, created time.Time, stopSignal string) (*Container, error) {
 	state := &ContainerState{}
 	state.Created = created
 	c := &Container{
@@ -151,7 +151,7 @@ func (c *Container) Annotations() map[string]string {
 }
 
 // Image returns the image of the container.
-func (c *Container) Image() *pb.ImageSpec {
+func (c *Container) Image() string {
 	return c.image
 }
 

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -714,7 +714,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		return nil, err
 	}
 
-	container, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, sb.netNs(), labels, kubeAnnotations, imageSpec, metadata, sb.id, containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.privileged, sb.trusted, containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
+	container, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, sb.netNs(), labels, kubeAnnotations, image, metadata, sb.id, containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.privileged, sb.trusted, containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -75,7 +75,9 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 		created := cState.Created.UnixNano()
 		rState := pb.ContainerState_CONTAINER_UNKNOWN
 		cID := ctr.ID()
-
+		img := &pb.ImageSpec{
+			Image: ctr.Image(),
+		}
 		c := &pb.Container{
 			Id:           cID,
 			PodSandboxId: podSandboxID,
@@ -83,7 +85,7 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 			Labels:       ctr.Labels(),
 			Metadata:     ctr.Metadata(),
 			Annotations:  ctr.Annotations(),
-			Image:        ctr.Image(),
+			Image:        img,
 		}
 
 		switch cState.Status {

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -47,7 +47,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 	}
 	resp.Status.Mounts = mounts
 
-	imageName := c.Image().Image
+	imageName := c.Image()
 	status, err := s.storageImageServer.ImageStatus(s.imageContext, imageName)
 	if err != nil {
 		return nil, err

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -475,7 +475,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, fmt.Errorf("failed to write runtime configuration for pod sandbox %s(%s): %v", sb.name, id, err)
 	}
 
-	container, err := oci.NewContainer(id, containerName, podContainer.RunDir, logPath, sb.netNs(), labels, kubeAnnotations, nil, nil, id, false, false, false, sb.privileged, sb.trusted, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
+	container, err := oci.NewContainer(id, containerName, podContainer.RunDir, logPath, sb.netNs(), labels, kubeAnnotations, "", nil, id, false, false, false, sb.privileged, sb.trusted, podContainer.Dir, created, podContainer.Config.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -140,12 +140,9 @@ func (s *Server) loadContainer(id string) error {
 		return err
 	}
 
-	var img *pb.ImageSpec
-	image, ok := m.Annotations[annotations.Image]
-	if ok {
-		img = &pb.ImageSpec{
-			Image: image,
-		}
+	img, ok := m.Annotations[annotations.Image]
+	if !ok {
+		img = ""
 	}
 
 	kubeAnnotations := make(map[string]string)
@@ -316,7 +313,7 @@ func (s *Server) loadSandbox(id string) error {
 		return err
 	}
 
-	scontainer, err := oci.NewContainer(m.Annotations[annotations.ContainerID], cname, sandboxPath, m.Annotations[annotations.LogPath], sb.netNs(), labels, kubeAnnotations, nil, nil, id, false, false, false, privileged, trusted, sandboxDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
+	scontainer, err := oci.NewContainer(m.Annotations[annotations.ContainerID], cname, sandboxPath, m.Annotations[annotations.LogPath], sb.netNs(), labels, kubeAnnotations, "", nil, id, false, false, false, privileged, trusted, sandboxDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
ImageSpec just contains a string, so replacing instances of ImageSpec with string in oci.Containter{} is a simple step towards removing kubernetes dependence in kpod