### PR TITLE
Do Not Merge: call update in libkpod.New()

### DIFF
--- a/libkpod/container_server.go
+++ b/libkpod/container_server.go
@@ -130,7 +130,7 @@ func New(config *Config) (*ContainerServer, error) {
 		lock = new(sync.Mutex)
 	}
 
-	return &ContainerServer{
+	c := &ContainerServer{
 		runtime:              runtime,
 		store:                store,
 		storageImageServer:   imageService,
@@ -146,7 +146,8 @@ func New(config *Config) (*ContainerServer, error) {
 			sandboxes:  make(map[string]*sandbox.Sandbox),
 		},
 		config: config,
-	}, nil
+	}
+	return c, c.Update()
 }
 
 // Update makes changes to the server's state (lists of pods and containers) to


### PR DESCRIPTION
libkpod.New() should call update to get the list of containers and pods on the disk, but I believe this causes errors in the server package