### PR TITLE
Default to the storage defaults

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -12,21 +12,27 @@ var commentedConfigTemplate = template.Must(template.New("config").Parse(`
 # The "crio" table contains all of the server options.
 [crio]
 
+# CRI-O reads its storage defaults from the containers/storage configuration
+# file, /etc/containers/storage.conf. Modify storage.conf if you want to
+# change default storage for all tools that use containers/storage.  If you
+# want to modify just crio, you can change the storage configuration in this
+# file.
+
 # root is a path to the "root directory". CRIO stores all of its data,
 # including container images, in this directory.
-root = "{{ .Root }}"
+#root = "{{ .Root }}"
 
 # run is a path to the "run directory". CRIO stores all of its state
 # in this directory.
-runroot = "{{ .RunRoot }}"
+#runroot = "{{ .RunRoot }}"
 
 # storage_driver select which storage driver is used to manage storage
 # of images and containers.
-storage_driver = "{{ .Storage }}"
+#storage_driver = "{{ .Storage }}"
 
 # storage_option is used to pass an option to the storage driver.
-storage_option = [
-{{ range $opt := .StorageOptions }}{{ printf "\t%q,\n" $opt }}{{ end }}]
+#storage_option = [
+{{ range $opt := .StorageOptions }}{{ printf "#\t%q,\n" $opt }}{{ end }}#]
 
 # The "crio.api" table contains settings for the kubelet/gRPC interface.
 [crio.api]

--- a/contrib/system_containers/centos/Dockerfile
+++ b/contrib/system_containers/centos/Dockerfile
@@ -19,7 +19,7 @@ RUN yum-config-manager --nogpgcheck --add-repo https://cbs.centos.org/repos/virt
     cp /etc/crio/* /exports/hostfs/etc/crio && \
     if test -e /usr/libexec/cni; then cp -Lr /usr/libexec/cni/* /exports/hostfs/opt/cni/bin/; fi
 
-RUN sed -i '/storage_option =/s/.*/&\n"overlay.override_kernel_check=1",/' /exports/hostfs/etc/crio/crio.conf
+RUN sed -i '/^#storage_option =/s/.*/storage_option = [\n\t"overlay.override_kernel_check=1",\n]/' /exports/hostfs/etc/crio/crio.conf
 
 COPY manifest.json tmpfiles.template config.json.template service.template /exports/
 

--- a/contrib/system_containers/fedora/Dockerfile
+++ b/contrib/system_containers/fedora/Dockerfile
@@ -20,8 +20,6 @@ RUN dnf install --enablerepo=updates-testing --setopt=tsflags=nodocs -y iptables
     cp /etc/crio/* /exports/hostfs/etc/crio && \
     if test -e /usr/libexec/cni; then cp -Lr /usr/libexec/cni/* /exports/hostfs/opt/cni/bin/; fi
 
-RUN sed -i '/storage_option =/s/.*/&\n"overlay.override_kernel_check=1",/' /exports/hostfs/etc/crio/crio.conf
-
 COPY manifest.json tmpfiles.template config.json.template service.template /exports/
 
 COPY set_mounts.sh /

--- a/contrib/system_containers/rhel/Dockerfile
+++ b/contrib/system_containers/rhel/Dockerfile
@@ -17,6 +17,8 @@ RUN \
     cp /etc/crio/* /exports/hostfs/etc/crio && \
     if test -e /usr/libexec/cni; then cp -Lr /usr/libexec/cni/* /exports/hostfs/opt/cni/bin/; fi
 
+RUN sed -i '/^#storage_option =/s/.*/storage_option = [\n\t"overlay.override_kernel_check=1",\n]/' /exports/hostfs/etc/crio/crio.conf
+
 COPY manifest.json tmpfiles.template config.json.template service.template /exports/
 
 COPY set_mounts.sh /

--- a/contrib/test/integration/build/cri-o.yml
+++ b/contrib/test/integration/build/cri-o.yml
@@ -72,7 +72,7 @@
 - name: add overlay storage opts on RHEL/CentOS
   lineinfile:
     dest: /etc/crio/crio.conf
-    line: '"overlay.override_kernel_check=1"'
+    line: 'storage_option = [ "overlay.override_kernel_check=1", ]'
     insertafter: 'storage_option = \['
     regexp: 'overlay\.override_kernel_check=1'
     state: present

--- a/lib/config.go
+++ b/lib/config.go
@@ -5,13 +5,12 @@ import (
 	"io/ioutil"
 
 	"github.com/BurntSushi/toml"
+	"github.com/containers/storage"
 	"github.com/kubernetes-incubator/cri-o/oci"
 )
 
 // Default paths if none are specified
 const (
-	crioRoot            = "/var/lib/containers/storage"
-	crioRunRoot         = "/var/run/containers/storage"
 	conmonPath          = "/usr/local/libexec/crio/conmon"
 	pauseImage          = "kubernetes/pause"
 	pauseCommand        = "/pause"
@@ -273,10 +272,12 @@ func (c *Config) ToFile(path string) error {
 func DefaultConfig() *Config {
 	return &Config{
 		RootConfig: RootConfig{
-			Root:        crioRoot,
-			RunRoot:     crioRunRoot,
-			LogDir:      "/var/log/crio/pods",
-			FileLocking: true,
+			Root:           storage.DefaultStoreOptions.GraphRoot,
+			RunRoot:        storage.DefaultStoreOptions.RunRoot,
+			Storage:        storage.DefaultStoreOptions.GraphDriverName,
+			StorageOptions: storage.DefaultStoreOptions.GraphDriverOptions,
+			LogDir:         "/var/log/crio/pods",
+			FileLocking:    true,
 		},
 		RuntimeConfig: RuntimeConfig{
 			Runtime:                  "/usr/bin/runc",

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -216,7 +216,7 @@ function start_crio() {
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=docker.io/library/busybox:latest --import-from=dir:"$ARTIFACTS_PATH"/busybox-image --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=docker.io/runcom/stderr-test:latest --import-from=dir:"$ARTIFACTS_PATH"/stderr-test --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --cgroup-manager "$CGROUP_MANAGER" --registry "docker.io" --runtime "$RUNTIME_BINARY" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --log-size-max "$LOG_SIZE_MAX_LIMIT" --config /dev/null config >$CRIO_CONFIG
-
+	sed -r -e 's/^(#)?root =/root =/g' -e 's/^(#)?runroot =/runroot =/g' -e 's/^(#)?storage_driver =/storage_driver =/g' -e '/^(#)?storage_option = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -i $CRIO_CONFIG
 	# Prepare the CNI configuration files, we're running with non host networking by default
 	if [[ -n "$4" ]]; then
 		netfunc="$4"


### PR DESCRIPTION
Change the config to use github.com/containers/storage by default.
Allow users to override in the config, but if the admin does not
override the config.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>