### PR TITLE
Add Ansible playbook env. setup wrapper script

### DIFF
--- a/contrib/test/requirements.txt
+++ b/contrib/test/requirements.txt
@@ -1,0 +1,42 @@
+# Pip requirements file for Ansible-based integration-testing environment.
+# Intended to be utilized by venv-ansible-playbook.sh script
+#
+# N/B: Hashes are required here | versions frozen for stability
+
+ansible==2.3.1.0 --hash=sha256:cd4b8f53720fcd0c351156b840fdd15ecfbec22c951b5406ec503de49d40b9f5
+
+asn1crypto==0.22.0 --hash=sha256:d232509fefcfcdb9a331f37e9c9dc20441019ad927c7d2176cf18ed5da0ba097
+
+bcrypt==3.1.3 --hash=sha256:05b35b9842b009b44496fa5433ce462f69966291e50fbd471dbb427f399f748f
+
+cffi==1.10.0 --hash=sha256:c49187260043bd4c1d6a52186f9774f17d9b1da0a406798ebf4bfc12da166ade
+
+cryptography==1.9 --hash=sha256:5518337022718029e367d982642f3e3523541e098ad671672a90b82474c84882
+
+enum34==1.1.6 --hash=sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79
+
+idna==2.5 --hash=sha256:cc19709fd6d0cbfed39ea875d29ba6d4e22c0cebc510a76d6302a28385e8bb70
+
+ipaddress==1.0.18 --hash=sha256:d34cf15d95ce9a734560f7400a8bd2ac2606f378e2a1d0eadbf1c98707e7c74a
+
+Jinja2==2.9.6 --hash=sha256:2231bace0dfd8d2bf1e5d7e41239c06c9e0ded46e70cc1094a0aa64b0afeb054
+
+MarkupSafe==1.0 --hash=sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665
+
+paramiko==2.2.1 --hash=sha256:9c9402377ba8594889aab1e44a13b78eda685eb2145dc00b2353b4fbb25088cf
+
+pyasn1==0.2.3 --hash=sha256:0439b9bd518418260c2641a571f0e07fce4370cab13b68f19b5e023306c03cad
+
+pycparser==2.17 --hash=sha256:0aac31e917c24cb3357f5a4d5566f2cc91a19ca41862f6c3c22dc60a629673b6
+
+pycrypto==2.6.1 --hash=sha256:f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c
+
+PyNaCl==1.1.2 --hash=sha256:57314a7bad4bd39501dc622942f9921923673e52e126b0fc4f0214b5d25d619a
+
+PyYAML==3.12 --hash=sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab
+
+six==1.10.0 --hash=sha256:0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1
+
+virtualenv==15.1.0 --hash=sha256:39d88b533b422825d644087a21e78c45cf5af0ef7a99a1fc9fbb7b481e5c85b0
+
+pip==9.0.1 --hash=sha256:690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0

