### PR TITLE
cmd/kpod/ps.go: Use getCommand for JSON

### DIFF
--- a/cmd/kpod/ps.go
+++ b/cmd/kpod/ps.go
@@ -298,7 +298,7 @@ func getJSONOutput(containers []*libkpod.ContainerData) (psOutput []psJSONParams
 			ID:               ctr.ID,
 			Image:            ctr.FromImage,
 			ImageID:          ctr.FromImageID,
-			Command:          ctr.ImageCreatedBy,
+			Command:          getCommand(ctr.ImageCreatedBy),
 			CreatedAt:        ctr.State.Created,
 			RunningFor:       time.Since(ctr.State.Created),
 			Status:           ctr.State.Status,


### PR DESCRIPTION
The getCommand func strips out unwanted characters around the
command of the container.  The JSON output should use this func
like the regular ps output for both consistency and because
Python does a literal interpretation of the bracket [] characters
when consuming as JSON.

Signed-off-by: baude <bbaude@redhat.com>