### PR TITLE
cmd/kpod/tag.go: Do not assume docker.io for tagging

### DIFF
--- a/cmd/kpod/tag.go
+++ b/cmd/kpod/tag.go
@@ -62,17 +62,17 @@ func addImageNames(store storage.Store, image *storage.Image, addNames []string)
 func expandedTags(tags []string) ([]string, error) {
 	expandedNames := []string{}
 	for _, tag := range tags {
-		name, err := reference.ParseNormalizedNamed(tag)
+		var labelName string
+		name, err := reference.Parse(tag)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error parsing tag %q", name)
 		}
-
-		name = reference.TagNameOnly(name)
-		newTag := ""
-		if tagged, ok := name.(reference.NamedTagged); ok {
-			newTag = tagged.Tag()
+		if _, ok := name.(reference.NamedTagged); ok {
+			labelName = name.String()
+		} else {
+			labelName = name.String() + ":latest"
 		}
-		expandedNames = append(expandedNames, name.Name()+":"+newTag)
+		expandedNames = append(expandedNames, labelName)
 	}
 	return expandedNames, nil
 }

--- a/test/tag.bats
+++ b/test/tag.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load helpers
+
+
+IMAGE="docker.io/library/alpine:latest"
+ROOT="$TESTDIR/crio"
+RUNROOT="$TESTDIR/crio-run"
+KPOD_OPTIONS="--root $ROOT --runroot $RUNROOT --storage-driver vfs"
+
+function teardown() {
+    cleanup_test
+}
+
+@test "kpod tag with shortname:latest" {
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} tag $IMAGE foobar:latest
+	[ "$status" -eq 0 ]
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} inspect foobar:latest
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} rmi foobar:latest
+	[ "$status" -eq 0 ]
+}
+
+@test "kpod tag with shortname" {
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} tag $IMAGE foobar
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} inspect foobar:latest
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} rmi foobar:latest
+	[ "$status" -eq 0 ]
+}
+
+@test "kpod tag with shortname:tag" {
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} tag $IMAGE foobar:v
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} inspect foobar:v
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} rmi foobar:v
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
When performing a tag, if a shortname was provided, tag.go would
preprend docker.io to the shortname through the ParseNormalized
function.  Here we work around that such that is a short name
and tag are provided, the resulting tag will be shortname:tag.  If
a shortname is provided without a tag, we append "latest" as the
tag.

Added specific tag tests too

Signed-off-by: baude <bbaude@redhat.com>