### PR TITLE
Use errors.Cause() when looking at storage errors

### DIFF
--- a/libkpod/container_server.go
+++ b/libkpod/container_server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kubernetes-incubator/cri-o/pkg/storage"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
 
@@ -156,7 +157,7 @@ func (c *ContainerServer) Update() error {
 	defer c.updateLock.Unlock()
 
 	containers, err := c.store.Containers()
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !os.IsNotExist(errors.Cause(err)) {
 		logrus.Warnf("could not read containers and sandboxes: %v", err)
 		return err
 	}

--- a/libkpod/image/copy_data.go
+++ b/libkpod/image/copy_data.go
@@ -365,7 +365,7 @@ func GetContainerCopyData(store storage.Store, name string) (*CopyData, error) {
 	var err error
 	if name != "" {
 		data, err = openCopyData(store, name)
-		if os.IsNotExist(err) {
+		if os.IsNotExist(errors.Cause(err)) {
 			data, err = importCopyData(store, name, "")
 		}
 	}

--- a/pkg/storage/runtime.go
+++ b/pkg/storage/runtime.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
 	"github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -175,7 +175,7 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 		}
 	}
 	img, err := istorage.Transport.GetStoreImage(r.storageImageServer.GetStore(), ref)
-	if img == nil && err == storage.ErrImageUnknown && imageName == r.pauseImage {
+	if img == nil && errors.Cause(err) == storage.ErrImageUnknown && imageName == r.pauseImage {
 		image := imageID
 		if imageName != "" {
 			image = imageName
@@ -194,7 +194,7 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 		}
 		logrus.Debugf("successfully pulled image %q", image)
 	}
-	if img == nil && err == storage.ErrImageUnknown {
+	if img == nil && errors.Cause(err) == storage.ErrImageUnknown {
 		if imageID == "" {
 			return ContainerInfo{}, fmt.Errorf("image %q not present in image store", imageName)
 		}
@@ -331,7 +331,7 @@ func (r *runtimeService) CreateContainer(systemContext *types.SystemContext, pod
 func (r *runtimeService) RemovePodSandbox(idOrName string) error {
 	container, err := r.storageImageServer.GetStore().Container(idOrName)
 	if err != nil {
-		if err == storage.ErrContainerUnknown {
+		if errors.Cause(err) == storage.ErrContainerUnknown {
 			return ErrInvalidSandboxID
 		}
 		return err
@@ -384,7 +384,7 @@ func (r *runtimeService) GetContainerMetadata(idOrName string) (RuntimeContainer
 func (r *runtimeService) StartContainer(idOrName string) (string, error) {
 	container, err := r.storageImageServer.GetStore().Container(idOrName)
 	if err != nil {
-		if err == storage.ErrContainerUnknown {
+		if errors.Cause(err) == storage.ErrContainerUnknown {
 			return "", ErrInvalidContainerID
 		}
 		return "", err
@@ -422,7 +422,7 @@ func (r *runtimeService) StopContainer(idOrName string) error {
 func (r *runtimeService) GetWorkDir(id string) (string, error) {
 	container, err := r.storageImageServer.GetStore().Container(id)
 	if err != nil {
-		if err == storage.ErrContainerUnknown {
+		if errors.Cause(err) == storage.ErrContainerUnknown {
 			return "", ErrInvalidContainerID
 		}
 		return "", err
@@ -433,7 +433,7 @@ func (r *runtimeService) GetWorkDir(id string) (string, error) {
 func (r *runtimeService) GetRunDir(id string) (string, error) {
 	container, err := r.storageImageServer.GetStore().Container(id)
 	if err != nil {
-		if err == storage.ErrContainerUnknown {
+		if errors.Cause(err) == storage.ErrContainerUnknown {
 			return "", ErrInvalidContainerID
 		}
 		return "", err

--- a/server/image_status.go
+++ b/server/image_status.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/storage"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
@@ -34,7 +35,7 @@ func (s *Server) ImageStatus(ctx context.Context, req *pb.ImageStatusRequest) (*
 	image = images[0]
 	status, err := s.StorageImageServer().ImageStatus(s.ImageContext(), image)
 	if err != nil {
-		if err == storage.ErrImageUnknown {
+		if errors.Cause(err) == storage.ErrImageUnknown {
 			return &pb.ImageStatusResponse{}, nil
 		}
 		return nil, err

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kubernetes-incubator/cri-o/libkpod/sandbox"
 	"github.com/kubernetes-incubator/cri-o/oci"
 	pkgstorage "github.com/kubernetes-incubator/cri-o/pkg/storage"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 )
@@ -75,7 +76,7 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 	s.removeContainer(podInfraContainer)
 
 	// Remove the files related to the sandbox
-	if err := s.StorageRuntimeServer().StopContainer(sb.ID()); err != nil && err != storage.ErrContainerUnknown {
+	if err := s.StorageRuntimeServer().StopContainer(sb.ID()); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {
 		logrus.Warnf("failed to stop sandbox container in pod sandbox %s: %v", sb.ID(), err)
 	}
 	if err := s.StorageRuntimeServer().RemovePodSandbox(sb.ID()); err != nil && err != pkgstorage.ErrInvalidSandboxID {

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -19,6 +19,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"golang.org/x/sys/unix"
 	"k8s.io/kubernetes/pkg/api/v1"
@@ -162,7 +163,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		namespace,
 		attempt,
 		nil)
-	if err == storage.ErrDuplicateName {
+	if errors.Cause(err) == storage.ErrDuplicateName {
 		return nil, fmt.Errorf("pod sandbox with name %q already exists", name)
 	}
 	if err != nil {

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubernetes-incubator/cri-o/libkpod/sandbox"
 	"github.com/kubernetes-incubator/cri-o/oci"
 	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"golang.org/x/sys/unix"
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
@@ -80,7 +81,7 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 			if c.ID() == podInfraContainer.ID() {
 				continue
 			}
-			if err := s.StorageRuntimeServer().StopContainer(c.ID()); err != nil && err != storage.ErrContainerUnknown {
+			if err := s.StorageRuntimeServer().StopContainer(c.ID()); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {
 				// assume container already umounted
 				logrus.Warnf("failed to stop container %s in pod sandbox %s: %v", c.Name(), sb.ID(), err)
 			}
@@ -108,7 +109,7 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 			}
 		}
 	}
-	if err := s.StorageRuntimeServer().StopContainer(sb.ID()); err != nil && err != storage.ErrContainerUnknown {
+	if err := s.StorageRuntimeServer().StopContainer(sb.ID()); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {
 		logrus.Warnf("failed to stop sandbox container in pod sandbox %s: %v", sb.ID(), err)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubernetes-incubator/cri-o/pkg/storage"
 	"github.com/kubernetes-incubator/cri-o/server/apparmor"
 	"github.com/kubernetes-incubator/cri-o/server/seccomp"
+	"github.com/pkg/errors"
 	knet "k8s.io/apimachinery/pkg/util/net"
 	pb "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 	"k8s.io/kubernetes/pkg/kubelet/network/hostport"
@@ -77,7 +78,7 @@ func (s *Server) GetPortForward(req *pb.PortForwardRequest) (*pb.PortForwardResp
 
 func (s *Server) restore() {
 	containers, err := s.Store().Containers()
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !os.IsNotExist(errors.Cause(err)) {
 		logrus.Warnf("could not read containers and sandboxes: %v", err)
 	}
 	pods := map[string]*storage.RuntimeContainerMetadata{}


### PR DESCRIPTION
The storage library uses `github.com/pkg/errors` to wrap errors that it returns from many of its functions, so when passing them to `os.IsNotExist()` or comparing them to specific errors defined in the storage library, unwrap them using `errors.Cause()`.