### PR TITLE
Force use of the "vfs" driver when testing on AUFS

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -57,6 +57,16 @@ IMAGE_VOLUMES=${IMAGE_VOLUMES:-mkdir}
 PIDS_LIMIT=${PIDS_LIMIT:-1024}
 
 TESTDIR=$(mktemp -d)
+
+# We may need to set some default storage options.
+case "$(stat -f -c %T ${TESTDIR})" in
+    aufs)
+        # None of device mapper, overlay, or aufs can be used dependably over aufs, and of course btrfs and zfs can't,
+        # and we have to explicitly specify the "vfs" driver in order to use it, so do that now.
+        STORAGE_OPTS=${STORAGE_OPTS:---storage-driver vfs}
+        ;;
+esac
+
 if [ -e /usr/sbin/selinuxenabled ] && /usr/sbin/selinuxenabled; then
     . /etc/selinux/config
     filelabel=$(awk -F'"' '/^file.*=.*/ {print $2}' /etc/selinux/${SELINUXTYPE}/contexts/lxc_contexts)


### PR DESCRIPTION
Basically none of the clever storage drivers will work when we're on top of AUFS, so if we find ourselves in that situation when running tests, default to storage options of "--storage-driver vfs".