### PR TITLE
[WIP] Support IRC notifications from testing playbooks

### DIFF
--- a/contrib/test/roles/irc_channel_notice/defaults/main.yml
+++ b/contrib/test/roles/irc_channel_notice/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+
+irc_server: "chat.freenode.net"
+irc_port: 6665
+irc_channel: "cri-o"
+
+# Nick to join / send message
+irc_from: "kry-oh"
+
+# To whom should the message be addressed.
+irc_to:
+
+# If non-empty, use irc_nick_xlation file to set irc_to
+commit_author:
+
+# Author to nick translation file (in files subdir).  CSV commit_author,irc_nick mapping
+irc_nick_xlation: "author_to_nick.csv"
+
+# jinja2 template filename (in templates subdir) to use for producing the message
+irc_msg_template: "crio-integration-playbook.j2"
+
+# Assertion-strings that must pass for above template
+irc_msg_tmpl_asserts:
+    - 'verb | default()'
+    - 'irc_to | default()'
+    - 'commit | default() | trim | search("[0-9A-Fa-f]+")'
+    - 'pullrequest | default(0) | string | search("\d+")'
+    - 'irc_from | default()'  # nick of sender
+    - 'commit_author | default() or irc_to | default()'  # PR author / nick of recipient

--- a/contrib/test/roles/irc_channel_notice/files/author_to_nick.csv
+++ b/contrib/test/roles/irc_channel_notice/files/author_to_nick.csv
@@ -1,0 +1,2 @@
+willgates:cevich
+rhatdan:dwalsh

--- a/contrib/test/roles/irc_channel_notice/files/author_to_nick.csv
+++ b/contrib/test/roles/irc_channel_notice/files/author_to_nick.csv
@@ -1,2 +1,3 @@
 willgates:cevich
 rhatdan:dwalsh
+TomSweeneyRedHat:tsweeney

--- a/contrib/test/roles/irc_channel_notice/tasks/main.yml
+++ b/contrib/test/roles/irc_channel_notice/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+
+- block:  # delegate_to: localhost b/c 'is_file()', 'csvfile' and 'template' lookups
+
+  - name: All role assertions pass
+    assert:
+      that:  # All are defined and non-empty
+        - 'irc_server | default()'
+        - 'irc_channel | default()'
+        - 'irc_from | default()'
+        - 'irc_to | default() or commit_author | default()'
+        - 'irc_msg_template | default()'
+        - 'irc_nick_xlation | default()'
+
+  - name: Relative paths are made absolute
+    set_fact:
+      _irc_msg_template: '{{ role_path ~ "/templates/" ~ irc_msg_template }}'
+      _irc_nick_xlation: '{{ role_path ~ "/files/" ~ irc_nick_xlation }}'
+
+  - name: Message recipient name is translated
+    set_fact:
+      irc_to: >
+        {{ lookup("csvfile",
+                  commit_author ~
+                  " file=" ~ _irc_nick_xlation ~
+                  " col=1 delimiter=: default=" ~ irc_to) }}
+    when: commit_author | default() and _irc_nick_xlation | is_file
+
+  - name: All template assertions pass
+    assert:
+      that: '{{ irc_msg_tmpl_asserts }}'
+
+  - debug:
+      msg: 'Sending - {{ irc_server | trim }}#{{ irc_channel | trim }}: {{ irc_to |trim }}, {{ lookup("template", _irc_msg_template) | trim }}'
+
+  - name: Irc notification is sent
+    irc:
+      server: '{{ irc_server | trim }}'
+      port: '{{ irc_port | default(omit) }}'
+      channel: '{{ irc_channel | trim }}'
+      nick_to: '{{ irc_to | trim }}'
+      nick: '{{ irc_from | trim }}'
+      msg: '{{ lookup("template", _irc_msg_template) | trim }}'
+
+  delegate_to: localhost

--- a/contrib/test/roles/irc_channel_notice/tasks/main.yml
+++ b/contrib/test/roles/irc_channel_notice/tasks/main.yml
@@ -33,6 +33,8 @@
   - debug:
       msg: 'Sending - {{ irc_server | trim }}#{{ irc_channel | trim }}: {{ irc_to |trim }}, {{ lookup("template", _irc_msg_template) | trim }}'
 
+  # FIXME: This is broken WRT freenode in Ansible 2.3
+  # possibly https://github.com/ansible/ansible/issues/24023
   - name: Irc notification is sent
     irc:
       server: '{{ irc_server | trim }}'

--- a/contrib/test/roles/irc_channel_notice/templates/crio-integration-playbook.j2
+++ b/contrib/test/roles/irc_channel_notice/templates/crio-integration-playbook.j2
@@ -1,0 +1,7 @@
+{{ irc_to | trim }}, crio-integration-playbook {{ verb }} on {{
+    ansible_distribution ~ "-" ~ ansible_distribution_version }} for: {%
+    if pullrequest|default()
+         %}https://github.com/kubernetes-incubator/cri-o/pull/{{ pullrequest | trim }}{%
+    else
+         %}https://github.com/kubernetes-incubator/cri-o/commit/{{ commit | trim }}{%
+    endif %}


### PR DESCRIPTION
Add an 'irc_channel_notice' role to help post messages in a somewhat
generic way.  It verifies it's own required variables and is able
to translate between commit-author names and irc nicks.  The message
itself is generated via a jinja2 template, making it easy to swap in
alternate messages for different situations.

The intent is this role is applied during different stages of the
crio-integration-playbook.  As long as at least one variable differs
between references (e.g. verb), it will execute multiple times.

Test with:

- hosts: localhost
  gather_subset: network
  roles:
    - role: irc_channel_notice
      verb: testing
      commit_author: willgates
      pullrequest: 889

Signed-off-by: Chris Evich <cevich@redhat.com>