### PR TITLE
Add --debug flag to kpod to turn up logging level to debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,16 @@ It is currently in active development in the Kubernetes community through the [d
 | [kpod(1)](/docs/kpod.1.md)                 | Simple management tool for pods and images |
 | [kpod-history(1)](/docs/kpod-history.1.md)] | Shows the history of an image |
 | [kpod-images(1)](/docs/kpod-images.1.md)   | List images in local storage |
+| [kpod-info(1)](/docs/kpod-info.1.md)        | Display System Information                             |
 | [kpod-inspect(1)](/docs/kpod-inspect.1.md)       | Display the configuration of a container or image |
+| [kpod-mount(1)](/docs/kpod-mount.1.md)     | Mount a working container's root filesystem |
 | [kpod-load(1)](/docs/kpod-load.1.md)       | Load an image from docker archive or oci |
 | [kpod-pull(1)](/docs/kpod-pull.1.md)       | Pull an image from a registry |
 | [kpod-push(1)](/docs/kpod-push.1.md)       | Push an image to a specified destination |
 | [kpod-rmi(1)](/docs/kpod-rmi.1.md)         | Removes one or more images   |
 | [kpod-save(1)](/docs/kpod-save.1.md)       | Saves an image to an archive |
 | [kpod-tag(1)](/docs/kpod-tag.1.md)         | Add an additional name to a local image |
+| [kpod-umount(1)](/docs/kpod-umount.1.md)   | Unmount a working container's root filesystem |
 | [kpod-version(1)](/docs/kpod-version.1.md) | Display the Kpod Version Information |
 
 ## Configuration

--- a/cmd/kpod/common.go
+++ b/cmd/kpod/common.go
@@ -4,6 +4,7 @@ import (
 	is "github.com/containers/image/storage"
 	"github.com/containers/storage"
 	"github.com/kubernetes-incubator/cri-o/libkpod"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -46,5 +47,9 @@ func getConfig(c *cli.Context) (*libkpod.Config, error) {
 			config.StorageOptions = opts
 		}
 	}
+	if c.Bool("debug") {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+
 	return config, nil
 }

--- a/cmd/kpod/main.go
+++ b/cmd/kpod/main.go
@@ -15,6 +15,7 @@ func main() {
 	if reexec.Init() {
 		return
 	}
+	logrus.SetLevel(logrus.ErrorLevel)
 
 	app := cli.NewApp()
 	app.Name = "kpod"
@@ -27,20 +28,28 @@ func main() {
 		imagesCommand,
 		infoCommand,
 		inspectCommand,
+		loadCommand,
 		mountCommand,
 		pullCommand,
 		pushCommand,
 		rmiCommand,
+		saveCommand,
 		tagCommand,
 		umountCommand,
 		versionCommand,
-		saveCommand,
-		loadCommand,
 	}
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
+			Name:  "config, c",
+			Usage: "path of a config file detailing container server configuration options",
+		},
+		cli.BoolFlag{
+			Name:  "debug",
+			Usage: "print debugging information",
+		},
+		cli.StringFlag{
 			Name:  "root",
-			Usage: "path to the root directory in which data, including images,  is stored",
+			Usage: "path to the root directory in which data, including images, is stored",
 		},
 		cli.StringFlag{
 			Name:  "runroot",
@@ -54,12 +63,9 @@ func main() {
 			Name:  "storage-opt",
 			Usage: "used to pass an option to the storage driver",
 		},
-		cli.StringFlag{
-			Name:  "config, c",
-			Usage: "path of a config file detailing container server configuration options",
-		},
 	}
 	if err := app.Run(os.Args); err != nil {
-		logrus.Fatal(err)
+		logrus.Errorf(err.Error())
+		os.Exit(1)
 	}
 }

--- a/completions/bash/kpod
+++ b/completions/bash/kpod
@@ -28,6 +28,25 @@ _kpod_history() {
     esac
 }
 
+_kpod_info() {
+    local boolean_options="
+     --help
+     -h
+     --json
+     --debug
+     "
+    local options_with_args="
+  "
+
+    local all_options="$options_with_args $boolean_options"
+
+    case "$cur" in
+        -*)
+            COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
+            ;;
+    esac
+}
+
 _kpod_images() {
     local boolean_options="
      --help
@@ -52,7 +71,7 @@ _kpod_images() {
             COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
             ;;
     esac
- }
+}
 
 _kpod_launch() {
      local options_with_args="
@@ -220,14 +239,21 @@ _kpod_load() {
 
 _kpod_kpod() {
      local options_with_args="
-     "
+           --config -c
+           --root
+           --runroot
+           --storage-driver
+           --storage-opt
+    "
      local boolean_options="
-	   --version -v
-	   --help -h
+           --debug
+           --help -h
+           --version -v
      "
      commands="
     history
     images
+    info
     launch
     load
     mount

--- a/docs/kpod-info.1.md
+++ b/docs/kpod-info.1.md
@@ -21,9 +21,9 @@ Information display here pertain to the host, current storage stats, and build o
 
 Show additional information
 
-**--debug, -D**
+**--json**
 
-Show additional information
+Output as JSON instead of the default YAML",
 
 
 ## EXAMPLE

--- a/docs/kpod.1.md
+++ b/docs/kpod.1.md
@@ -5,8 +5,7 @@
 kpod - Simple management tool for containers and images
 
 ## SYNOPSIS
-**kpod**
-[**--help**|**-h**]
+**kpod** [*options*] COMMAND
 
 # DESCRIPTION
 kpod is a simple client only tool to help with debugging issues when daemons
@@ -23,6 +22,24 @@ has the capability to debug pods/images created by crio.
 
 **--help, -h**
   Print usage statement
+
+**--config value, -c**=**"config.file"**
+   Path of a config file detailing container server configuration options
+
+**--debug**
+   Print debugging information
+
+**--root**=**value**
+   Path to the root directory in which data, including images, is stored
+
+**--runroot**=**value**
+   Path to the 'run directory' where all state information is stored
+
+**--storage-driver, -s**=**value**
+   Select which storage driver is used to manage storage of images and containers (default is overlay)
+
+**--storage-opt**=**value**
+   Used to pass an option to the storage driver
 
 **--version, -v**
   Print the version


### PR DESCRIPTION
Also set default level of logging to errors,  we should not see
info messages in the kpod command line.

While adding this patch, I found missing options in kpod command line
and bash completions, so I added them in.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>