### PR TITLE
Makefile: install alias, not symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,8 +152,8 @@ install.completions:
 
 install.systemd:
 	install -D -m 644 contrib/systemd/crio.service $(PREFIX)/lib/systemd/system/crio.service
+	install -D -m 644 contrib/systemd/crio.service $(PREFIX)/lib/systemd/system/cri-o.service
 	install -D -m 644 contrib/systemd/crio-shutdown.service $(PREFIX)/lib/systemd/system/crio-shutdown.service
-	ln -s crio.service $(PREFIX)/lib/systemd/system/cri-o.service
 
 uninstall:
 	rm -f $(BINDIR)/crio


### PR DESCRIPTION
`ln -s` errors out with `file exists` if you run `make install.systemd` twice or more. This patch installs the alias directly w/o using a symlink so it can be run multiple times w/o errors.

@rhatdan PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>