--- a/contrib/test/venv-ansible-playbook.sh
+++ b/contrib/test/venv-ansible-playbook.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# example usage
+#   $ ./venv-ansible-playbook.sh \
+#               -i 192.168.169.170 \
+#               --private-key=/path/to/key \
+#               --extra-vars "pullrequest=42" \
+#               --extra-vars "commit=abcd1234" \
+#               --user root \
+#               --verbose \
+#               $PWD/crio-integration-playbook.yaml
+
+SCRIPT_PATH=`realpath $(dirname $0)`
+REQUIREMENTS="$SCRIPT_PATH/requirements.txt"
+
+echo
+
+if ! type -P virtualenv &> /dev/null
+then
+    echo "Could not find required 'virtualenv' binary installed on system."
+    exit 1
+fi
+
+if [ "$#" -lt "1" ]
+then
+    echo "No ansible-playbook command-line options specified."
+    echo "usage: $0 -i whatever --private-key=something --extra-vars foo=bar playbook.yml"
+    exit 2
+fi
+
+# Avoid dirtying up repository, keep execution bits confined to a known location
+if [ -z "$WORKSPACE" ] || [ ! -d "$WORKSPACE" ]
+then
+    export WORKSPACE="$(mktemp -d)"
+    echo "Using temporary \$WORKSPACE=\"$WORKSPACE\" for execution environment."
+    echo "Directory will be removed upon exit.  Export this variable with path"
+    echo "to an existing directory to preserve contents."
+    trap 'rm -rf "$WORKSPACE"' EXIT
+else
+    echo "Using existing \$WORKSPACE=\"$WORKSPACE\" for execution environment."
+    echo "Directory will be left as-is upon exit."
+    # Don't recycle cache, next job may have different requirements
+    trap 'rm -rf "$PIPCACHE"' EXIT
+fi
+
+# All command failures from now on are fatal
+set -e
+echo
+echo "Bootstrapping trusted virtual environment, this may take a few minutes, depending on networking."
+echo "(logs:  \"$WORKSPACE/crio_venv_setup_log.txt\")"
+echo
+
+(
+    set -x
+    cd "$WORKSPACE"
+    # N/B: local system's virtualenv binary - uncontrolled version fixed below
+    virtualenv --no-site-packages --python=python2.7 ./.venvbootstrap
+    # Set up paths to install/operate out of $WORKSPACE/.venvbootstrap
+    source ./.venvbootstrap/bin/activate
+    # N/B: local system's pip binary - uncontrolled version fixed below
+    # pip may not support --cache-dir, force it's location into $WORKSPACE the ugly-way
+    OLD_HOME="$HOME"
+    export HOME="$WORKSPACE"
+    export PIPCACHE="$WORKSPACE/.cache/pip"
+    pip install --force-reinstall --upgrade pip==9.0.1
+    # Undo --cache-dir workaround
+    export HOME="$OLD_HOME"
+    # Install fixed, trusted, hashed versions of all requirements (including pip and virtualenv)
+    pip --cache-dir="$PIPCACHE" install --require-hashes \
+        --requirement "$SCRIPT_PATH/requirements.txt"
+
+    # Setup trusted virtualenv using hashed binary from requirements.txt
+    ./.venvbootstrap/bin/virtualenv --no-site-packages --python=python2.7 ./.cri-o_venv
+    # Exit untrusted virtualenv
+    deactivate
+
+    # Enter trusted virtualenv
+    source ./.cri-o_venv/bin/activate
+    # Re-install from cache
+    pip install --force-reinstall --upgrade pip==9.0.1
+    pip --cache-dir="$PIPCACHE" install --require-hashes \
+        --requirement "$SCRIPT_PATH/requirements.txt"
+    # Remove temporary bootstrap virtualenv
+    rm -rf ./.venvbootstrap
+    # Exit trusted virtualenv
+
+) &> $WORKSPACE/crio_venv_setup_log.txt;
+
+echo
+echo "Executing \"$WORKSPACE/.cri-o_venv/bin/ansible-playbook $@\""
+echo
+
+# Execute command-line arguments under virtualenv
+cd "$WORKSPACE"
+source ./.cri-o_venv/bin/activate
+./.cri-o_venv/bin/ansible-playbook $@
+deactivate


### PR DESCRIPTION
The environment executing the test playbooks matters.  Establish a
script to bootstrap a known-good and fixed-version python virtual
environment.  Spell out precise execution requirements in a standard
pip 'requirements.txt' file, including version numbers and hashes.

Upon executing the ``venv-ansible-playbook.sh`` wrapper, a virtual
environment is setup and contained within a fixed (or temporary)
directory, with full logs from setup.  If this is to be preserved
across executions, the ``$WORKSPACE`` environment variable must be
set and exported beforehand.

Example execution command-line provided in script file

Signed-off-by: Chris Evich <cevich@redhat.com>