### PR TITLE
add basic config struct to libkpod

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -38,7 +38,7 @@ func validateConfig(config *server.Config) error {
 func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	// Don't parse the config if the user explicitly set it to "".
 	if path := ctx.GlobalString("config"); path != "" {
-		if err := config.FromFile(path); err != nil {
+		if err := config.UpdateFromFile(path); err != nil {
 			if ctx.GlobalIsSet("config") || !os.IsNotExist(err) {
 				return err
 			}

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/storage/pkg/reexec"
+	"github.com/kubernetes-incubator/cri-o/libkpod"
 	"github.com/kubernetes-incubator/cri-o/server"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/urfave/cli"
@@ -24,9 +25,9 @@ const crioConfigPath = "/etc/crio/crio.conf"
 
 func validateConfig(config *server.Config) error {
 	switch config.ImageVolumes {
-	case server.ImageVolumesMkdir:
-	case server.ImageVolumesIgnore:
-	case server.ImageVolumesBind:
+	case libkpod.ImageVolumesMkdir:
+	case libkpod.ImageVolumesIgnore:
+	case libkpod.ImageVolumesBind:
 	default:
 		return fmt.Errorf("Unrecognized image volume type specified")
 
@@ -114,7 +115,7 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 		config.PluginDir = ctx.GlobalString("cni-plugin-dir")
 	}
 	if ctx.GlobalIsSet("image-volumes") {
-		config.ImageVolumes = server.ImageVolumesType(ctx.GlobalString("image-volumes"))
+		config.ImageVolumes = libkpod.ImageVolumesType(ctx.GlobalString("image-volumes"))
 	}
 	return nil
 }
@@ -245,7 +246,7 @@ func main() {
 		},
 		cli.Int64Flag{
 			Name:  "pids-limit",
-			Value: server.DefaultPidsLimit,
+			Value: libkpod.DefaultPidsLimit,
 			Usage: "maximum number of processes allowed in a container",
 		},
 		cli.StringFlag{
@@ -258,7 +259,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "image-volumes",
-			Value: string(server.ImageVolumesMkdir),
+			Value: string(libkpod.ImageVolumesMkdir),
 			Usage: "image volume handling ('mkdir' or 'ignore')",
 		},
 		cli.BoolFlag{

--- a/cmd/kpod/common.go
+++ b/cmd/kpod/common.go
@@ -3,6 +3,7 @@ package main
 import (
 	is "github.com/containers/image/storage"
 	"github.com/containers/storage"
+	"github.com/kubernetes-incubator/cri-o/libkpod"
 	"github.com/urfave/cli"
 )
 
@@ -30,4 +31,31 @@ func getStore(c *cli.Context) (storage.Store, error) {
 	}
 	is.Transport.SetStore(store)
 	return store, nil
+}
+
+func getConfig(c *cli.Context) (*libkpod.Config, error) {
+	config := libkpod.DefaultConfig()
+	if c.GlobalIsSet("config") {
+		err := config.FromFile(c.String("config"))
+		if err != nil {
+			return config, err
+		}
+	}
+	if c.GlobalIsSet("root") {
+		config.Root = c.GlobalString("root")
+	}
+	if c.GlobalIsSet("runroot") {
+		config.RunRoot = c.GlobalString("runroot")
+	}
+
+	if c.GlobalIsSet("storage-driver") {
+		config.Storage = c.GlobalString("storage-driver")
+	}
+	if c.GlobalIsSet("storage-opt") {
+		opts := c.GlobalStringSlice("storage-opt")
+		if len(opts) > 0 {
+			config.StorageOptions = opts
+		}
+	}
+	return config, nil
 }

--- a/cmd/kpod/common.go
+++ b/cmd/kpod/common.go
@@ -7,24 +7,13 @@ import (
 	"github.com/urfave/cli"
 )
 
-func getStore(c *cli.Context) (storage.Store, error) {
+func getStore(c *libkpod.Config) (storage.Store, error) {
 	options := storage.DefaultStoreOptions
-	if c.GlobalIsSet("root") {
-		options.GraphRoot = c.GlobalString("root")
-	}
-	if c.GlobalIsSet("runroot") {
-		options.RunRoot = c.GlobalString("runroot")
-	}
+	options.GraphRoot = c.Root
+	options.RunRoot = c.RunRoot
+	options.GraphDriverName = c.Storage
+	options.GraphDriverOptions = c.StorageOptions
 
-	if c.GlobalIsSet("storage-driver") {
-		options.GraphDriverName = c.GlobalString("storage-driver")
-	}
-	if c.GlobalIsSet("storage-opt") {
-		opts := c.GlobalStringSlice("storage-opt")
-		if len(opts) > 0 {
-			options.GraphDriverOptions = opts
-		}
-	}
 	store, err := storage.GetStore(options)
 	if err != nil {
 		return nil, err
@@ -36,7 +25,7 @@ func getStore(c *cli.Context) (storage.Store, error) {
 func getConfig(c *cli.Context) (*libkpod.Config, error) {
 	config := libkpod.DefaultConfig()
 	if c.GlobalIsSet("config") {
-		err := config.FromFile(c.String("config"))
+		err := config.UpdateFromFile(c.String("config"))
 		if err != nil {
 			return config, err
 		}

--- a/cmd/kpod/history.go
+++ b/cmd/kpod/history.go
@@ -80,7 +80,11 @@ var (
 )
 
 func historyCmd(c *cli.Context) error {
-	store, err := getStore(c)
+	config, err := getConfig(c)
+	if err != nil {
+		return errors.Wrapf(err, "Could not get config")
+	}
+	store, err := getStore(config)
 	if err != nil {
 		return err
 	}

--- a/cmd/kpod/images.go
+++ b/cmd/kpod/images.go
@@ -60,7 +60,11 @@ var (
 )
 
 func imagesCmd(c *cli.Context) error {
-	store, err := getStore(c)
+	config, err := getConfig(c)
+	if err != nil {
+		return errors.Wrapf(err, "Could not get config")
+	}
+	store, err := getStore(config)
 	if err != nil {
 		return err
 	}

--- a/cmd/kpod/info.go
+++ b/cmd/kpod/info.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/docker/pkg/system"
 	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -125,9 +126,14 @@ func hostInfo(c *cli.Context) (string, map[string]interface{}, error) {
 
 // top-level "store" info
 func storeInfo(c *cli.Context) (string, map[string]interface{}, error) {
-	store, err := getStore(c)
+	storeStr := "store"
+	config, err := getConfig(c)
 	if err != nil {
-		return "store", nil, err
+		return storeStr, nil, errors.Wrapf(err, "Could not get config")
+	}
+	store, err := getStore(config)
+	if err != nil {
+		return storeStr, nil, err
 	}
 
 	// lets say storage driver in use, number of images, number of containers
@@ -150,7 +156,7 @@ func storeInfo(c *cli.Context) (string, map[string]interface{}, error) {
 			"number": len(containers),
 		}
 	}
-	return "store", info, nil
+	return storeStr, info, nil
 }
 
 func readKernelVersion() (string, error) {

--- a/cmd/kpod/inspect.go
+++ b/cmd/kpod/inspect.go
@@ -77,7 +77,11 @@ func inspectCmd(c *cli.Context) error {
 
 	name := args[0]
 
-	store, err := getStore(c)
+	config, err := getConfig(c)
+	if err != nil {
+		return errors.Wrapf(err, "Could not get config")
+	}
+	store, err := getStore(config)
 	if err != nil {
 		return err
 	}

--- a/cmd/kpod/main.go
+++ b/cmd/kpod/main.go
@@ -49,6 +49,10 @@ func main() {
 			Name:  "storage-opt",
 			Usage: "used to pass an option to the storage driver",
 		},
+		cli.StringFlag{
+			Name:  "config, c",
+			Usage: "path of a config file detailing container server configuration options",
+		},
 	}
 	if err := app.Run(os.Args); err != nil {
 		logrus.Fatal(err)

--- a/cmd/kpod/pull.go
+++ b/cmd/kpod/pull.go
@@ -45,7 +45,11 @@ func pullCmd(c *cli.Context) error {
 	}
 	image := args[0]
 
-	store, err := getStore(c)
+	config, err := getConfig(c)
+	if err != nil {
+		return errors.Wrapf(err, "could not get config")
+	}
+	store, err := getStore(config)
 	if err != nil {
 		return err
 	}

--- a/cmd/kpod/push.go
+++ b/cmd/kpod/push.go
@@ -93,7 +93,11 @@ func pushCmd(c *cli.Context) error {
 		registryCreds = creds
 	}
 
-	store, err := getStore(c)
+	config, err := getConfig(c)
+	if err != nil {
+		return errors.Wrapf(err, "Could not get config")
+	}
+	store, err := getStore(config)
 	if err != nil {
 		return err
 	}

--- a/cmd/kpod/rmi.go
+++ b/cmd/kpod/rmi.go
@@ -39,7 +39,11 @@ func rmiCmd(c *cli.Context) error {
 		return errors.Errorf("image name or ID must be specified")
 	}
 
-	store, err := getStore(c)
+	config, err := getConfig(c)
+	if err != nil {
+		return errors.Wrapf(err, "Could not get config")
+	}
+	store, err := getStore(config)
 	if err != nil {
 		return err
 	}

--- a/cmd/kpod/tag.go
+++ b/cmd/kpod/tag.go
@@ -24,7 +24,11 @@ func tagCmd(c *cli.Context) error {
 	if len(args) < 2 {
 		return errors.Errorf("image name and at least one new name must be specified")
 	}
-	store, err := getStore(c)
+	config, err := getConfig(c)
+	if err != nil {
+		return errors.Wrapf(err, "Could not get config")
+	}
+	store, err := getStore(config)
 	if err != nil {
 		return err
 	}

--- a/libkpod/config.go
+++ b/libkpod/config.go
@@ -1,0 +1,267 @@
+package libkpod
+
+import (
+	"bytes"
+	"io/ioutil"
+
+	"github.com/BurntSushi/toml"
+	"github.com/opencontainers/selinux/go-selinux"
+)
+
+// Default paths if none are specified
+const (
+	crioRoot            = "/var/lib/containers/storage"
+	crioRunRoot         = "/var/run/containers/storage"
+	conmonPath          = "/usr/local/libexec/crio/conmon"
+	pauseImage          = "kubernetes/pause"
+	pauseCommand        = "/pause"
+	defaultTransport    = "docker://"
+	seccompProfilePath  = "/etc/crio/seccomp.json"
+	apparmorProfileName = "crio-default"
+	cniConfigDir        = "/etc/cni/net.d/"
+	cniBinDir           = "/opt/cni/bin/"
+	cgroupManager       = "cgroupfs"
+)
+
+// Config represents the entire set of configuration values that can be set for
+// the server. This is intended to be loaded from a toml-encoded config file.
+type Config struct {
+	RootConfig
+	RuntimeConfig
+	ImageConfig
+	NetworkConfig
+}
+
+// ImageVolumesType describes image volume handling strategies
+type ImageVolumesType string
+
+const (
+	// ImageVolumesMkdir option is for using mkdir to handle image volumes
+	ImageVolumesMkdir ImageVolumesType = "mkdir"
+	// ImageVolumesIgnore option is for ignoring image volumes altogether
+	ImageVolumesIgnore ImageVolumesType = "ignore"
+	// ImageVolumesBind option is for using bind mounted volumes
+	ImageVolumesBind ImageVolumesType = "bind"
+)
+
+const (
+	// DefaultPidsLimit is the default value for maximum number of processes
+	// allowed inside a container
+	DefaultPidsLimit = 1024
+)
+
+// This structure is necessary to fake the TOML tables when parsing,
+// while also not requiring a bunch of layered structs for no good
+// reason.
+
+// RootConfig represents the root of the "crio" TOML config table.
+type RootConfig struct {
+	// Root is a path to the "root directory" where data not
+	// explicitly handled by other options will be stored.
+	Root string `toml:"root"`
+
+	// RunRoot is a path to the "run directory" where state information not
+	// explicitly handled by other options will be stored.
+	RunRoot string `toml:"runroot"`
+
+	// Storage is the name of the storage driver which handles actually
+	// storing the contents of containers.
+	Storage string `toml:"storage_driver"`
+
+	// StorageOption is a list of storage driver specific options.
+	StorageOptions []string `toml:"storage_option"`
+
+	// LogDir is the default log directory were all logs will go unless kubelet
+	// tells us to put them somewhere else.
+	LogDir string `toml:"log_dir"`
+}
+
+// RuntimeConfig represents the "crio.runtime" TOML config table.
+type RuntimeConfig struct {
+	// Runtime is the OCI compatible runtime used for trusted container workloads.
+	// This is a mandatory setting as this runtime will be the default one and
+	// will also be used for untrusted container workloads if
+	// RuntimeUntrustedWorkload is not set.
+	Runtime string `toml:"runtime"`
+
+	// RuntimeUntrustedWorkload is the OCI compatible runtime used for untrusted
+	// container workloads. This is an optional setting, except if
+	// DefaultWorkloadTrust is set to "untrusted".
+	RuntimeUntrustedWorkload string `toml:"runtime_untrusted_workload"`
+
+	// DefaultWorkloadTrust is the default level of trust crio puts in container
+	// workloads. This can either be "trusted" or "untrusted" and the default
+	// is "trusted"
+	// Containers can be run through different container runtimes, depending on
+	// the trust hints we receive from kubelet:
+	// - If kubelet tags a container workload as untrusted, crio will try first
+	// to run it through the untrusted container workload runtime. If it is not
+	// set, crio will use the trusted runtime.
+	// - If kubelet does not provide any information about the container workload trust
+	// level, the selected runtime will depend on the DefaultWorkloadTrust setting.
+	// If it is set to "untrusted", then all containers except for the host privileged
+	// ones, will be run by the RuntimeUntrustedWorkload runtime. Host privileged
+	// containers are by definition trusted and will always use the trusted container
+	// runtime. If DefaultWorkloadTrust is set to "trusted", crio will use the trusted
+	// container runtime for all containers.
+	DefaultWorkloadTrust string `toml:"default_workload_trust"`
+
+	// Conmon is the path to conmon binary, used for managing the runtime.
+	Conmon string `toml:"conmon"`
+
+	// ConmonEnv is the environment variable list for conmon process.
+	ConmonEnv []string `toml:"conmon_env"`
+
+	// SELinux determines whether or not SELinux is used for pod separation.
+	SELinux bool `toml:"selinux"`
+
+	// SeccompProfile is the seccomp json profile path which is used as the
+	// default for the runtime.
+	SeccompProfile string `toml:"seccomp_profile"`
+
+	// ApparmorProfile is the apparmor profile name which is used as the
+	// default for the runtime.
+	ApparmorProfile string `toml:"apparmor_profile"`
+
+	// CgroupManager is the manager implementation name which is used to
+	// handle cgroups for containers.
+	CgroupManager string `toml:"cgroup_manager"`
+
+	// PidsLimit is the number of processes each container is restricted to
+	// by the cgroup process number controller.
+	PidsLimit int64 `toml:"pids_limit"`
+}
+
+// ImageConfig represents the "crio.image" TOML config table.
+type ImageConfig struct {
+	// DefaultTransport is a value we prefix to image names that fail to
+	// validate source references.
+	DefaultTransport string `toml:"default_transport"`
+	// PauseImage is the name of an image which we use to instantiate infra
+	// containers.
+	PauseImage string `toml:"pause_image"`
+	// PauseCommand is the path of the binary we run in an infra
+	// container that's been instantiated using PauseImage.
+	PauseCommand string `toml:"pause_command"`
+	// SignaturePolicyPath is the name of the file which decides what sort
+	// of policy we use when deciding whether or not to trust an image that
+	// we've pulled.  Outside of testing situations, it is strongly advised
+	// that this be left unspecified so that the default system-wide policy
+	// will be used.
+	SignaturePolicyPath string `toml:"signature_policy"`
+	// InsecureRegistries is a list of registries that must be contacted w/o
+	// TLS verification.
+	InsecureRegistries []string `toml:"insecure_registries"`
+	// ImageVolumes controls how volumes specified in image config are handled
+	ImageVolumes ImageVolumesType `toml:"image_volumes"`
+}
+
+// NetworkConfig represents the "crio.network" TOML config table
+type NetworkConfig struct {
+	// NetworkDir is where CNI network configuration files are stored.
+	NetworkDir string `toml:"network_dir"`
+
+	// PluginDir is where CNI plugin binaries are stored.
+	PluginDir string `toml:"plugin_dir"`
+}
+
+// tomlConfig is another way of looking at a Config, which is
+// TOML-friendly (it has all of the explicit tables). It's just used for
+// conversions.
+type tomlConfig struct {
+	Crio struct {
+		RootConfig
+		Runtime struct{ RuntimeConfig } `toml:"runtime"`
+		Image   struct{ ImageConfig }   `toml:"image"`
+		Network struct{ NetworkConfig } `toml:"network"`
+	} `toml:"crio"`
+}
+
+func (t *tomlConfig) toConfig(c *Config) {
+	c.RootConfig = t.Crio.RootConfig
+	c.RuntimeConfig = t.Crio.Runtime.RuntimeConfig
+	c.ImageConfig = t.Crio.Image.ImageConfig
+	c.NetworkConfig = t.Crio.Network.NetworkConfig
+}
+
+func (t *tomlConfig) fromConfig(c *Config) {
+	t.Crio.RootConfig = c.RootConfig
+	t.Crio.Runtime.RuntimeConfig = c.RuntimeConfig
+	t.Crio.Image.ImageConfig = c.ImageConfig
+	t.Crio.Network.NetworkConfig = c.NetworkConfig
+}
+
+// FromFile populates the Config from the TOML-encoded file at the given path.
+// Returns errors encountered when reading or parsing the files, or nil
+// otherwise.
+func (c *Config) FromFile(path string) error {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	t := new(tomlConfig)
+	t.fromConfig(c)
+
+	_, err = toml.Decode(string(data), t)
+	if err != nil {
+		return err
+	}
+
+	t.toConfig(c)
+	return nil
+}
+
+// ToFile outputs the given Config as a TOML-encoded file at the given path.
+// Returns errors encountered when generating or writing the file, or nil
+// otherwise.
+func (c *Config) ToFile(path string) error {
+	var w bytes.Buffer
+	e := toml.NewEncoder(&w)
+
+	t := new(tomlConfig)
+	t.fromConfig(c)
+
+	if err := e.Encode(*t); err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, w.Bytes(), 0644)
+}
+
+// DefaultConfig returns the default configuration for crio.
+func DefaultConfig() *Config {
+	return &Config{
+		RootConfig: RootConfig{
+			Root:    crioRoot,
+			RunRoot: crioRunRoot,
+			LogDir:  "/var/log/crio/pods",
+		},
+		RuntimeConfig: RuntimeConfig{
+			Runtime:                  "/usr/bin/runc",
+			RuntimeUntrustedWorkload: "",
+			DefaultWorkloadTrust:     "trusted",
+
+			Conmon: conmonPath,
+			ConmonEnv: []string{
+				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			},
+			SELinux:         selinux.GetEnabled(),
+			SeccompProfile:  seccompProfilePath,
+			ApparmorProfile: apparmorProfileName,
+			CgroupManager:   cgroupManager,
+			PidsLimit:       DefaultPidsLimit,
+		},
+		ImageConfig: ImageConfig{
+			DefaultTransport:    defaultTransport,
+			PauseImage:          pauseImage,
+			PauseCommand:        pauseCommand,
+			SignaturePolicyPath: "",
+			ImageVolumes:        ImageVolumesMkdir,
+		},
+		NetworkConfig: NetworkConfig{
+			NetworkDir: cniConfigDir,
+			PluginDir:  cniBinDir,
+		},
+	}
+}

--- a/libkpod/config.go
+++ b/libkpod/config.go
@@ -191,10 +191,10 @@ func (t *tomlConfig) fromConfig(c *Config) {
 	t.Crio.Network.NetworkConfig = c.NetworkConfig
 }
 
-// FromFile populates the Config from the TOML-encoded file at the given path.
+// UpdateFromFile populates the Config from the TOML-encoded file at the given path.
 // Returns errors encountered when reading or parsing the files, or nil
 // otherwise.
-func (c *Config) FromFile(path string) error {
+func (c *Config) UpdateFromFile(path string) error {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err

--- a/server/config.go
+++ b/server/config.go
@@ -58,10 +58,10 @@ func (t *tomlConfig) fromConfig(c *Config) {
 	t.Crio.Network.NetworkConfig = c.NetworkConfig
 }
 
-// FromFile populates the Config from the TOML-encoded file at the given path.
+// UpdateFromFile populates the Config from the TOML-encoded file at the given path.
 // Returns errors encountered when reading or parsing the files, or nil
 // otherwise.
-func (c *Config) FromFile(path string) error {
+func (c *Config) UpdateFromFile(path string) error {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err

--- a/server/config.go
+++ b/server/config.go
@@ -5,76 +5,14 @@ import (
 	"io/ioutil"
 
 	"github.com/BurntSushi/toml"
-	"github.com/opencontainers/selinux/go-selinux"
-)
-
-// Default paths if none are specified
-const (
-	crioRoot            = "/var/lib/containers/storage"
-	crioRunRoot         = "/var/run/containers/storage"
-	conmonPath          = "/usr/local/libexec/crio/conmon"
-	pauseImage          = "kubernetes/pause"
-	pauseCommand        = "/pause"
-	defaultTransport    = "docker://"
-	seccompProfilePath  = "/etc/crio/seccomp.json"
-	apparmorProfileName = "crio-default"
-	cniConfigDir        = "/etc/cni/net.d/"
-	cniBinDir           = "/opt/cni/bin/"
-	cgroupManager       = "cgroupfs"
+	"github.com/kubernetes-incubator/cri-o/libkpod"
 )
 
 // Config represents the entire set of configuration values that can be set for
 // the server. This is intended to be loaded from a toml-encoded config file.
 type Config struct {
-	RootConfig
+	libkpod.Config
 	APIConfig
-	RuntimeConfig
-	ImageConfig
-	NetworkConfig
-}
-
-// ImageVolumesType describes image volume handling strategies
-type ImageVolumesType string
-
-const (
-	// ImageVolumesMkdir option is for using mkdir to handle image volumes
-	ImageVolumesMkdir ImageVolumesType = "mkdir"
-	// ImageVolumesIgnore option is for ignoring image volumes altogether
-	ImageVolumesIgnore ImageVolumesType = "ignore"
-	// ImageVolumesBind option is for using bind mounted volumes
-	ImageVolumesBind ImageVolumesType = "bind"
-)
-
-const (
-	// DefaultPidsLimit is the default value for maximum number of processes
-	// allowed inside a container
-	DefaultPidsLimit = 1024
-)
-
-// This structure is necessary to fake the TOML tables when parsing,
-// while also not requiring a bunch of layered structs for no good
-// reason.
-
-// RootConfig represents the root of the "crio" TOML config table.
-type RootConfig struct {
-	// Root is a path to the "root directory" where data not
-	// explicitly handled by other options will be stored.
-	Root string `toml:"root"`
-
-	// RunRoot is a path to the "run directory" where state information not
-	// explicitly handled by other options will be stored.
-	RunRoot string `toml:"runroot"`
-
-	// Storage is the name of the storage driver which handles actually
-	// storing the contents of containers.
-	Storage string `toml:"storage_driver"`
-
-	// StorageOption is a list of storage driver specific options.
-	StorageOptions []string `toml:"storage_option"`
-
-	// LogDir is the default log directory were all logs will go unless kubelet
-	// tells us to put them somewhere else.
-	LogDir string `toml:"log_dir"`
 }
 
 // APIConfig represents the "crio.api" TOML config table.
@@ -91,105 +29,16 @@ type APIConfig struct {
 	StreamPort string `toml:"stream_port"`
 }
 
-// RuntimeConfig represents the "crio.runtime" TOML config table.
-type RuntimeConfig struct {
-	// Runtime is the OCI compatible runtime used for trusted container workloads.
-	// This is a mandatory setting as this runtime will be the default one and
-	// will also be used for untrusted container workloads if
-	// RuntimeUntrustedWorkload is not set.
-	Runtime string `toml:"runtime"`
-
-	// RuntimeUntrustedWorkload is the OCI compatible runtime used for untrusted
-	// container workloads. This is an optional setting, except if
-	// DefaultWorkloadTrust is set to "untrusted".
-	RuntimeUntrustedWorkload string `toml:"runtime_untrusted_workload"`
-
-	// DefaultWorkloadTrust is the default level of trust crio puts in container
-	// workloads. This can either be "trusted" or "untrusted" and the default
-	// is "trusted"
-	// Containers can be run through different container runtimes, depending on
-	// the trust hints we receive from kubelet:
-	// - If kubelet tags a container workload as untrusted, crio will try first
-	// to run it through the untrusted container workload runtime. If it is not
-	// set, crio will use the trusted runtime.
-	// - If kubelet does not provide any information about the container workload trust
-	// level, the selected runtime will depend on the DefaultWorkloadTrust setting.
-	// If it is set to "untrusted", then all containers except for the host privileged
-	// ones, will be run by the RuntimeUntrustedWorkload runtime. Host privileged
-	// containers are by definition trusted and will always use the trusted container
-	// runtime. If DefaultWorkloadTrust is set to "trusted", crio will use the trusted
-	// container runtime for all containers.
-	DefaultWorkloadTrust string `toml:"default_workload_trust"`
-
-	// Conmon is the path to conmon binary, used for managing the runtime.
-	Conmon string `toml:"conmon"`
-
-	// ConmonEnv is the environment variable list for conmon process.
-	ConmonEnv []string `toml:"conmon_env"`
-
-	// SELinux determines whether or not SELinux is used for pod separation.
-	SELinux bool `toml:"selinux"`
-
-	// SeccompProfile is the seccomp json profile path which is used as the
-	// default for the runtime.
-	SeccompProfile string `toml:"seccomp_profile"`
-
-	// ApparmorProfile is the apparmor profile name which is used as the
-	// default for the runtime.
-	ApparmorProfile string `toml:"apparmor_profile"`
-
-	// CgroupManager is the manager implementation name which is used to
-	// handle cgroups for containers.
-	CgroupManager string `toml:"cgroup_manager"`
-
-	// PidsLimit is the number of processes each container is restricted to
-	// by the cgroup process number controller.
-	PidsLimit int64 `toml:"pids_limit"`
-}
-
-// ImageConfig represents the "crio.image" TOML config table.
-type ImageConfig struct {
-	// DefaultTransport is a value we prefix to image names that fail to
-	// validate source references.
-	DefaultTransport string `toml:"default_transport"`
-	// PauseImage is the name of an image which we use to instantiate infra
-	// containers.
-	PauseImage string `toml:"pause_image"`
-	// PauseCommand is the path of the binary we run in an infra
-	// container that's been instantiated using PauseImage.
-	PauseCommand string `toml:"pause_command"`
-	// SignaturePolicyPath is the name of the file which decides what sort
-	// of policy we use when deciding whether or not to trust an image that
-	// we've pulled.  Outside of testing situations, it is strongly advised
-	// that this be left unspecified so that the default system-wide policy
-	// will be used.
-	SignaturePolicyPath string `toml:"signature_policy"`
-	// InsecureRegistries is a list of registries that must be contacted w/o
-	// TLS verification.
-	InsecureRegistries []string `toml:"insecure_registries"`
-	// ImageVolumes controls how volumes specified in image config are handled
-	ImageVolumes ImageVolumesType `toml:"image_volumes"`
-}
-
-// NetworkConfig represents the "crio.network" TOML config table
-type NetworkConfig struct {
-	// NetworkDir is where CNI network configuration files are stored.
-	NetworkDir string `toml:"network_dir"`
-
-	// PluginDir is where CNI plugin binaries are stored.
-	PluginDir string `toml:"plugin_dir"`
-}
-
 // tomlConfig is another way of looking at a Config, which is
 // TOML-friendly (it has all of the explicit tables). It's just used for
 // conversions.
 type tomlConfig struct {
 	Crio struct {
-		RootConfig
-		API     struct{ APIConfig }     `toml:"api"`
-		Runtime struct{ RuntimeConfig } `toml:"runtime"`
-		Image   struct{ ImageConfig }   `toml:"image"`
-		Network struct{ NetworkConfig } `toml:"network"`
+		libkpod.RootConfig
+		API     struct{ APIConfig }             `toml:"api"`
+		Runtime struct{ libkpod.RuntimeConfig } `toml:"runtime"`
+		Image   struct{ libkpod.ImageConfig }   `toml:"image"`
+		Network struct{ libkpod.NetworkConfig } `toml:"network"`
 	} `toml:"crio"`
 }
 
@@ -250,41 +99,11 @@ func (c *Config) ToFile(path string) error {
 // DefaultConfig returns the default configuration for crio.
 func DefaultConfig() *Config {
 	return &Config{
-		RootConfig: RootConfig{
-			Root:    crioRoot,
-			RunRoot: crioRunRoot,
-			LogDir:  "/var/log/crio/pods",
-		},
+		Config: *libkpod.DefaultConfig(),
 		APIConfig: APIConfig{
 			Listen:        "/var/run/crio.sock",
 			StreamAddress: "",
 			StreamPort:    "10010",
-		},
-		RuntimeConfig: RuntimeConfig{
-			Runtime:                  "/usr/bin/runc",
-			RuntimeUntrustedWorkload: "",
-			DefaultWorkloadTrust:     "trusted",
-
-			Conmon: conmonPath,
-			ConmonEnv: []string{
-				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-			},
-			SELinux:         selinux.GetEnabled(),
-			SeccompProfile:  seccompProfilePath,
-			ApparmorProfile: apparmorProfileName,
-			CgroupManager:   cgroupManager,
-			PidsLimit:       DefaultPidsLimit,
-		},
-		ImageConfig: ImageConfig{
-			DefaultTransport:    defaultTransport,
-			PauseImage:          pauseImage,
-			PauseCommand:        pauseCommand,
-			SignaturePolicyPath: "",
-			ImageVolumes:        ImageVolumesMkdir,
-		},
-		NetworkConfig: NetworkConfig{
-			NetworkDir: cniConfigDir,
-			PluginDir:  cniBinDir,
 		},
 	}
 }

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/symlink"
+	"github.com/kubernetes-incubator/cri-o/libkpod"
 	"github.com/kubernetes-incubator/cri-o/libkpod/sandbox"
 	"github.com/kubernetes-incubator/cri-o/oci"
 	"github.com/kubernetes-incubator/cri-o/pkg/annotations"
@@ -82,11 +83,11 @@ func addImageVolumes(rootfs string, s *Server, containerInfo *storage.ContainerI
 			return err
 		}
 		switch s.config.ImageVolumes {
-		case ImageVolumesMkdir:
+		case libkpod.ImageVolumesMkdir:
 			if err1 := os.MkdirAll(fp, 0644); err1 != nil {
 				return err1
 			}
-		case ImageVolumesBind:
+		case libkpod.ImageVolumesBind:
 			volumeDirName := stringid.GenerateNonCryptoID()
 			src := filepath.Join(containerInfo.RunDir, "mounts", volumeDirName)
 			if err1 := os.MkdirAll(src, 0644); err1 != nil {
@@ -101,7 +102,7 @@ func addImageVolumes(rootfs string, s *Server, containerInfo *storage.ContainerI
 
 			logrus.Debugf("Adding bind mounted volume: %s to %s", src, dest)
 			specgen.AddBindMount(src, dest, []string{"rw"})
-		case ImageVolumesIgnore:
+		case libkpod.ImageVolumesIgnore:
 			logrus.Debugf("Ignoring volume %v", dest)
 		default:
 			logrus.Fatalf("Unrecognized image volumes setting")

--- a/server/server.go
+++ b/server/server.go
@@ -471,11 +471,6 @@ func New(config *Config) (*Server, error) {
 		return nil, err
 	}
 
-	r, err := oci.New(config.Runtime, config.RuntimeUntrustedWorkload, config.DefaultWorkloadTrust, config.Conmon, config.ConmonEnv, config.CgroupManager)
-	if err != nil {
-		return nil, err
-	}
-
 	storageRuntimeService := storage.GetRuntimeService(imageService, config.PauseImage)
 	if err != nil {
 		return nil, err
@@ -484,8 +479,10 @@ func New(config *Config) (*Server, error) {
 	if err := os.MkdirAll("/var/run/crio", 0755); err != nil {
 		return nil, err
 	}
-
-	containerServer := libkpod.New(r, store, imageService, config.SignaturePolicyPath)
+	containerServer, err := libkpod.New(&config.Config)
+	if err != nil {
+		return nil, err
+	}
 
 	netPlugin, err := ocicni.InitCNI(config.NetworkDir, config.PluginDir)
 	if err != nil {


### PR DESCRIPTION
Add a basic config struct to libkpod so that it can be used in commands such as `kpod logs` and `kpod stats`.  This can be refined once kpod gets fleshed out more but it prevents having magic constants all over the place