### PR TITLE
Change back to linking crio.service to cri-o.service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ install.completions:
 install.systemd:
 	install -D -m 644 contrib/systemd/crio.service $(PREFIX)/lib/systemd/system/crio.service
 	install -D -m 644 contrib/systemd/crio.service $(PREFIX)/lib/systemd/system/cri-o.service
-	install -D -m 644 contrib/systemd/crio-shutdown.service $(PREFIX)/lib/systemd/system/crio-shutdown.service
+	ln -fs crio.service $(PREFIX)/lib/systemd/system/cri-o.service
 
 uninstall:
 	rm -f $(BINDIR)/crio


### PR DESCRIPTION
We don't want to install two different services, but link one
to the other.  I have added a -f flag so that this will fix the
issue where you install twice.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>