### PR TITLE
Make kpod parse configuration file

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -21,8 +21,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
 
-const crioConfigPath = "/etc/crio/crio.conf"
-
 func validateConfig(config *server.Config) error {
 	switch config.ImageVolumes {
 	case libkpod.ImageVolumesMkdir:
@@ -46,7 +44,7 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 			// We don't error out if --config wasn't explicitly set and the
 			// default doesn't exist. But we will log a warning about it, so
 			// the user doesn't miss it.
-			logrus.Warnf("default configuration file does not exist: %s", crioConfigPath)
+			logrus.Warnf("default configuration file does not exist: %s", server.CrioConfigPath)
 		}
 	}
 
@@ -161,7 +159,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "config",
-			Value: crioConfigPath,
+			Value: server.CrioConfigPath,
 			Usage: "path to configuration file",
 		},
 		cli.StringFlag{

--- a/cmd/kpod/common.go
+++ b/cmd/kpod/common.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"os"
 	"strings"
 
 	is "github.com/containers/image/storage"
 	"github.com/containers/storage"
 	"github.com/fatih/camelcase"
 	"github.com/kubernetes-incubator/cri-o/libkpod"
+	"github.com/kubernetes-incubator/cri-o/server"
 	"github.com/urfave/cli"
 )
 
@@ -40,8 +42,16 @@ func shutdownStores() {
 
 func getConfig(c *cli.Context) (*libkpod.Config, error) {
 	config := libkpod.DefaultConfig()
+	var configFile string
 	if c.GlobalIsSet("config") {
-		err := config.UpdateFromFile(c.String("config"))
+		configFile = c.GlobalString("config")
+	} else if _, err := os.Stat(server.CrioConfigPath); err == nil {
+		configFile = server.CrioConfigPath
+	}
+	// load and merge the configfile from the commandline or use
+	// the default crio config file
+	if configFile != "" {
+		err := config.UpdateFromFile(configFile)
 		if err != nil {
 			return config, err
 		}

--- a/server/config.go
+++ b/server/config.go
@@ -8,6 +8,9 @@ import (
 	"github.com/kubernetes-incubator/cri-o/libkpod"
 )
 
+//CrioConfigPath is the default location for the conf file
+const CrioConfigPath = "/etc/crio/crio.conf"
+
 // Config represents the entire set of configuration values that can be set for
 // the server. This is intended to be loaded from a toml-encoded config file.
 type Config struct {


### PR DESCRIPTION
kpod must parse the crio configuration file or the storage
is not set up correctly.  By default it is not.  We now pass
/etc/crio/crio.conf in as the configuration file as part of the
command line parser.  This can of course be overriden by the user.

Signed-off-by: baude <bbaude@redhat.com>