### PR TITLE
Format

### DIFF
--- a/cmd/kpod/diff.go
+++ b/cmd/kpod/diff.go
@@ -1,10 +1,9 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-
 	"github.com/containers/storage/pkg/archive"
+	"github.com/kubernetes-incubator/cri-o/cmd/kpod/formats"
 	"github.com/kubernetes-incubator/cri-o/libkpod"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -16,6 +15,22 @@ type diffJSONOutput struct {
 	Deleted []string `json:"deleted,omitempty"`
 }
 
+type diffOutputParams struct {
+	Change archive.ChangeType
+	Path   string
+}
+
+type stdoutStruct struct {
+	output []diffOutputParams
+}
+
+func (so stdoutStruct) Out() error {
+	for _, d := range so.output {
+		fmt.Printf("%s %s\n", d.Change, d.Path)
+	}
+	return nil
+}
+
 var (
 	diffFlags = []cli.Flag{
 		cli.BoolFlag{
@@ -23,9 +38,9 @@ var (
 			Usage:  "Save the diff as a tar archive",
 			Hidden: true,
 		},
-		cli.BoolFlag{
-			Name:  "json",
-			Usage: "Format output as JSON",
+		cli.StringFlag{
+			Name:  "format",
+			Usage: "Change the output format.",
 		},
 	}
 	diffDescription = fmt.Sprint(`Displays changes on a container or image's filesystem.  The
@@ -40,6 +55,23 @@ var (
 		ArgsUsage:   "ID-NAME",
 	}
 )
+
+func formatJSON(output []diffOutputParams) (diffJSONOutput, error) {
+	jsonStruct := diffJSONOutput{}
+	for _, output := range output {
+		switch output.Change {
+		case archive.ChangeModify:
+			jsonStruct.Changed = append(jsonStruct.Changed, output.Path)
+		case archive.ChangeAdd:
+			jsonStruct.Added = append(jsonStruct.Added, output.Path)
+		case archive.ChangeDelete:
+			jsonStruct.Deleted = append(jsonStruct.Deleted, output.Path)
+		default:
+			return jsonStruct, errors.Errorf("output kind %q not recognized", output.Change.String())
+		}
+	}
+	return jsonStruct, nil
+}
 
 func diffCmd(c *cli.Context) error {
 	if len(c.Args()) != 1 {
@@ -61,29 +93,35 @@ func diffCmd(c *cli.Context) error {
 		return errors.Wrapf(err, "could not get changes for %q", to)
 	}
 
-	if c.Bool("json") {
-		jsonStruct := diffJSONOutput{}
-		for _, change := range changes {
-			if change.Kind == archive.ChangeModify {
-				jsonStruct.Changed = append(jsonStruct.Changed, change.Path)
-			} else if change.Kind == archive.ChangeAdd {
-				jsonStruct.Added = append(jsonStruct.Added, change.Path)
-			} else if change.Kind == archive.ChangeDelete {
-				jsonStruct.Deleted = append(jsonStruct.Deleted, change.Path)
-			} else {
-				return errors.Errorf("change kind %q not recognized", change.Kind.String())
-			}
+	diffOutput := []diffOutputParams{}
+	outputFormat := c.String("format")
+
+	for _, change := range changes {
+
+		params := diffOutputParams{
+			Change: change.Kind,
+			Path:   change.Path,
 		}
-		b, err := json.MarshalIndent(jsonStruct, "", "  ")
-		if err != nil {
-			return errors.Wrapf(err, "could not marshal json for %+v", jsonStruct)
-		}
-		fmt.Println(string(b))
-	} else {
-		for _, change := range changes {
-			fmt.Println(change.String())
-		}
+		diffOutput = append(diffOutput, params)
 	}
+
+	var out formats.Writer
+
+	if outputFormat != "" {
+		switch outputFormat {
+		case formats.JSONString:
+			data, err := formatJSON(diffOutput)
+			if err != nil {
+				return err
+			}
+			out = formats.JSONStruct{Output: data}
+		default:
+			return errors.New("only valid format for diff is 'json'")
+		}
+	} else {
+		out = stdoutStruct{output: diffOutput}
+	}
+	formats.Writer(out).Out()
 
 	return nil
 }

--- a/cmd/kpod/images.go
+++ b/cmd/kpod/images.go
@@ -33,7 +33,7 @@ var (
 		},
 		cli.StringFlag{
 			Name:  "format",
-			Usage: "Change the output format.",
+			Usage: "Change the output format to JSON or a Go template",
 		},
 		cli.StringFlag{
 			Name:  "filter, f",
@@ -160,10 +160,10 @@ func outputImages(store storage.Store, images []storage.Image, truncate, digests
 	var out formats.Writer
 
 	switch outputFormat {
-	case "json":
-		out = formats.JSONstruct{Output: toGeneric(imageOutput)}
+	case formats.JSONString:
+		out = formats.JSONStructArray{Output: toGeneric(imageOutput)}
 	default:
-		out = formats.StdoutTemplate{Output: toGeneric(imageOutput), Template: outputFormat, Fields: imageOutput[0].headerMap()}
+		out = formats.StdoutTemplateArray{Output: toGeneric(imageOutput), Template: outputFormat, Fields: imageOutput[0].headerMap()}
 	}
 
 	formats.Writer(out).Out()

--- a/cmd/kpod/mount.go
+++ b/cmd/kpod/mount.go
@@ -4,6 +4,7 @@ import (
 	js "encoding/json"
 	"fmt"
 
+	of "github.com/kubernetes-incubator/cri-o/cmd/kpod/formats"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -28,7 +29,7 @@ var (
 		},
 		cli.StringFlag{
 			Name:  "format",
-			Usage: "Print mounted containers in specified format",
+			Usage: "Change the output format to Go template",
 		},
 	}
 	mountCommand = cli.Command{
@@ -55,7 +56,7 @@ func mountCmd(c *cli.Context) error {
 	}
 
 	args := c.Args()
-	json := c.String("format") == "json"
+	json := c.String("format") == of.JSONString
 	if !formats[c.String("format")] {
 		return errors.Errorf("%q is not a supported format", c.String("format"))
 	}

--- a/completions/bash/kpod
+++ b/completions/bash/kpod
@@ -35,10 +35,10 @@ _kpod_info() {
     local boolean_options="
      --help
      -h
-     --json
      --debug
      "
     local options_with_args="
+    --format
   "
 
     local all_options="$options_with_args $boolean_options"

--- a/docs/kpod-diff.1.md
+++ b/docs/kpod-diff.1.md
@@ -13,9 +13,9 @@ Displays changes on a container or image's filesystem.  The container or image w
 
 ## OPTIONS
 
-**--json**
+**--format**
 
-Format output as json
+Alter the output into a different format.  The only valid format for diff is `json`.
 
 
 ## EXAMPLE
@@ -26,7 +26,7 @@ C /usr/local
 C /usr/local/bin
 A /usr/local/bin/docker-entrypoint.sh
 
-kpod diff --json redis:alpine
+kpod diff --format json redis:alpine
 {
   "changed": [
     "/usr",

--- a/docs/kpod-history.1.md
+++ b/docs/kpod-history.1.md
@@ -47,10 +47,8 @@ Valid placeholders for the Go template are listed below:
     Print the numeric IDs only
 
 **--format**
-    Pretty-print history of the image using a Go template
+    Alter the output for a format like 'json' or a Go template.
 
-**--json**
-    Print the history in JSON form
 
 ## COMMANDS
 
@@ -59,6 +57,8 @@ Valid placeholders for the Go template are listed below:
 **kpod history --no-trunc=true --human=false debian**
 
 **kpod history --format "{{.ID}} {{.Created}}" debian**
+
+**kpod history --format json debian**
 
 ## history
 Show the history of an image

--- a/docs/kpod-info.1.md
+++ b/docs/kpod-info.1.md
@@ -21,16 +21,16 @@ Information display here pertain to the host, current storage stats, and build o
 
 Show additional information
 
-**--json**
+**--format**
 
-Output as JSON instead of the default YAML",
+Change output format to "json" or a Go template.
 
 
 ## EXAMPLE
 
 `kpod info`
 
-`kpod info --debug --json | jq .host.kernel`
+`kpod info --debug --format json| jq .host.kernel`
 
 ## SEE ALSO
 crio(8), crio.conf(5)

--- a/test/kpod.bats
+++ b/test/kpod.bats
@@ -73,7 +73,7 @@ function teardown() {
 	[ "$status" -eq 0 ]
 }
 
-@test "kpod history with format" {
+@test "kpod history with Go template format" {
 	run ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
 	[ "$status" -eq 0 ]
 	run ${KPOD_BINARY} ${KPOD_OPTIONS} history --format "{{.ID}} {{.Created}}" $IMAGE
@@ -116,7 +116,7 @@ function teardown() {
 @test "kpod history json flag" {
 	run ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
 	[ "$status" -eq 0 ]
-	run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} history --json $IMAGE | python -m json.tool"
+	run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} history --format json $IMAGE | python -m json.tool"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	run ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE

--- a/test/kpod_diff.bats
+++ b/test/kpod_diff.bats
@@ -29,8 +29,8 @@ function teardown() {
 @test "test diff with json output" {
     run ${KPOD_BINARY} $KPOD_OPTIONS pull $IMAGE
     [ "$status" -eq 0 ]
-    # run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} diff --json $IMAGE | python -m json.tool"
-    run ${KPOD_BINARY} $KPOD_OPTIONS diff --json $IMAGE
+    # run bash -c "${KPOD_BINARY} ${KPOD_OPTIONS} diff --format json $IMAGE | python -m json.tool"
+    run ${KPOD_BINARY} $KPOD_OPTIONS diff --format json $IMAGE
     [ "$status" -eq 0 ]
     echo "$output"
     run ${KKPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE


### PR DESCRIPTION
Modify kpod diff --json to --format json
    
We want all kpod subcommands to use the formats code to output
formats like json.  Altering kpod diff --json to kpod diff --format json
like the kpod images command.
