### PR TITLE
add 'enable OverlayFS' test env note

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -25,6 +25,18 @@ To run a single test bucket:
 $ make integration TESTFLAGS="runtimeversion.bats"
 ```
 
+NOTE: You need OverlayFS enabled. If there's no output from this command...
+
+```
+$ sudo lsmod | grep overlay
+```
+
+...then run...
+
+```
+$ sudo modprobe overlay
+```
+
 ### On your host
 
 To run the integration tests on your host, you will first need to setup a development environment plus


### PR DESCRIPTION
This was a gotcha for me when contributing a test. The error message is clear enough. This just spells out the required command explicitly.

Signed-off-by: Aaron Weitekamp <aweiteka@redhat.com>