### PR TITLE
kpod images --digests output align

### DIFF
--- a/cmd/kpod/images.go
+++ b/cmd/kpod/images.go
@@ -183,7 +183,7 @@ func outputHeader(truncate, digests bool) {
 	}
 
 	if digests {
-		fmt.Printf("%-64s ", "DIGEST")
+		fmt.Printf("%-71s ", "DIGEST")
 	}
 
 	fmt.Printf("%-22s %s\n", "CREATED AT", "SIZE")


### PR DESCRIPTION
kpod images --digests output header not aligned
because there have **sha256:**  prefix at image's digest


Signed-off-by: CuiHaozhi <cuihz@wise2c.com>