### PR TITLE
Add option to use file-based locking for CRI-O state

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -41,6 +41,10 @@ stream_address = "{{ .StreamAddress }}"
 # stream_port is the port on which the stream server will listen
 stream_port = "{{ .StreamPort }}"
 
+# file_locking is whether file-based locking will be used instead of
+# in-memory locking
+file_locking = {{ .FileLocking }}
+
 # The "crio.runtime" table contains settings pertaining to the OCI
 # runtime used and options for how to set up and manage the OCI runtime.
 [crio.runtime]

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -75,6 +75,9 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("storage-opt") {
 		config.StorageOptions = ctx.GlobalStringSlice("storage-opt")
 	}
+	if ctx.GlobalIsSet("file-locking") {
+		config.FileLocking = ctx.GlobalBool("file-locking")
+	}
 	if ctx.GlobalIsSet("insecure-registry") {
 		config.InsecureRegistries = ctx.GlobalStringSlice("insecure-registry")
 	}
@@ -215,6 +218,10 @@ func main() {
 		cli.StringSliceFlag{
 			Name:  "storage-opt",
 			Usage: "storage driver option",
+		},
+		cli.BoolFlag{
+			Name:  "file-locking",
+			Usage: "enable or disable file-based locking",
 		},
 		cli.StringSliceFlag{
 			Name:  "insecure-registry",

--- a/libkpod/config.go
+++ b/libkpod/config.go
@@ -21,6 +21,7 @@ const (
 	cniConfigDir        = "/etc/cni/net.d/"
 	cniBinDir           = "/opt/cni/bin/"
 	cgroupManager       = "cgroupfs"
+	lockPath            = "/run/crio.lock"
 )
 
 // Config represents the entire set of configuration values that can be set for
@@ -74,6 +75,11 @@ type RootConfig struct {
 	// LogDir is the default log directory were all logs will go unless kubelet
 	// tells us to put them somewhere else.
 	LogDir string `toml:"log_dir"`
+
+	// FileLocking specifies whether to use file-based or in-memory locking
+	// File-based locking is required when multiple users of libkpod are
+	// present on the same system
+	FileLocking bool `toml:"file_locking"`
 }
 
 // RuntimeConfig represents the "crio.runtime" TOML config table.
@@ -233,9 +239,10 @@ func (c *Config) ToFile(path string) error {
 func DefaultConfig() *Config {
 	return &Config{
 		RootConfig: RootConfig{
-			Root:    crioRoot,
-			RunRoot: crioRunRoot,
-			LogDir:  "/var/log/crio/pods",
+			Root:        crioRoot,
+			RunRoot:     crioRunRoot,
+			LogDir:      "/var/log/crio/pods",
+			FileLocking: true,
 		},
 		RuntimeConfig: RuntimeConfig{
 			Runtime:                  "/usr/bin/runc",

--- a/server/server.go
+++ b/server/server.go
@@ -502,6 +502,7 @@ func New(config *Config) (*Server, error) {
 		appArmorEnabled:      apparmor.IsEnabled(),
 		appArmorProfile:      config.ApparmorProfile,
 	}
+
 	if s.seccompEnabled {
 		seccompProfile, fileErr := ioutil.ReadFile(config.SeccompProfile)
 		if fileErr != nil {


### PR DESCRIPTION
This is the first step to allowing proper sharing of state between CRI-O and kpod. For now, only the state lock will be file-based.