### PR TITLE
Touchup apt to apt-get in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ yum install -y \
 Debian, Ubuntu, and related distributions:
 
 ```bash
-apt install -y \
+apt-get install -y \
   btrfs-tools \
   libassuan-dev \
   libdevmapper-dev \
@@ -137,7 +137,7 @@ Fedora, CentOS, RHEL, and related distributions:
 Debian, Ubuntu, and related distributions:
 
 ```bash
-apt install -y \
+apt-get install -y \
   libapparmor-dev
 ```
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Replaces https://github.com/kubernetes-incubator/cri-o/pull/797.

Touches up README.md with appropriate command