### PR TITLE
kpod: display image dates from inspection data, and don't display non-OCI settings in "inspect"

### DIFF
--- a/cmd/kpod/images.go
+++ b/cmd/kpod/images.go
@@ -136,14 +136,17 @@ func outputHeader(truncate, digests bool) {
 
 func outputImages(store storage.Store, images []storage.Image, format string, hasTemplate, truncate, digests, quiet bool) error {
 	for _, img := range images {
-		createdTime := img.Created.Format("Jan 2, 2006 15:04")
+		createdTime := img.Created
 
 		name := ""
 		if len(img.Names) > 0 {
 			name = img.Names[0]
 		}
 
-		digest, size, _ := libkpodimage.DigestAndSize(store, img)
+		info, digest, size, _ := libkpodimage.InfoAndDigestAndSize(store, img)
+		if info != nil {
+			createdTime = info.Created
+		}
 
 		if quiet {
 			fmt.Printf("%-64s\n", img.ID)
@@ -155,7 +158,7 @@ func outputImages(store storage.Store, images []storage.Image, format string, ha
 			ID:        img.ID,
 			Name:      name,
 			Digest:    digest,
-			CreatedAt: createdTime,
+			CreatedAt: createdTime.Format("Jan 2, 2006 15:04"),
 			Size:      libkpodimage.FormattedSize(size),
 		}
 		if hasTemplate {

--- a/libkpod/image/image.go
+++ b/libkpod/image/image.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	is "github.com/containers/image/storage"
+	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
 	"github.com/kubernetes-incubator/cri-o/libkpod/common"
@@ -174,7 +175,7 @@ func FormattedSize(size int64) string {
 	return fmt.Sprintf("%.4g %s", formattedSize, suffixes[count])
 }
 
-// FindImage searches for an image with a matching the given name or ID in the given store
+// FindImage searches for a *storage.Image with a matching the given name or ID in the given store.
 func FindImage(store storage.Store, image string) (*storage.Image, error) {
 	var img *storage.Image
 	ref, err := is.Transport.ParseStoreReference(store, image)
@@ -194,6 +195,23 @@ func FindImage(store storage.Store, image string) (*storage.Image, error) {
 	return img, nil
 }
 
+// FindImageRef searches for and returns a new types.Image matching the given name or ID in the given store.
+func FindImageRef(store storage.Store, image string) (types.Image, error) {
+	img, err := FindImage(store, image)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to locate image %q", image)
+	}
+	ref, err := is.Transport.ParseStoreReference(store, "@"+img.ID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error parsing reference to image %q", img.ID)
+	}
+	imgRef, err := ref.NewImage(nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading image %q", img.ID)
+	}
+	return imgRef, nil
+}
+
 func findImageInSlice(images []storage.Image, ref string) (storage.Image, error) {
 	for _, image := range images {
 		if MatchesID(image.ID, ref) {
@@ -211,23 +229,22 @@ func findImageInSlice(images []storage.Image, ref string) (storage.Image, error)
 // InfoAndDigestAndSize returns the inspection info and size of the image in the given
 // store and the digest of its manifest, if it has one, or "" if it doesn't.
 func InfoAndDigestAndSize(store storage.Store, img storage.Image) (*types.ImageInspectInfo, digest.Digest, int64, error) {
-	is.Transport.SetStore(store)
-	storeRef, err := is.Transport.ParseStoreReference(store, "@"+img.ID)
-	if err != nil {
-		return nil, "", -1, errors.Wrapf(err, "error parsing image reference %q", "@"+img.ID)
-	}
-	imgRef, err := storeRef.NewImage(nil)
+	imgRef, err := FindImageRef(store, "@"+img.ID)
 	if err != nil {
 		return nil, "", -1, errors.Wrapf(err, "error reading image %q", img.ID)
 	}
 	defer imgRef.Close()
+	return infoAndDigestAndSize(imgRef)
+}
+
+func infoAndDigestAndSize(imgRef types.Image) (*types.ImageInspectInfo, digest.Digest, int64, error) {
 	imgSize, err := imgRef.Size()
 	if err != nil {
-		return nil, "", -1, errors.Wrapf(err, "error reading size of image %q", img.ID)
+		return nil, "", -1, errors.Wrapf(err, "error reading size of image %q", transports.ImageName(imgRef.Reference()))
 	}
 	manifest, _, err := imgRef.Manifest()
 	if err != nil {
-		return nil, "", -1, errors.Wrapf(err, "error reading manifest for image %q", img.ID)
+		return nil, "", -1, errors.Wrapf(err, "error reading manifest for image %q", transports.ImageName(imgRef.Reference()))
 	}
 	manifestDigest := digest.Digest("")
 	if len(manifest) > 0 {
@@ -235,7 +252,7 @@ func InfoAndDigestAndSize(store storage.Store, img storage.Image) (*types.ImageI
 	}
 	info, err := imgRef.Inspect()
 	if err != nil {
-		return nil, "", -1, errors.Wrapf(err, "error inspecting image %q", img.ID)
+		return nil, "", -1, errors.Wrapf(err, "error inspecting image %q", transports.ImageName(imgRef.Reference()))
 	}
 	return info, manifestDigest, imgSize, nil
 }

--- a/libkpod/image/imageData.go
+++ b/libkpod/image/imageData.go
@@ -98,7 +98,7 @@ func GetImageData(store storage.Store, name string) (*ImageData, error) {
 		return nil, err
 	}
 
-	digest, virtualSize, err := DigestAndSize(store, *img)
+	_, digest, virtualSize, err := InfoAndDigestAndSize(store, *img)
 	if err != nil {
 		return nil, err
 	}

--- a/libkpod/image/imageData.go
+++ b/libkpod/image/imageData.go
@@ -1,11 +1,12 @@
 package image
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/transports"
 	"github.com/containers/storage"
-	"github.com/kubernetes-incubator/cri-o/cmd/kpod/docker"
 	"github.com/kubernetes-incubator/cri-o/libkpod/driver"
 	digest "github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -15,23 +16,23 @@ import (
 // ImageData handles the data used when inspecting a container
 // nolint
 type ImageData struct {
-	ID              string
-	Tags            []string
-	Digests         []string
-	Digest          digest.Digest
-	Parent          string
-	Comment         string
-	Created         *time.Time
-	Container       string
-	ContainerConfig docker.Config
-	Author          string
-	Config          ociv1.ImageConfig
-	Architecture    string
-	OS              string
-	Size            uint
-	VirtualSize     uint
-	GraphDriver     driver.Data
-	RootFS          ociv1.RootFS
+	ID           string
+	Tags         []string
+	Digests      []string
+	Digest       digest.Digest
+	Comment      string
+	Created      *time.Time
+	Container    string
+	Author       string
+	Config       ociv1.ImageConfig
+	Architecture string
+	OS           string
+	Annotations  map[string]string
+	CreatedBy    string
+	Size         uint
+	VirtualSize  uint
+	GraphDriver  driver.Data
+	RootFS       ociv1.RootFS
 }
 
 // ParseImageNames parses the names we've stored with an image into a list of
@@ -60,6 +61,20 @@ func ParseImageNames(names []string) (tags, digests []string, err error) {
 	return tags, digests, nil
 }
 
+func annotations(manifest []byte, manifestType string) map[string]string {
+	annotations := make(map[string]string)
+	switch manifestType {
+	case ociv1.MediaTypeImageManifest:
+		var m ociv1.Manifest
+		if err := json.Unmarshal(manifest, &m); err == nil {
+			for k, v := range m.Annotations {
+				annotations[k] = v
+			}
+		}
+	}
+	return annotations
+}
+
 // GetImageData gets the ImageData for a container with the given name in the given store.
 func GetImageData(store storage.Store, name string) (*ImageData, error) {
 	img, err := FindImage(store, name)
@@ -67,10 +82,11 @@ func GetImageData(store storage.Store, name string) (*ImageData, error) {
 		return nil, errors.Wrapf(err, "error reading image %q", name)
 	}
 
-	cid, err := GetImageCopyData(store, name)
+	imgRef, err := FindImageRef(store, "@"+img.ID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error reading image %q", name)
+		return nil, errors.Wrapf(err, "error reading image %q", img.ID)
 	}
+	defer imgRef.Close()
 
 	tags, digests, err := ParseImageNames(img.Names)
 	if err != nil {
@@ -79,50 +95,70 @@ func GetImageData(store storage.Store, name string) (*ImageData, error) {
 
 	driverName, err := driver.GetDriverName(store)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error reading name of storage driver")
 	}
 
 	topLayerID := img.TopLayer
 
 	driverMetadata, err := driver.GetDriverMetadata(store, topLayerID)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error asking storage driver %q for metadata", driverName)
 	}
 
 	layer, err := store.Layer(topLayerID)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error reading information about layer %q", topLayerID)
 	}
 	size, err := store.DiffSize(layer.Parent, layer.ID)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error determining size of layer %q", layer.ID)
 	}
 
-	_, digest, virtualSize, err := InfoAndDigestAndSize(store, *img)
+	imgSize, err := imgRef.Size()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error determining size of image %q", transports.ImageName(imgRef.Reference()))
+	}
+
+	manifest, manifestType, err := imgRef.Manifest()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading manifest for image %q", img.ID)
+	}
+	manifestDigest := digest.Digest("")
+	if len(manifest) > 0 {
+		manifestDigest = digest.Canonical.FromBytes(manifest)
+	}
+	annotations := annotations(manifest, manifestType)
+
+	config, err := imgRef.OCIConfig()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading image configuration for %q", img.ID)
+	}
+	historyComment := ""
+	historyCreatedBy := ""
+	if len(config.History) > 0 {
+		historyComment = config.History[len(config.History)-1].Comment
+		historyCreatedBy = config.History[len(config.History)-1].CreatedBy
 	}
 
 	return &ImageData{
-		ID:              img.ID,
-		Tags:            tags,
-		Digests:         digests,
-		Digest:          digest,
-		Parent:          string(cid.Docker.Parent),
-		Comment:         cid.OCIv1.History[0].Comment,
-		Created:         cid.OCIv1.Created,
-		Container:       cid.Docker.Container,
-		ContainerConfig: cid.Docker.ContainerConfig,
-		Author:          cid.OCIv1.Author,
-		Config:          cid.OCIv1.Config,
-		Architecture:    cid.OCIv1.Architecture,
-		OS:              cid.OCIv1.OS,
-		Size:            uint(size),
-		VirtualSize:     uint(virtualSize),
+		ID:           img.ID,
+		Tags:         tags,
+		Digests:      digests,
+		Digest:       manifestDigest,
+		Comment:      historyComment,
+		Created:      config.Created,
+		Author:       config.Author,
+		Config:       config.Config,
+		Architecture: config.Architecture,
+		OS:           config.OS,
+		Annotations:  annotations,
+		CreatedBy:    historyCreatedBy,
+		Size:         uint(size),
+		VirtualSize:  uint(size + imgSize),
 		GraphDriver: driver.Data{
 			Name: driverName,
 			Data: driverMetadata,
 		},
-		RootFS: cid.OCIv1.RootFS,
+		RootFS: config.RootFS,
 	}, nil
 }


### PR DESCRIPTION
* We parse image data when checking if an image matches a label filter for `kpod images`, so extend that to read the image inspection data and OCI configuration blob.
* Use the creation date from an image's inspection data when the image is to be used as a reference date, and for display.
* Only show the image's OCI configuration in `kpod inspect`, since that's the only information `cri-o` will use when it attempts to run the image.  This discards the "parent" image's ID, so we drop that field, too.