### PR TITLE
monitor CNI networks continuously

### DIFF
--- a/pkg/ocicni/ocicni.go
+++ b/pkg/ocicni/ocicni.go
@@ -54,9 +54,8 @@ func (plugin *cniNetworkPlugin) monitorNetDir() {
 				}
 
 				if err = plugin.syncNetworkConfig(); err == nil {
-					logrus.Debugf("CNI asynchronous setting succeeded")
-					close(plugin.monitorNetDirChan)
-					return
+					logrus.Infof("CNI asynchronous setting succeeded")
+					continue
 				}
 
 				logrus.Errorf("CNI setting failed, continue monitoring: %v", err)


### PR DESCRIPTION
Needs testing.
Fixes #791 (or the part of it where a restart is needed after cni dir changes - will not be needed anymore)

@sameo @dcbw, PTAL
/cc @mrunalp 

Signed-off-by: Rajat Chopra <rchopra@redhat.com>