### PR TITLE
Switch kpod save to use config

### DIFF
--- a/cmd/kpod/save.go
+++ b/cmd/kpod/save.go
@@ -50,7 +50,11 @@ func saveCmd(c *cli.Context) error {
 		return errors.Errorf("need at least 1 argument")
 	}
 
-	store, err := getStore(c)
+	config, err := getConfig(c)
+	if err != nil {
+		return errors.Wrapf(err, "could not get config")
+	}
+	store, err := getStore(config)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The kpod save and libkpod config PRs were probably merged around the same time so this went unnoticed