### PR TITLE
Inotify exit watch

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -408,6 +408,10 @@ func main() {
 		// after the daemon is done setting up we can notify systemd api
 		notifySystem()
 
+		go func() {
+			service.StartExitMonitor()
+		}()
+
 		err = s.Serve(lis)
 		if graceful && strings.Contains(strings.ToLower(err.Error()), "use of closed network connection") {
 			err = nil

--- a/libkpod/config.go
+++ b/libkpod/config.go
@@ -22,6 +22,7 @@ const (
 	cniBinDir           = "/opt/cni/bin/"
 	cgroupManager       = "cgroupfs"
 	lockPath            = "/run/crio.lock"
+	containerExitsDir   = "/var/run/kpod/exits"
 )
 
 // Config represents the entire set of configuration values that can be set for
@@ -136,6 +137,10 @@ type RuntimeConfig struct {
 	// PidsLimit is the number of processes each container is restricted to
 	// by the cgroup process number controller.
 	PidsLimit int64 `toml:"pids_limit"`
+
+	// ContainerExitsDir is the directory in which container exit files are
+	// written to by conmon.
+	ContainerExitsDir string `toml:"container_exits_dir"`
 }
 
 // ImageConfig represents the "crio.image" TOML config table.
@@ -255,11 +260,12 @@ func DefaultConfig() *Config {
 			ConmonEnv: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			},
-			SELinux:         selinux.GetEnabled(),
-			SeccompProfile:  seccompProfilePath,
-			ApparmorProfile: apparmorProfileName,
-			CgroupManager:   cgroupManager,
-			PidsLimit:       DefaultPidsLimit,
+			SELinux:           selinux.GetEnabled(),
+			SeccompProfile:    seccompProfilePath,
+			ApparmorProfile:   apparmorProfileName,
+			CgroupManager:     cgroupManager,
+			PidsLimit:         DefaultPidsLimit,
+			ContainerExitsDir: containerExitsDir,
 		},
 		ImageConfig: ImageConfig{
 			DefaultTransport:    defaultTransport,

--- a/libkpod/container_server.go
+++ b/libkpod/container_server.go
@@ -114,7 +114,7 @@ func New(config *Config) (*ContainerServer, error) {
 		return nil, err
 	}
 
-	runtime, err := oci.New(config.Runtime, config.RuntimeUntrustedWorkload, config.DefaultWorkloadTrust, config.Conmon, config.ConmonEnv, config.CgroupManager)
+	runtime, err := oci.New(config.Runtime, config.RuntimeUntrustedWorkload, config.DefaultWorkloadTrust, config.Conmon, config.ConmonEnv, config.CgroupManager, config.ContainerExitsDir)
 	if err != nil {
 		return nil, err
 	}

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -66,10 +66,6 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 	}
 
 	for _, ctr := range ctrList {
-		if err := s.Runtime().UpdateStatus(ctr); err != nil {
-			return nil, err
-		}
-
 		podSandboxID := ctr.Sandbox()
 		cState := s.Runtime().ContainerStatus(ctr)
 		created := cState.Created.UnixNano()

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/kubernetes-incubator/cri-o/oci"
 	"github.com/sirupsen/logrus"
@@ -34,6 +36,10 @@ func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerReq
 
 	if err := s.Runtime().DeleteContainer(c); err != nil {
 		return nil, fmt.Errorf("failed to delete container %s: %v", c.ID(), err)
+	}
+
+	if err := os.Remove(filepath.Join(s.config.ContainerExitsDir, c.ID())); err != nil {
+		return nil, fmt.Errorf("failed to remove container exit file %s: %v", c.ID(), err)
 	}
 
 	s.removeContainer(c)


### PR DESCRIPTION
We add an inotify based container exit watch that can asynchronously update the status of the containers that have exited so we don't have to call runtime state on containers during container list which gets called frequently by the kubelet.

Replaces #747