### PR TITLE
Add libcontainer dependencies to vendor.conf

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -14,6 +14,9 @@ github.com/opencontainers/selinux v1.0.0-rc1
 github.com/opencontainers/go-digest v1.0.0-rc0
 github.com/opencontainers/runtime-tools 20db5990713e97e64bc2d340531d61f2edf4cccb
 github.com/opencontainers/runc c5ec25487693612aed95673800863e134785f946
+github.com/mrunalp/fileutils 4ee1cc9a80582a0c75febdd5cfa779ee4361cbca
+github.com/vishvananda/netlink 8d7f7aad193e778023f06a843a26ffc9615ca840
+github.com/vishvananda/netns 86bef332bfc3b59b7624a600bd53009ce91a9829
 github.com/opencontainers/image-spec v1.0.0
 github.com/opencontainers/runtime-spec v1.0.0
 github.com/juju/ratelimit acf38b000a03e4ab89e40f20f1e548f4e6ac7f72


### PR DESCRIPTION
These are dependencies of libcontainer that are not currently vendored in