### PR TITLE
[wip] Vendor in latest container/storage

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -360,7 +360,16 @@ func main() {
 
 		return nil
 	}
-
+	app.After = func(*cli.Context) error {
+		// called by Run() when the command handler succeeds
+		libkpod.ShutdownStores(false)
+		return nil
+	}
+	cli.OsExiter = func(code int) {
+		// called by Run() when the command fails, bypassing After()
+		libkpod.ShutdownStores(false)
+		os.Exit(code)
+	}
 	app.Action = func(c *cli.Context) error {
 		if c.GlobalBool("profile") {
 			profilePort := c.GlobalInt("profile-port")

--- a/cmd/kpod/common.go
+++ b/cmd/kpod/common.go
@@ -14,10 +14,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-var (
-	stores = make(map[storage.Store]struct{})
-)
-
 func getStore(c *libkpod.Config) (storage.Store, error) {
 	options := storage.DefaultStoreOptions
 	options.GraphRoot = c.Root
@@ -30,7 +26,7 @@ func getStore(c *libkpod.Config) (storage.Store, error) {
 		return nil, err
 	}
 	is.Transport.SetStore(store)
-	stores[store] = struct{}{}
+	libkpod.AddStore(store)
 	return store, nil
 }
 

--- a/cmd/kpod/main.go
+++ b/cmd/kpod/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/containers/storage/pkg/reexec"
+	"github.com/kubernetes-incubator/cri-o/libkpod"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -49,12 +50,12 @@ func main() {
 	}
 	app.After = func(*cli.Context) error {
 		// called by Run() when the command handler succeeds
-		shutdownStores()
+		libkpod.ShutdownStores(false)
 		return nil
 	}
 	cli.OsExiter = func(code int) {
 		// called by Run() when the command fails, bypassing After()
-		shutdownStores()
+		libkpod.ShutdownStores(false)
 		os.Exit(code)
 	}
 	app.Flags = []cli.Flag{

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -103,7 +103,7 @@ func addImageVolumes(rootfs string, s *Server, containerInfo *storage.ContainerI
 			}
 		case libkpod.ImageVolumesBind:
 			volumeDirName := stringid.GenerateNonCryptoID()
-			src := filepath.Join(containerInfo.RunDir, "mounts", volumeDirName)
+			src := filepath.Join(containerInfo.Dir, "mounts", volumeDirName)
 			if err1 := os.MkdirAll(src, 0644); err1 != nil {
 				return err1
 			}
@@ -975,7 +975,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	if err = specgen.SaveToFile(filepath.Join(containerInfo.Dir, "config.json"), saveOptions); err != nil {
 		return nil, err
 	}
-	if err = specgen.SaveToFile(filepath.Join(containerInfo.RunDir, "config.json"), saveOptions); err != nil {
+	if err = specgen.SaveToFile(filepath.Join(containerInfo.Dir, "config.json"), saveOptions); err != nil {
 		return nil, err
 	}
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -8,7 +8,7 @@ github.com/sirupsen/logrus v1.0.0
 github.com/containers/image abb4cd79e3427bb2b02a5930814ef2ad19983c24
 github.com/docker/docker-credential-helpers d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1
 github.com/ostreedev/ostree-go master
-github.com/containers/storage f8cff0727cf0802f0752ca58d2c05ec5270a47d5
+github.com/containers/storage 71b14b06d4f19e3870c24cc1bca0ede685a532c2 https://github.com/rhatdan/storage
 github.com/containernetworking/cni v0.4.0
 google.golang.org/grpc v1.0.4 https://github.com/grpc/grpc-go
 github.com/opencontainers/selinux v1.0.0-rc1

--- a/vendor/github.com/containers/storage/containers.go
+++ b/vendor/github.com/containers/storage/containers.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -11,11 +10,6 @@ import (
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/containers/storage/pkg/truncindex"
-)
-
-var (
-	// ErrContainerUnknown indicates that there was no container with the specified name or ID
-	ErrContainerUnknown = errors.New("container not known")
 )
 
 // A Container is a reference to a read-write layer with metadata.

--- a/vendor/github.com/containers/storage/errors.go
+++ b/vendor/github.com/containers/storage/errors.go
@@ -1,0 +1,52 @@
+package storage
+
+import (
+	"errors"
+)
+
+var (
+	// ErrContainerUnknown indicates that there was no container with the specified name or ID.
+	ErrContainerUnknown = errors.New("container not known")
+	// ErrImageUnknown indicates that there was no image with the specified name or ID.
+	ErrImageUnknown = errors.New("image not known")
+	// ErrParentUnknown indicates that we didn't record the ID of the parent of the specified layer.
+	ErrParentUnknown = errors.New("parent of layer not known")
+	// ErrLayerUnknown indicates that there was no layer with the specified name or ID.
+	ErrLayerUnknown = errors.New("layer not known")
+	// ErrLoadError indicates that there was an initialization error.
+	ErrLoadError = errors.New("error loading storage metadata")
+	// ErrDuplicateID indicates that an ID which is to be assigned to a new item is already being used.
+	ErrDuplicateID = errors.New("that ID is already in use")
+	// ErrDuplicateName indicates that a name which is to be assigned to a new item is already being used.
+	ErrDuplicateName = errors.New("that name is already in use")
+	// ErrParentIsContainer is returned when a caller attempts to create a layer as a child of a container's layer.
+	ErrParentIsContainer = errors.New("would-be parent layer is a container")
+	// ErrNotAContainer is returned when the caller attempts to delete a container that isn't a container.
+	ErrNotAContainer = errors.New("identifier is not a container")
+	// ErrNotAnImage is returned when the caller attempts to delete an image that isn't an image.
+	ErrNotAnImage = errors.New("identifier is not an image")
+	// ErrNotALayer is returned when the caller attempts to delete a layer that isn't a layer.
+	ErrNotALayer = errors.New("identifier is not a layer")
+	// ErrNotAnID is returned when the caller attempts to read or write metadata from an item that doesn't exist.
+	ErrNotAnID = errors.New("identifier is not a layer, image, or container")
+	// ErrLayerHasChildren is returned when the caller attempts to delete a layer that has children.
+	ErrLayerHasChildren = errors.New("layer has children")
+	// ErrLayerUsedByImage is returned when the caller attempts to delete a layer that is an image's top layer.
+	ErrLayerUsedByImage = errors.New("layer is in use by an image")
+	// ErrLayerUsedByContainer is returned when the caller attempts to delete a layer that is a container's layer.
+	ErrLayerUsedByContainer = errors.New("layer is in use by a container")
+	// ErrImageUsedByContainer is returned when the caller attempts to delete an image that is a container's image.
+	ErrImageUsedByContainer = errors.New("image is in use by a container")
+	// ErrIncompleteOptions is returned when the caller attempts to initialize a Store without providing required information.
+	ErrIncompleteOptions = errors.New("missing necessary StoreOptions")
+	// ErrSizeUnknown is returned when the caller asks for the size of a big data item, but the Store couldn't determine the answer.
+	ErrSizeUnknown = errors.New("size is not known")
+	// ErrStoreIsReadOnly is returned when the caller makes a call to a read-only store that would require modifying its contents.
+	ErrStoreIsReadOnly = errors.New("called a write method on a read-only store")
+	// ErrLockReadOnly indicates that the caller only took a read-only lock, and is not allowed to write.
+	ErrLockReadOnly = errors.New("lock is not a read-write lock")
+	// ErrDuplicateImageNames indicates that the read-only store uses the same name for multiple images.
+	ErrDuplicateImageNames = errors.New("read-only image store assigns the same name to multiple images")
+	// ErrDuplicateLayerNames indicates that the read-only store uses the same name for multiple layers.
+	ErrDuplicateLayerNames = errors.New("read-only layer store assigns the same name to multiple layers")
+)

--- a/vendor/github.com/containers/storage/images.go
+++ b/vendor/github.com/containers/storage/images.go
@@ -13,11 +13,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	// ErrImageUnknown indicates that there was no image with the specified name or ID
-	ErrImageUnknown = errors.New("image not known")
-)
-
 // An Image is a reference to a layer and an associated metadata string.
 type Image struct {
 	// ID is either one which was specified at create-time, or a random
@@ -153,7 +148,7 @@ func (r *imageStore) Load() error {
 		}
 	}
 	if shouldSave && !r.IsReadWrite() {
-		return errors.New("image store assigns the same name to multiple images")
+		return ErrDuplicateImageNames
 	}
 	r.images = images
 	r.idindex = truncindex.NewTruncIndex(idlist)

--- a/vendor/github.com/containers/storage/layers.go
+++ b/vendor/github.com/containers/storage/layers.go
@@ -27,13 +27,6 @@ const (
 	compressionFlag = "diff-compression"
 )
 
-var (
-	// ErrParentUnknown indicates that we didn't record the ID of the parent of the specified layer
-	ErrParentUnknown = errors.New("parent of layer not known")
-	// ErrLayerUnknown indicates that there was no layer with the specified name or ID
-	ErrLayerUnknown = errors.New("layer not known")
-)
-
 // A Layer is a record of a copy-on-write layer that's stored by the lower
 // level graph driver.
 type Layer struct {
@@ -280,7 +273,7 @@ func (r *layerStore) Load() error {
 		}
 	}
 	if shouldSave && !r.IsReadWrite() {
-		return errors.New("layer store assigns the same name to multiple layers")
+		return ErrDuplicateLayerNames
 	}
 	mpath := r.mountspath()
 	data, err = ioutil.ReadFile(mpath)

--- a/vendor/github.com/containers/storage/lockfile.go
+++ b/vendor/github.com/containers/storage/lockfile.go
@@ -44,8 +44,6 @@ type lockfile struct {
 var (
 	lockfiles     map[string]*lockfile
 	lockfilesLock sync.Mutex
-	// ErrLockReadOnly indicates that the caller only took a read-only lock, and is not allowed to write
-	ErrLockReadOnly = errors.New("lock is not a read-write lock")
 )
 
 // GetLockfile opens a read-write lock file, creating it if necessary.  The

--- a/vendor/github.com/containers/storage/pkg/archive/example_changes.go
+++ b/vendor/github.com/containers/storage/pkg/archive/example_changes.go
@@ -1,0 +1,97 @@
+// +build ignore
+
+// Simple tool to create an archive stream from an old and new directory
+//
+// By default it will stream the comparison of two temporary directories with junk files
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/containers/storage/pkg/archive"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	flDebug  = flag.Bool("D", false, "debugging output")
+	flNewDir = flag.String("newdir", "", "")
+	flOldDir = flag.String("olddir", "", "")
+	log      = logrus.New()
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Println("Produce a tar from comparing two directory paths. By default a demo tar is created of around 200 files (including hardlinks)")
+		fmt.Printf("%s [OPTIONS]\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	log.Out = os.Stderr
+	if (len(os.Getenv("DEBUG")) > 0) || *flDebug {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+	var newDir, oldDir string
+
+	if len(*flNewDir) == 0 {
+		var err error
+		newDir, err = ioutil.TempDir("", "storage-test-newDir")
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer os.RemoveAll(newDir)
+		if _, err := prepareUntarSourceDirectory(100, newDir, true); err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		newDir = *flNewDir
+	}
+
+	if len(*flOldDir) == 0 {
+		oldDir, err := ioutil.TempDir("", "storage-test-oldDir")
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer os.RemoveAll(oldDir)
+	} else {
+		oldDir = *flOldDir
+	}
+
+	changes, err := archive.ChangesDirs(newDir, oldDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	a, err := archive.ExportChanges(newDir, changes)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer a.Close()
+
+	i, err := io.Copy(os.Stdout, a)
+	if err != nil && err != io.EOF {
+		log.Fatal(err)
+	}
+	fmt.Fprintf(os.Stderr, "wrote archive of %d bytes", i)
+}
+
+func prepareUntarSourceDirectory(numberOfFiles int, targetPath string, makeLinks bool) (int, error) {
+	fileData := []byte("fooo")
+	for n := 0; n < numberOfFiles; n++ {
+		fileName := fmt.Sprintf("file-%d", n)
+		if err := ioutil.WriteFile(path.Join(targetPath, fileName), fileData, 0700); err != nil {
+			return 0, err
+		}
+		if makeLinks {
+			if err := os.Link(path.Join(targetPath, fileName), path.Join(targetPath, fileName+"-link")); err != nil {
+				return 0, err
+			}
+		}
+	}
+	totalSize := numberOfFiles * len(fileData)
+	return totalSize, nil
+}

--- a/vendor/github.com/containers/storage/pkg/mount/mount.go
+++ b/vendor/github.com/containers/storage/pkg/mount/mount.go
@@ -2,6 +2,8 @@ package mount
 
 import (
 	"time"
+
+	"github.com/containers/storage/pkg/fileutils"
 )
 
 // GetMounts retrieves a list of mounts for the current running process.
@@ -17,6 +19,10 @@ func Mounted(mountpoint string) (bool, error) {
 		return false, err
 	}
 
+	mountpoint, err = fileutils.ReadSymlinkedDirectory(mountpoint)
+	if err != nil {
+		return false, err
+	}
 	// Search the table for the mountpoint
 	for _, e := range entries {
 		if e.Mountpoint == mountpoint {

--- a/vendor/github.com/containers/storage/pkg/mount/sharedsubtree_notlinux.go
+++ b/vendor/github.com/containers/storage/pkg/mount/sharedsubtree_notlinux.go
@@ -1,0 +1,9 @@
+// +build !linux
+
+package mount
+
+// MakePrivate ensures a mounted filesystem has the PRIVATE mount option enabled.
+// See the supported options in flags.go for further reference.
+func MakePrivate(mountPoint string) error {
+	return nil
+}


### PR DESCRIPTION
This container/storage will mount /run/containers/storage as a
private mount so that cri-o stops leaking shm mountpoints in to the
hosts namespace.  Will also fix issues with oci-umount cleaning up
mount points.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>