### PR TITLE
kpod rmi by ID untagged: %name incorrect

### DIFF
--- a/libpod/images/rmi.go
+++ b/libpod/images/rmi.go
@@ -11,7 +11,7 @@ func UntagImage(store storage.Store, image *storage.Image, imgArg string) (strin
 	newNames := []string{}
 	removedName := ""
 	for _, name := range image.Names {
-		if MatchesReference(name, imgArg) {
+		if MatchesReference(name, imgArg) || MatchesID(imgArg, image.ID) {
 			removedName = name
 			continue
 		}


### PR DESCRIPTION
As described in https://github.com/kubernetes-incubator/cri-o/issues/888, when
deleting by ID, the name being returned for the untagged message was "".

Signed-off-by: baude <bbaude@redhat.com>