### PR TITLE
server: container_remove: ignore not existent exit file

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -153,7 +153,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "crio"
 	app.Usage = "crio server"
-	app.Version = "1.0.0-alpha.0"
+	app.Version = "1.0.0-beta.0"
 	app.Metadata = map[string]interface{}{
 		"config": server.DefaultConfig(),
 	}

--- a/cmd/crioctl/main.go
+++ b/cmd/crioctl/main.go
@@ -67,7 +67,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "crioctl"
 	app.Usage = "client for crio"
-	app.Version = "1.0.0-alpha.0"
+	app.Version = "1.0.0-beta.0"
 
 	app.Commands = []cli.Command{
 		podSandboxCommand,

--- a/server/container_remove.go
+++ b/server/container_remove.go
@@ -34,7 +34,7 @@ func (s *Server) RemoveContainer(ctx context.Context, req *pb.RemoveContainerReq
 		return nil, fmt.Errorf("failed to delete container %s: %v", c.ID(), err)
 	}
 
-	if err := os.Remove(filepath.Join(s.config.ContainerExitsDir, c.ID())); err != nil {
+	if err := os.Remove(filepath.Join(s.config.ContainerExitsDir, c.ID())); err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("failed to remove container exit file %s: %v", c.ID(), err)
 	}
 

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -48,7 +48,6 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 
 	// If we defaulted to exit code -1 earlier then we attempt to
 	// get the exit code from the exit file again.
-	// TODO: We could wait in UpdateStatus for exit file to show up.
 	if cState.ExitCode == -1 {
 		err := s.Runtime().UpdateStatus(c)
 		if err != nil {


### PR DESCRIPTION
Found out that during OpenShift testing, node was trying to remove
containers (probably in a bad state) and was failing the removal with
this kind of error:
```
E0828 13:19:46.082710    1235 kuberuntime_gc.go:127] Failed to remove
container
"e907f0f46b969e0dc83ca82c03ae7dd072cfe4155341e4521223d9fe3dec5afb": rpc
error: code = 2 desc = failed to remove container exit file
e907f0f46b969e0dc83ca82c03ae7dd072cfe4155341e4521223d9fe3dec5afb: remove
/var/run/crio/exits/e907f0f46b969e0dc83ca82c03ae7dd072cfe4155341e4521223d9fe3dec5afb:
no such file or directory
```
I believe it's ok to ignore this error as it may happen conmon will
fail early before exit file is written.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>