### PR TITLE
build: Allow overwrite of BUILDTAGS variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LIBEXECDIR ?= ${PREFIX}/libexec
 MANDIR ?= ${PREFIX}/share/man
 ETCDIR ?= ${DESTDIR}/etc
 ETCDIR_CRIO ?= ${ETCDIR}/crio
-BUILDTAGS := selinux seccomp $(shell hack/btrfs_tag.sh) $(shell hack/libdm_tag.sh)
+BUILDTAGS ?= selinux seccomp $(shell hack/btrfs_tag.sh) $(shell hack/libdm_tag.sh)
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 
 GIT_COMMIT := $(shell git rev-parse --short HEAD)


### PR DESCRIPTION
This allows modifying the `BUILDTAGS` variable as documented in the README.