### PR TITLE
Add image_id to json output

### DIFF
--- a/cmd/kpod/ps.go
+++ b/cmd/kpod/ps.go
@@ -53,6 +53,7 @@ type psTemplateParams struct {
 type psJSONParams struct {
 	ID               string              `json:"id"`
 	Image            string              `json:"image"`
+	ImageID          string              `json:"image_id"`
 	Command          string              `json:"command"`
 	CreatedAt        time.Time           `json:"createdAt"`
 	RunningFor       time.Duration       `json:"runningFor"`
@@ -296,6 +297,7 @@ func getJSONOutput(containers []*libkpod.ContainerData) (psOutput []psJSONParams
 		params := psJSONParams{
 			ID:               ctr.ID,
 			Image:            ctr.FromImage,
+			ImageID:          ctr.FromImageID,
 			Command:          ctr.ImageCreatedBy,
 			CreatedAt:        ctr.State.Created,
 			RunningFor:       time.Since(ctr.State.Created),

--- a/docs/kpod-images.1.md
+++ b/docs/kpod-images.1.md
@@ -51,6 +51,8 @@ kpod images --format json
 
 kpod images --format "{{.ID}}"
 
+kpod images --filter dangling=true
+
 ## SEE ALSO
 kpod(1)
 


### PR DESCRIPTION
Consumers of the json output, like the atomic cli, need the ID of the
image for the container as well as the name.  Specifically, it is used
to tract "used" and "vulnerable" images.

Signed-off-by: baude <bbaude@redhat.com>