### PR TITLE
Remove testing with 1.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.6.x
   - 1.7.x
   - 1.8.x
   - tip


### PR DESCRIPTION
Some features cri-o is now using are not supported by golang 1.6.
All Distros that use CRI-O are now using golang 1.7 or better,
so no reason to test with this older version.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>