### PR TITLE
Add golang version note to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Debian, Ubuntu, and related distributions will also need a copy of the developme
 
 If using an older release or a long-term support release, be careful to double-check that the version of `runc` is new enough (running `runc --version` should produce `spec: 1.0.0`), or else build your own.
 
+**NOTE**
+
+Be careful to double-check that the version of golang is new enough, version 1.8.x or higher is required.  If needed, golang kits are avaliable at https://golang.org/dl/
+
 **Optional**
 
 Fedora, CentOS, RHEL, and related distributions:


### PR DESCRIPTION
server: clean up sandbox network when running the sandbox fails
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Latest Fedora 26 installed go 1.7.6, not the required go 1.8.x.  Adding a note for verification after the install and where to go if needed to get the latest golang.