### PR TITLE
fix bug with creation time in ParseFilter()

### DIFF
--- a/cmd/kpod/images.go
+++ b/cmd/kpod/images.go
@@ -151,7 +151,7 @@ func outputImages(store storage.Store, images []storage.Image, format string, ha
 		if quiet {
 			fmt.Printf("%-64s\n", img.ID)
 			// We only want to print each id once
-			break
+			continue
 		}
 
 		params := imageOutputParams{


### PR DESCRIPTION
Previously, the creation time was set to the time the image was downloaded, but that was being compared to the time the image was built in matchesSinceImage() and matchesBeforeImage().  Updated the time to be the time that the image was built