### PR TITLE
contrib: test: run kube tests in CI with same cgroup driver

### DIFF
--- a/contrib/test/crio-integration-playbook.yaml
+++ b/contrib/test/crio-integration-playbook.yaml
@@ -409,7 +409,7 @@
     poll: 10
   - name: run k8s tests
     shell: |
-            make test-e2e-node PARALLELISM=1 RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT=/var/run/crio.sock IMAGE_SERVICE_ENDPOINT=/var/run/crio.sock TEST_ARGS="--prepull-images=true" FOCUS="\[Conformance\]" 2>&1 > node-e2e.log
+            make test-e2e-node PARALLELISM=1 RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT=/var/run/crio.sock IMAGE_SERVICE_ENDPOINT=/var/run/crio.sock TEST_ARGS='--prepull-images=true --kubelet-flags="--cgroup-driver=systemd"' FOCUS="\[Conformance\]" 2>&1 > node-e2e.log
     args:
       chdir: /root/src/k8s.io/kubernetes
     async: 7200

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -719,7 +719,7 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	# Wait for container to OOM
-	run sleep 10
+	run sleep 100
 	run crioctl ctr status --id "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
Our CI tests on RHEL and Fedora and we want to test the systemd cgroup
driver. However, kubelet needs to run in tests with systemd cgroup
driver as well, or tests fail. This patch fixes broken CI because of
not matching cgroup driver between CRI-O and the kubelet.

Close https://github.com/kubernetes-incubator/cri-o/pull/864

Signed-off-by: Antonio Murdaca <runcom@redhat.com>