### PR TITLE
vendor in Update containers/image to add support for kpod save

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -5,7 +5,7 @@ k8s.io/apimachinery release-1.6 https://github.com/kubernetes/apimachinery
 k8s.io/apiserver release-1.6 https://github.com/kubernetes/apiserver
 #
 github.com/Sirupsen/logrus v0.11.5
-github.com/containers/image c2a797dfe5bb4a9dd7f48332ce40c6223ffba492
+github.com/containers/image 106607808da3cff168be56821e994611c919d283
 github.com/ostreedev/ostree-go master
 github.com/containers/storage 5d8c2f87387fa5be9fa526ae39fbd79b8bdf27be
 github.com/containernetworking/cni v0.4.0


### PR DESCRIPTION
This update allows the creation of docker-archive files when the
destination does not exists or is empty.  kpod save needs this functionality.

Signed-off-by: Dan Walsh <dwalsh@redhat.com>