### PR TITLE
utils: Fix close conn after starting scope

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -64,6 +64,7 @@ func RunUnderSystemdScope(pid int, slice string, unitName string) error {
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 
 	// Block until job is started
 	<-ch


### PR DESCRIPTION
This fixes the goroutine leak in cri-o.

Signed-off-by: Mrunal Patel <mpatel@redhat.com>