### PR TITLE
Add goterm to vendor.conf

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -71,3 +71,4 @@ github.com/godbus/dbus v4.0.0
 github.com/urfave/cli v1.19.1
 github.com/vbatts/tar-split v0.10.1
 github.com/renstrom/dedent v1.0.0
+github.com/buger/goterm bc6c333206f446a53cac4db5d2e6a4316139d737


### PR DESCRIPTION
goterm is used to update information displayed in a terminal.  This is used in `kpod stats`

Signed-off-by: Ryan Cole <rcyoalne@gmail.com>