### PR TITLE
Build a fixed version of ostree in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,10 @@ before_install:
 
 install:
   - make install.tools
+  - OSTREE_VERSION=v2017.9
   - git clone https://github.com/ostreedev/ostree ${TRAVIS_BUILD_DIR}/ostree
   - pushd ${TRAVIS_BUILD_DIR}/ostree
+  -   git checkout $OSTREE_VERSION
   -   ./autogen.sh --prefix=/usr/local
   -   make all
   -   sudo make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,6 @@ WORKDIR /go/src/github.com/kubernetes-incubator/cri-o
 
 ADD . /go/src/github.com/kubernetes-incubator/cri-o
 
-RUN make .install.ostree
-
 RUN make test/copyimg/copyimg \
 	&& mkdir -p .artifacts/redis-image \
 	&& ./test/copyimg/copyimg --import-from=docker://redis --export-to=dir:.artifacts/redis-image --signature-policy ./test/policy.json


### PR DESCRIPTION
Build glib in Travis, because ostree now requires a newer glib than we have in Trusty.