### PR TITLE
Slight modification to kpod ps based on QE feedback

### DIFF
--- a/cmd/kpod/ps.go
+++ b/cmd/kpod/ps.go
@@ -85,6 +85,7 @@ var (
 		cli.IntFlag{
 			Name:  "last, n",
 			Usage: "Print the n last created containers (all states)",
+			Value: -1,
 		},
 		cli.BoolFlag{
 			Name:  "latest, l",
@@ -149,7 +150,7 @@ func psCmd(c *cli.Context) error {
 
 	// all, latest, and last are mutually exclusive. Only one flag can be used at a time
 	exclusiveOpts := 0
-	if opts.last > 0 {
+	if opts.last >= 0 {
 		exclusiveOpts++
 	}
 	if opts.latest {
@@ -225,7 +226,7 @@ func (p *psTemplateParams) headerMap() map[string]string {
 // getContainers gets the containers that match the flags given
 func getContainers(containers []*libkpod.ContainerData, opts psOptions) []*libkpod.ContainerData {
 	var containersOutput []*libkpod.ContainerData
-	if opts.last > 0 && opts.last < len(containers) {
+	if opts.last >= 0 && opts.last < len(containers) {
 		for i := 0; i < opts.last; i++ {
 			containersOutput = append(containersOutput, containers[i])
 		}

--- a/docs/kpod-ps.1.md
+++ b/docs/kpod-ps.1.md
@@ -57,7 +57,6 @@ Valid placeholders for the Go template are listed below:
 | .Size           | Size of container                                |
 | .Names          | Name of container                                |
 | .Labels         | All the labels assigned to the container         |
-| .Label          | Value of the specific label provided by the user |
 | .Mounts         | Volumes mounted in the container                 |
 
 


### PR DESCRIPTION
QE noticed that kpod ps --last 0 was returning the running containers
Fixed that problem so that it returns nothing

Signed-off-by: umohnani8 <umohnani@redhat.com>