### PR TITLE
Remove duplicate kpod command names

### DIFF
--- a/cmd/kpod/main.go
+++ b/cmd/kpod/main.go
@@ -34,12 +34,10 @@ func main() {
 		renameCommand,
 		rmiCommand,
 		saveCommand,
+		statsCommand,
 		tagCommand,
 		umountCommand,
 		versionCommand,
-		saveCommand,
-		statsCommand,
-		loadCommand,
 	}
 	app.Before = func(c *cli.Context) error {
 		logrus.SetLevel(logrus.ErrorLevel)


### PR DESCRIPTION
Some kpod commands were listed twice in main.go.  Removed these duplicates and alphabetized the remaining commands to prevent this from happening in the future