### PR TITLE
Use template for travis IRC notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,10 @@ jobs:
       go: 1.8.x
 
 notifications:
-  irc: "chat.freenode.net#cri-o"
+    irc:
+        channels:
+            -  "chat.freenode.net#cri-o"
+        template:
+            - "%{author}, %{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
+            - "%{author}, ^^^^^ changes: %{compare_url}"
+            - "%{author}, ^^^^^ details : %{build_url}"


### PR DESCRIPTION
When notifying on IRC, mention the github author's name in the message.
This makes it easier to distinguish one message from another during
periods of heavy notification activity.