### PR TITLE
cmd/kpod/rmi.go: Fix deletion by ID

### DIFF
--- a/cmd/kpod/rmi.go
+++ b/cmd/kpod/rmi.go
@@ -79,10 +79,10 @@ func rmiCmd(c *cli.Context) error {
 				if err2 != nil {
 					return err
 				}
-				fmt.Printf("untagged: %s", name)
+				fmt.Printf("untagged: %s\n", name)
 			}
 
-			if len(image.Names) > 0 {
+			if len(image.Names) > 1 {
 				continue
 			}
 			id, err := images.RemoveImage(image, store)


### PR DESCRIPTION
When deleting by ID, kpod rmi was only "untagging" the image
and not actually removing it.

Signed-off-by: baude <bbaude@redhat.com>