### PR TITLE
kpod pull needs to shutdown the runtime

### DIFF
--- a/cmd/kpod/pull.go
+++ b/cmd/kpod/pull.go
@@ -49,6 +49,7 @@ func pullCmd(c *cli.Context) error {
 	if err != nil {
 		return errors.Wrapf(err, "could not create runtime")
 	}
+	defer runtime.Shutdown()
 	if err := runtime.PullImage(image, c.Bool("all-tags"), os.Stdout); err != nil {
 		return errors.Errorf("error pulling image from %q: %v", image, err)
 	}


### PR DESCRIPTION
Since kpod is using the new runtime code it needs to call
Shutdown, when it is finished to make sure the store is
cleaned up.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>