### PR TITLE
Move remaining server state to libkpod

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -275,7 +275,7 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 		return nil, fmt.Errorf("PodSandboxId should not be empty")
 	}
 
-	sandboxID, err := s.podIDIndex.Get(sbID)
+	sandboxID, err := s.PodIDIndex().Get(sbID)
 	if err != nil {
 		return nil, fmt.Errorf("PodSandbox with ID starting with %s not found: %v", sbID, err)
 	}

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -55,7 +55,7 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 			}
 		} else {
 			if filter.PodSandboxId != "" {
-				pod := s.state.sandboxes[filter.PodSandboxId]
+				pod := s.ContainerServer.GetSandbox(filter.PodSandboxId)
 				if pod == nil {
 					ctrList = []*oci.Container{}
 				} else {

--- a/server/naming.go
+++ b/server/naming.go
@@ -54,7 +54,7 @@ func (s *Server) generatePodIDandName(sandboxConfig *pb.PodSandboxConfig) (strin
 	if sandboxConfig.Metadata.Namespace == "" {
 		return "", "", fmt.Errorf("cannot generate pod ID without namespace")
 	}
-	name, err := s.reservePodName(id, makeSandboxName(sandboxConfig))
+	name, err := s.ReservePodName(id, makeSandboxName(sandboxConfig))
 	if err != nil {
 		return "", "", err
 	}

--- a/server/sandbox_list.go
+++ b/server/sandbox_list.go
@@ -40,7 +40,7 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxReque
 	// Filter by pod id first.
 	if filter != nil {
 		if filter.Id != "" {
-			id, err := s.podIDIndex.Get(filter.Id)
+			id, err := s.PodIDIndex().Get(filter.Id)
 			if err != nil {
 				return nil, err
 			}

--- a/server/sandbox_list.go
+++ b/server/sandbox_list.go
@@ -32,7 +32,7 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxReque
 	logrus.Debugf("ListPodSandboxRequest %+v", req)
 	var pods []*pb.PodSandbox
 	var podList []*sandbox.Sandbox
-	for _, sb := range s.state.sandboxes {
+	for _, sb := range s.ContainerServer.ListSandboxes() {
 		podList = append(podList, sb)
 	}
 

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -87,9 +87,9 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 		return nil, fmt.Errorf("failed to delete infra container %s in pod sandbox %s from index: %v", podInfraContainer.ID(), sb.ID(), err)
 	}
 
-	s.releasePodName(sb.Name())
+	s.ReleasePodName(sb.Name())
 	s.removeSandbox(sb.ID())
-	if err := s.podIDIndex.Delete(sb.ID()); err != nil {
+	if err := s.PodIDIndex().Delete(sb.ID()); err != nil {
 		return nil, fmt.Errorf("failed to delete pod sandbox %s from index: %v", sb.ID(), err)
 	}
 

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -138,7 +138,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 	defer func() {
 		if err != nil {
-			s.releasePodName(name)
+			s.ReleasePodName(name)
 		}
 	}()
 
@@ -358,13 +358,13 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 	}()
 
-	if err = s.podIDIndex.Add(id); err != nil {
+	if err = s.PodIDIndex().Add(id); err != nil {
 		return nil, err
 	}
 
 	defer func() {
 		if err != nil {
-			if err := s.podIDIndex.Delete(id); err != nil {
+			if err := s.PodIDIndex().Delete(id); err != nil {
 				logrus.Warnf("couldn't delete pod id %s from idIndex", id)
 			}
 		}

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -120,7 +120,7 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 // StopAllPodSandboxes removes all pod sandboxes
 func (s *Server) StopAllPodSandboxes() {
 	logrus.Debugf("StopAllPodSandboxes")
-	for _, sb := range s.state.sandboxes {
+	for _, sb := range s.ContainerServer.ListSandboxes() {
 		pod := &pb.StopPodSandboxRequest{
 			PodSandboxId: sb.ID(),
 		}


### PR DESCRIPTION
This moves sandbox-related state from the server package into libkpod. It removes remaining server state locking as well.