### PR TITLE
kpod: add more storage information to "info"

### DIFF
--- a/cmd/kpod/info.go
+++ b/cmd/kpod/info.go
@@ -139,7 +139,18 @@ func storeInfo(c *cli.Context) (string, map[string]interface{}, error) {
 	// lets say storage driver in use, number of images, number of containers
 	info := map[string]interface{}{}
 	info["GraphRoot"] = store.GraphRoot()
+	info["RunRoot"] = store.RunRoot()
 	info["GraphDriverName"] = store.GraphDriverName()
+	info["GraphOptions"] = store.GraphOptions()
+	statusPairs, err := store.Status()
+	if err != nil {
+		return storeStr, nil, err
+	}
+	status := map[string]string{}
+	for _, pair := range statusPairs {
+		status[pair[0]] = pair[1]
+	}
+	info["GraphStatus"] = status
 	images, err := store.Images()
 	if err != nil {
 		info["ImageStore"] = infoErr(err)


### PR DESCRIPTION
Have the "kpod info" command also package up the driver-level status information that the `github.com/containers/storage.Store`'s `Status()` method returns.