### PR TITLE
Container status fixes

### DIFF
--- a/libkpod/container_server.go
+++ b/libkpod/container_server.go
@@ -355,6 +355,18 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		return err
 	}
 
+	if m.Annotations[annotations.Volumes] != "" {
+		containerVolumes := []oci.ContainerVolume{}
+		if err = json.Unmarshal([]byte(m.Annotations[annotations.Volumes]), &containerVolumes); err != nil {
+			return fmt.Errorf("failed to unmarshal container volumes: %v", err)
+		}
+		if containerVolumes != nil {
+			for _, cv := range containerVolumes {
+				scontainer.AddVolume(cv)
+			}
+		}
+	}
+
 	c.ContainerStateFromDisk(scontainer)
 
 	if err = label.ReserveLabel(processLabel); err != nil {

--- a/libkpod/container_server.go
+++ b/libkpod/container_server.go
@@ -350,7 +350,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		return err
 	}
 
-	scontainer, err := oci.NewContainer(m.Annotations[annotations.ContainerID], cname, sandboxPath, m.Annotations[annotations.LogPath], sb.NetNs(), labels, kubeAnnotations, "", nil, id, false, false, false, privileged, trusted, sandboxDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
+	scontainer, err := oci.NewContainer(m.Annotations[annotations.ContainerID], cname, sandboxPath, m.Annotations[annotations.LogPath], sb.NetNs(), labels, kubeAnnotations, "", "", "", nil, id, false, false, false, privileged, trusted, sandboxDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
 	if err != nil {
 		return err
 	}
@@ -440,6 +440,16 @@ func (c *ContainerServer) LoadContainer(id string) error {
 		img = ""
 	}
 
+	imgName, ok := m.Annotations[annotations.ImageName]
+	if !ok {
+		imgName = ""
+	}
+
+	imgRef, ok := m.Annotations[annotations.ImageRef]
+	if !ok {
+		imgRef = ""
+	}
+
 	kubeAnnotations := make(map[string]string)
 	if err = json.Unmarshal([]byte(m.Annotations[annotations.Annotations]), &kubeAnnotations); err != nil {
 		return err
@@ -450,7 +460,7 @@ func (c *ContainerServer) LoadContainer(id string) error {
 		return err
 	}
 
-	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], sb.NetNs(), labels, kubeAnnotations, img, &metadata, sb.ID(), tty, stdin, stdinOnce, sb.Privileged(), sb.Trusted(), containerDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
+	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], sb.NetNs(), labels, kubeAnnotations, img, imgName, imgRef, &metadata, sb.ID(), tty, stdin, stdinOnce, sb.Privileged(), sb.Trusted(), containerDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
 	if err != nil {
 		return err
 	}

--- a/libkpod/sandbox/sandbox.go
+++ b/libkpod/sandbox/sandbox.go
@@ -153,6 +153,7 @@ type Sandbox struct {
 	resolvPath     string
 	hostname       string
 	portMappings   []*hostport.PortMapping
+	stopped        bool
 }
 
 const (
@@ -379,6 +380,19 @@ func (s *Sandbox) NetNsCreate() error {
 	}
 
 	return nil
+}
+
+// SetStopped sets the sandbox state to stopped.
+// This should be set after a stop operation succeeds
+// so that subsequent stops can return fast.
+func (s *Sandbox) SetStopped() {
+	s.stopped = true
+}
+
+// Stopped returns whether the sandbox state has been
+// set to stopped.
+func (s *Sandbox) Stopped() bool {
+	return s.stopped
 }
 
 // NetNsJoin attempts to join the sandbox to an existing network namespace

--- a/oci/container.go
+++ b/oci/container.go
@@ -43,6 +43,8 @@ type Container struct {
 	// this is the /var/lib/storage/... directory
 	dir        string
 	stopSignal string
+	imageName  string
+	imageRef   string
 }
 
 // ContainerState represents the status of a container.
@@ -57,7 +59,7 @@ type ContainerState struct {
 }
 
 // NewContainer creates a container object.
-func NewContainer(id string, name string, bundlePath string, logPath string, netns ns.NetNS, labels map[string]string, annotations map[string]string, image string, metadata *pb.ContainerMetadata, sandbox string, terminal bool, stdin bool, stdinOnce bool, privileged bool, trusted bool, dir string, created time.Time, stopSignal string) (*Container, error) {
+func NewContainer(id string, name string, bundlePath string, logPath string, netns ns.NetNS, labels map[string]string, annotations map[string]string, image string, imageName string, imageRef string, metadata *pb.ContainerMetadata, sandbox string, terminal bool, stdin bool, stdinOnce bool, privileged bool, trusted bool, dir string, created time.Time, stopSignal string) (*Container, error) {
 	state := &ContainerState{}
 	state.Created = created
 	c := &Container{
@@ -76,6 +78,8 @@ func NewContainer(id string, name string, bundlePath string, logPath string, net
 		metadata:    metadata,
 		annotations: annotations,
 		image:       image,
+		imageName:   imageName,
+		imageRef:    imageRef,
 		dir:         dir,
 		state:       state,
 		stopSignal:  stopSignal,
@@ -153,6 +157,16 @@ func (c *Container) Annotations() map[string]string {
 // Image returns the image of the container.
 func (c *Container) Image() string {
 	return c.image
+}
+
+// ImageName returns the image name of the container.
+func (c *Container) ImageName() string {
+	return c.imageName
+}
+
+// ImageRef returns the image ref of the container.
+func (c *Container) ImageRef() string {
+	return c.imageRef
 }
 
 // Sandbox returns the sandbox name of the container.

--- a/oci/container.go
+++ b/oci/container.go
@@ -45,6 +45,14 @@ type Container struct {
 	stopSignal string
 	imageName  string
 	imageRef   string
+	volumes    []ContainerVolume
+}
+
+// ContainerVolume is a bind mount for the container.
+type ContainerVolume struct {
+	ContainerPath string `json:"container_path"`
+	HostPath      string `json:"host_path"`
+	Readonly      bool   `json:"readonly"`
 }
 
 // ContainerState represents the status of a container.
@@ -197,4 +205,15 @@ func (c *Container) State() *ContainerState {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 	return c.state
+}
+
+// AddVolume adds a volume to list of container volumes.
+func (c *Container) AddVolume(v ContainerVolume) {
+	c.volumes = append(c.volumes, v)
+}
+
+// Volumes returns the list of container volumes.
+func (c *Container) Volumes() []ContainerVolume {
+	return c.volumes
+
 }

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -22,6 +22,12 @@ const (
 	// Image is the container image ID annotation
 	Image = "io.kubernetes.cri-o.Image"
 
+	// ImageName is the container image name annotation
+	ImageName = "io.kubernetes.cri-o.ImageName"
+
+	// ImageRef is the container image ref annotation
+	ImageRef = "io.kubernetes.cri-o.ImageRef"
+
 	// KubeName is the kubernetes name annotation
 	KubeName = "io.kubernetes.cri-o.KubeName"
 

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -69,6 +69,9 @@ const (
 
 	// StdinOnce is the stdin_once annotation
 	StdinOnce = "io.kubernetes.cri-o.StdinOnce"
+
+	// Volumes is the volumes annotatoin
+	Volumes = "io.kubernetes.cri-o.Volumes"
 )
 
 // ContainerType values

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -334,10 +334,6 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 		return nil, err
 	}
 
-	if err = s.Runtime().UpdateStatus(container); err != nil {
-		return nil, err
-	}
-
 	s.addContainer(container)
 
 	if err = s.CtrIDIndex().Add(containerID); err != nil {

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -20,10 +20,6 @@ func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerReq
 		return nil, err
 	}
 
-	if err := s.Runtime().UpdateStatus(c); err != nil {
-		return nil, fmt.Errorf("failed to update container state: %v", err)
-	}
-
 	cState := s.Runtime().ContainerStatus(c)
 	if cState.Status == oci.ContainerStateCreated || cState.Status == oci.ContainerStateRunning {
 		if err := s.Runtime().StopContainer(c, -1); err != nil {

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -46,6 +46,17 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 	cState := s.Runtime().ContainerStatus(c)
 	rStatus := pb.ContainerState_CONTAINER_UNKNOWN
 
+	// If we defaulted to exit code -1 earlier then we attempt to
+	// get the exit code from the exit file again.
+	// TODO: We could wait in UpdateStatus for exit file to show up.
+	if cState.ExitCode == -1 {
+		err := s.Runtime().UpdateStatus(c)
+		if err != nil {
+			logrus.Warnf("Failed to UpdateStatus of container %s: %v", c.ID(), err)
+		}
+		cState = s.Runtime().ContainerStatus(c)
+	}
+
 	switch cState.Status {
 	case oci.ContainerStateCreated:
 		rStatus = pb.ContainerState_CONTAINER_CREATED

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -26,11 +26,6 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 		return nil, err
 	}
 
-	if err = s.Runtime().UpdateStatus(c); err != nil {
-		return nil, err
-	}
-	s.ContainerStateToDisk(c)
-
 	containerID := c.ID()
 	resp := &pb.ContainerStatusResponse{
 		Status: &pb.ContainerStatus{

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -30,6 +30,6 @@ func (s *Server) StopContainer(ctx context.Context, req *pb.StopContainerRequest
 	s.ContainerStateToDisk(c)
 
 	resp := &pb.StopContainerResponse{}
-	logrus.Debugf("StopContainerResponse: %+v", resp)
+	logrus.Debugf("StopContainerResponse %s: %+v", c.ID(), resp)
 	return resp, nil
 }

--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -17,9 +17,6 @@ func (s *Server) StopContainer(ctx context.Context, req *pb.StopContainerRequest
 		return nil, err
 	}
 
-	if err := s.Runtime().UpdateStatus(c); err != nil {
-		return nil, err
-	}
 	cStatus := s.Runtime().ContainerStatus(c)
 	if cStatus.Status != oci.ContainerStateStopped {
 		if err := s.Runtime().StopContainer(c, req.Timeout); err != nil {

--- a/server/sandbox_list.go
+++ b/server/sandbox_list.go
@@ -60,10 +60,6 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxReque
 			// it's better not to panic
 			continue
 		}
-		if err := s.Runtime().UpdateStatus(podInfraContainer); err != nil {
-			return nil, err
-		}
-
 		cState := s.Runtime().ContainerStatus(podInfraContainer)
 		created := cState.Created.UnixNano()
 		rStatus := pb.PodSandboxState_SANDBOX_NOTREADY

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -38,11 +38,13 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 
 	// Delete all the containers in the sandbox
 	for _, c := range containers {
-		cState := s.Runtime().ContainerStatus(c)
-		if cState.Status == oci.ContainerStateCreated || cState.Status == oci.ContainerStateRunning {
-			if err := s.Runtime().StopContainer(c, -1); err != nil {
-				// Assume container is already stopped
-				logrus.Warnf("failed to stop container %s: %v", c.Name(), err)
+		if !sb.Stopped() {
+			cState := s.Runtime().ContainerStatus(c)
+			if cState.Status == oci.ContainerStateCreated || cState.Status == oci.ContainerStateRunning {
+				if err := s.Runtime().StopContainer(c, -1); err != nil {
+					// Assume container is already stopped
+					logrus.Warnf("failed to stop container %s: %v", c.Name(), err)
+				}
 			}
 		}
 

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -38,10 +38,6 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 
 	// Delete all the containers in the sandbox
 	for _, c := range containers {
-		if err := s.Runtime().UpdateStatus(c); err != nil {
-			return nil, fmt.Errorf("failed to update container state: %v", err)
-		}
-
 		cState := s.Runtime().ContainerStatus(c)
 		if cState.Status == oci.ContainerStateCreated || cState.Status == oci.ContainerStateRunning {
 			if err := s.Runtime().StopContainer(c, -1); err != nil {

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -78,19 +78,9 @@ func (s *Server) runContainer(container *oci.Container, cgroupParent string) err
 	if err := s.Runtime().CreateContainer(container, cgroupParent); err != nil {
 		return err
 	}
-
-	if err := s.Runtime().UpdateStatus(container); err != nil {
-		return err
-	}
-
 	if err := s.Runtime().StartContainer(container); err != nil {
 		return err
 	}
-
-	if err := s.Runtime().UpdateStatus(container); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -461,7 +461,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, fmt.Errorf("failed to write runtime configuration for pod sandbox %s(%s): %v", sb.Name(), id, err)
 	}
 
-	container, err := oci.NewContainer(id, containerName, podContainer.RunDir, logPath, sb.NetNs(), labels, kubeAnnotations, "", nil, id, false, false, false, sb.Privileged(), sb.Trusted(), podContainer.Dir, created, podContainer.Config.Config.StopSignal)
+	container, err := oci.NewContainer(id, containerName, podContainer.RunDir, logPath, sb.NetNs(), labels, kubeAnnotations, "", "", "", nil, id, false, false, false, sb.Privileged(), sb.Trusted(), podContainer.Dir, created, podContainer.Config.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}

--- a/server/sandbox_status.go
+++ b/server/sandbox_status.go
@@ -16,11 +16,6 @@ func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusR
 	}
 
 	podInfraContainer := sb.InfraContainer()
-	if err = s.Runtime().UpdateStatus(podInfraContainer); err != nil {
-		return nil, err
-	}
-	s.ContainerStateToDisk(podInfraContainer)
-
 	cState := s.Runtime().ContainerStatus(podInfraContainer)
 
 	netNsPath, err := podInfraContainer.NetNsPath()

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -37,6 +37,10 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 		return resp, nil
 	}
 
+	if sb.Stopped() {
+		return &pb.StopPodSandboxResponse{}, nil
+	}
+
 	podInfraContainer := sb.InfraContainer()
 	netnsPath, err := podInfraContainer.NetNsPath()
 	if err != nil {
@@ -110,6 +114,7 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 		logrus.Warnf("failed to stop sandbox container in pod sandbox %s: %v", sb.ID(), err)
 	}
 
+	sb.SetStopped()
 	resp := &pb.StopPodSandboxResponse{}
 	logrus.Debugf("StopPodSandboxResponse: %+v", resp)
 	return resp, nil

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -34,11 +34,14 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 
 		resp := &pb.StopPodSandboxResponse{}
 		logrus.Warnf("could not get sandbox %s, it's probably been stopped already: %v", req.PodSandboxId, err)
+		logrus.Debugf("StopPodSandboxResponse %s: %+v", req.PodSandboxId, resp)
 		return resp, nil
 	}
 
 	if sb.Stopped() {
-		return &pb.StopPodSandboxResponse{}, nil
+		resp := &pb.StopPodSandboxResponse{}
+		logrus.Debugf("StopPodSandboxResponse %s: %+v", sb.ID(), resp)
+		return resp, nil
 	}
 
 	podInfraContainer := sb.InfraContainer()
@@ -116,7 +119,7 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 
 	sb.SetStopped()
 	resp := &pb.StopPodSandboxResponse{}
-	logrus.Debugf("StopPodSandboxResponse: %+v", resp)
+	logrus.Debugf("StopPodSandboxResponse %s: %+v", sb.ID(), resp)
 	return resp, nil
 }
 

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -70,9 +70,6 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 	containers = append(containers, podInfraContainer)
 
 	for _, c := range containers {
-		if err := s.Runtime().UpdateStatus(c); err != nil {
-			return nil, err
-		}
 		cStatus := s.Runtime().ContainerStatus(c)
 		if cStatus.Status != oci.ContainerStateStopped {
 			if err := s.Runtime().StopContainer(c, -1); err != nil {


### PR DESCRIPTION
We calculate and store the container bind mounts, imageRef and imageName at container creation time so we can avoid the hit of calculation in container status API. Also, we take out the call to runtime status from container status API as the inotify watch should update the container status asynchronously already. We also remove a number of calls to UpdateStatus that aren't required in containers and sandboxes.