### PR TITLE
Makefile: do not rebuild tests every time "make" runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,6 @@ WORKDIR /go/src/github.com/kubernetes-incubator/cri-o
 
 ADD . /go/src/github.com/kubernetes-incubator/cri-o
 
-RUN make copyimg \
+RUN make test/copyimg/copyimg \
 	&& mkdir -p .artifacts/redis-image \
 	&& ./test/copyimg/copyimg --import-from=docker://redis --export-to=dir:.artifacts/redis-image --signature-policy ./test/policy.json

--- a/Makefile
+++ b/Makefile
@@ -64,14 +64,14 @@ conmon:
 pause:
 	$(MAKE) -C $@
 
-bin2img: .gopathok $(wildcard test/bin2img/*.go)
-	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o test/bin2img/$@ $(PROJECT)/test/bin2img
+test/bin2img/bin2img: .gopathok $(wildcard test/bin2img/*.go)
+	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/bin2img
 
-copyimg: .gopathok $(wildcard test/copyimg/*.go)
-	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o test/copyimg/$@ $(PROJECT)/test/copyimg
+test/copyimg/copyimg: .gopathok $(wildcard test/copyimg/*.go)
+	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/copyimg
 
-checkseccomp: .gopathok $(wildcard test/checkseccomp/*.go)
-	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o test/checkseccomp/$@ $(PROJECT)/test/checkseccomp
+test/checkseccomp/checkseccomp: .gopathok $(wildcard test/checkseccomp/*.go)
+	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/checkseccomp
 
 crio: .gopathok $(shell hack/find-godeps.sh $(GOPKGDIR) cmd/crio $(PROJECT))
 	$(GO) build $(LDFLAGS) -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/cmd/crio
@@ -113,7 +113,7 @@ integration: crioimage
 localintegration: clean binaries
 	./test/test_runner.sh ${TESTFLAGS}
 
-binaries: crio crioctl kpod conmon pause bin2img copyimg checkseccomp
+binaries: crio crioctl kpod conmon pause test/bin2img/bin2img test/copyimg/copyimg test/checkseccomp/checkseccomp
 
 MANPAGES_MD := $(wildcard docs/*.md)
 MANPAGES    := $(MANPAGES_MD:%.md=%)
@@ -203,12 +203,9 @@ install.tools: .install.gitvalidation .install.gometalinter .install.md2man
 	fi
 
 .PHONY: \
-	bin2img \
 	binaries \
-	checkseccomp \
 	clean \
 	conmon \
-	copyimg \
 	default \
 	docs \
 	gofmt \


### PR DESCRIPTION
bin2img/checkseccomp/copyimg are file targets and should not be .PHONY.
This prevents to build them if not necessary.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>