### PR TITLE
Remove atomic transport description.

### DIFF
--- a/docs/kpod-pull.1.md
+++ b/docs/kpod-pull.1.md
@@ -28,9 +28,6 @@ Image stored in local container/storage
 
  Multiple transports are supported:
 
-  **atomic:**_hostname_**/**_namespace_**/**_stream_**:**_tag_
-  An image served by an OpenShift(Atomic) Registry server. The current OpenShift project and OpenShift Registry instance are by default read from `$HOME/.kube/config`, which is set e.g. using `(oc login)`.
-
   **dir:**_path_
   An existing local directory _path_ storing the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
 

--- a/docs/kpod-push.1.md
+++ b/docs/kpod-push.1.md
@@ -22,9 +22,6 @@ Image stored in local container/storage
 
  Multiple transports are supported:
 
-  **atomic:**_hostname_**/**_namespace_**/**_stream_**:**_tag_
-  An image served by an OpenShift(Atomic) Registry server. The current OpenShift project and OpenShift Registry instance are by default read from `$HOME/.kube/config`, which is set e.g. using `(oc login)`.
-
   **dir:**_path_
   An existing local directory _path_ storing the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
 
@@ -96,11 +93,6 @@ This example extracts the imageID image to a container registry named registry.e
 This example extracts the imageID image and puts into the local docker container store
 
  `# kpod push imageID docker-daemon:image:tag`
-
-This example extracts the imageID image and pushes it to an OpenShift(Atomic) registry
-
- `# kpod push imageID atomic:registry.example.com/company/image:tag`
-
 
 ## SEE ALSO
 kpod(1)


### PR DESCRIPTION
Miloslav informs me that the docker transport talking to an OpenShift
registry will handle signatures properly, so no need for the atomic transport
any longer.  We want to stop documenting it.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>