### PR TITLE
move container state to libkpod

### DIFF
--- a/libkpod/containerserver.go
+++ b/libkpod/containerserver.go
@@ -1,6 +1,8 @@
 package libkpod
 
 import (
+	"sync"
+
 	"github.com/containers/image/types"
 	cstorage "github.com/containers/storage"
 	"github.com/docker/docker/pkg/registrar"
@@ -17,6 +19,8 @@ type ContainerServer struct {
 	ctrNameIndex       *registrar.Registrar
 	ctrIDIndex         *truncindex.TruncIndex
 	imageContext       *types.SystemContext
+	stateLock          sync.Locker
+	state              *containerServerState
 }
 
 // Runtime returns the oci runtime for the ContainerServer
@@ -51,6 +55,7 @@ func (c *ContainerServer) ImageContext() *types.SystemContext {
 
 // New creates a new ContainerServer
 func New(runtime *oci.Runtime, store cstorage.Store, storageImageServer storage.ImageServer, ctrNameIndex *registrar.Registrar, ctrIDIndex *truncindex.TruncIndex, imageContext *types.SystemContext) *ContainerServer {
+	containers := oci.NewMemoryStore()
 	return &ContainerServer{
 		runtime:            runtime,
 		store:              store,
@@ -58,5 +63,41 @@ func New(runtime *oci.Runtime, store cstorage.Store, storageImageServer storage.
 		ctrNameIndex:       ctrNameIndex,
 		ctrIDIndex:         ctrIDIndex,
 		imageContext:       imageContext,
+		stateLock:          new(sync.Mutex),
+		state: &containerServerState{
+			containers: containers,
+		},
 	}
+}
+
+type containerServerState struct {
+	containers oci.ContainerStorer
+}
+
+// AddContainer adds a container to the container state store
+func (c *ContainerServer) AddContainer(ctr *oci.Container) {
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+	c.state.containers.Add(ctr.ID(), ctr)
+}
+
+// GetContainer returns a container by its ID
+func (c *ContainerServer) GetContainer(id string) *oci.Container {
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+	return c.state.containers.Get(id)
+}
+
+// RemoveContainer removes a container from the container state store
+func (c *ContainerServer) RemoveContainer(ctr *oci.Container) {
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+	c.state.containers.Delete(ctr.ID())
+}
+
+// ListContainers returns a list of all containers stored by the server state
+func (c *ContainerServer) ListContainers() []*oci.Container {
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+	return c.state.containers.List()
 }

--- a/server/container.go
+++ b/server/container.go
@@ -16,7 +16,7 @@ func (s *Server) getContainerFromRequest(cid string) (*oci.Container, error) {
 		return nil, fmt.Errorf("container with ID starting with %s not found: %v", cid, err)
 	}
 
-	c := s.state.containers.Get(containerID)
+	c := s.ContainerServer.GetContainer(containerID)
 	if c == nil {
 		return nil, fmt.Errorf("specified container not found: %s", containerID)
 	}

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -31,7 +31,7 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 	logrus.Debugf("ListContainersRequest %+v", req)
 	var ctrs []*pb.Container
 	filter := req.Filter
-	ctrList := s.state.containers.List()
+	ctrList := s.ContainerServer.ListContainers()
 
 	// Filter using container id and pod id first.
 	if filter != nil {
@@ -40,7 +40,7 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 			if err != nil {
 				return nil, err
 			}
-			c := s.state.containers.Get(id)
+			c := s.ContainerServer.GetContainer(id)
 			if c != nil {
 				if filter.PodSandboxId != "" {
 					if c.Sandbox() == filter.PodSandboxId {


### PR DESCRIPTION
Move container state data to libkpod, separate from the sandbox data in server. However, the move is structured such that sandbox data could easily be moved over into libkpod in the future