### PR TITLE
Fix bug in find-godeps

### DIFF
--- a/hack/find-godeps.sh
+++ b/hack/find-godeps.sh
@@ -23,7 +23,7 @@ function find-deps() {
 	local deps=
 
 	# gather imports from cri-o
-	pkgs=$(cd ${basepath}/${srcdir} && go list -f "{{.Imports}}" . | tr ' ' '\n' | grep -v "/vendor/" | grep ${pkgname} | sed -e "s|${pkgname}/||g")
+	pkgs=$(cd ${basepath}/${srcdir} && go list -f "{{.Imports}}" . | tr ' ' '\n' | tr -d '[]' | grep -v "/vendor/" | grep ${pkgname} | sed -e "s|${pkgname}/||g")
 
 	# add each Go import's sources to the deps list,
 	# and recursively get that imports's imports too


### PR DESCRIPTION
go list {{.Imports}} outputs imports as an array, and the leading and trailing square brackets can get caught in the name of a package.  Added a pipe in the dependency command to remove the brackets