### PR TITLE
Don't double-free an UnparsedSource

### DIFF
--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -137,10 +137,9 @@ func (svc *imageService) CanPull(imageName string, options *copy.Options) (bool,
 	if err != nil {
 		return false, err
 	}
-	unparsedImage := image.UnparsedFromSource(rawSource)
-	defer unparsedImage.Close()
-	src, err := image.FromUnparsedImage(unparsedImage)
+	src, err := image.FromSource(rawSource)
 	if err != nil {
+		rawSource.Close()
 		return false, err
 	}
 	src.Close()


### PR DESCRIPTION
`github.com/containers/image/image.FromUnparsedImage()` "takes ownership" of the `UnparsedImage` that we pass to it, so we shouldn't also `Close()` the `UnparsedImage` ourselves after we've wrapped it up in an `Image` object.

Since creating an `Image` is the only thing we do with the `UnparsedImage` after creating it from a `SourceImage`, just use the `FromSource()` function to handle both steps at once.