### PR TITLE
Add file-backed swap to prevent OOM

### DIFF
--- a/contrib/test/crio-integration-playbook.yaml
+++ b/contrib/test/crio-integration-playbook.yaml
@@ -76,6 +76,13 @@
     async: 600
     poll: 10
     when: ansible_distribution == 'Fedora'
+  - name: Setup swap to prevent kernel firing off the OOM killer
+    shell: |
+      truncate -s 8G /root/swap && \
+      export SWAPDEV=$(losetup --show -f /root/swap | head -1) && \
+      mkswap $SWAPDEV && \
+      swapon $SWAPDEV && \
+      swapon --show
   - name: Make testing directories to conform to testing standards
     file:
       path: "{{ item }}"


### PR DESCRIPTION
Without any swap space enabled, it's possible some intensive operation
can chew up all the memory on the test VM.  Enabling swap space will
prevent this for minor cases, but could lead to disk-thrashing if the
memory demand is excessive.  Since the test system never reboots,
using a file-backed swap should suffice, though not ideal, it's easy to
setup.

Signed-off-by: Chris Evich <cevich@redhat.com>