### PR TITLE
oci: fix build condition

### DIFF
--- a/oci/finished.go
+++ b/oci/finished.go
@@ -1,4 +1,4 @@
-// +build !arm !386
+// +build !arm,!386
 
 package oci
 


### PR DESCRIPTION
AND default conditions

should fix failure on arm and 386 I guess.

@rhatdan @lsm5 can you cherry-pick this patch to test it out before we merge?

Signed-off-by: Antonio Murdaca <runcom@redhat.com>