### PR TITLE
Fix integration tests on systems with apparmor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM golang:1.7
 RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/backports.list
 
 RUN apt-get update && apt-get install -y \
+    apparmor \
     build-essential \
     curl \
     gawk \


### PR DESCRIPTION
When the integration test image is run on a system with apparmor enabled, it needs binaries from the 'apparmor' package, so ensure that it's always there.