### PR TITLE
test: Add timeout before checking for status

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -28,6 +28,7 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
+	run sleep 5
 	run crictl inspect --output yaml "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -53,6 +54,7 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
+	run sleep 5
 	run crictl inspect --output yaml "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
Under some slow environment (nested VMs) or with some
not as fast runtimes (Clear Containers), asking for a
status right away is racy.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>