### PR TITLE
Update urfave/cli to v1.20.0

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -73,7 +73,7 @@ github.com/emicklei/go-restful ff4f55a206334ef123e4f79bbf348980da81ca46
 github.com/emicklei/go-restful-swagger12 1.0.1
 github.com/pkg/errors v0.8.0
 github.com/godbus/dbus v4.0.0
-github.com/urfave/cli v1.19.1
+github.com/urfave/cli v1.20.0
 github.com/vbatts/tar-split v0.10.1
 github.com/renstrom/dedent v1.0.0
 github.com/hpcloud/tail v1.0.0

--- a/vendor/github.com/urfave/cli/README.md
+++ b/vendor/github.com/urfave/cli/README.md
@@ -455,13 +455,13 @@ error.
 
 Flags for the application and commands are shown in the order they are defined.
 However, it's possible to sort them from outside this library by using `FlagsByName`
-with `sort`.
+or `CommandsByName` with `sort`.
 
 For example this:
 
 <!-- {
   "args": ["&#45;&#45;help"],
-  "output": "Load configuration from FILE\n.*Language for the greeting.*"
+  "output": "add a task to the list\n.*complete a task on the list\n.*\n\n.*\n.*Load configuration from FILE\n.*Language for the greeting.*"
 } -->
 ``` go
 package main
@@ -488,7 +488,27 @@ func main() {
     },
   }
 
+  app.Commands = []cli.Command{
+    {
+      Name:    "complete",
+      Aliases: []string{"c"},
+      Usage:   "complete a task on the list",
+      Action:  func(c *cli.Context) error {
+        return nil
+      },
+    },
+    {
+      Name:    "add",
+      Aliases: []string{"a"},
+      Usage:   "add a task to the list",
+      Action:  func(c *cli.Context) error {
+        return nil
+      },
+    },
+  }
+
   sort.Sort(cli.FlagsByName(app.Flags))
+  sort.Sort(cli.CommandsByName(app.Commands))
 
   app.Run(os.Args)
 }
@@ -940,16 +960,13 @@ SUPPORT: support@awesometown.example.com
   cli.AppHelpTemplate = `NAME:
    {{.Name}} - {{.Usage}}
 USAGE:
-   {{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command
-[command options]{{end}} {{if
-.ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}
+   {{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}
    {{if len .Authors}}
-AUTHOR(S):
+AUTHOR:
    {{range .Authors}}{{ . }}{{end}}
    {{end}}{{if .Commands}}
 COMMANDS:
-{{range .Commands}}{{if not .HideHelp}}   {{join .Names ", "}}{{ "\t"
-}}{{.Usage}}{{ "\n" }}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+{{range .Commands}}{{if not .HideHelp}}   {{join .Names ", "}}{{ "\t"}}{{.Usage}}{{ "\n" }}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
 GLOBAL OPTIONS:
    {{range .VisibleFlags}}{{.}}
    {{end}}{{end}}{{if .Copyright }}

--- a/vendor/github.com/urfave/cli/app.go
+++ b/vendor/github.com/urfave/cli/app.go
@@ -85,6 +85,12 @@ type App struct {
 	ErrWriter io.Writer
 	// Other custom info
 	Metadata map[string]interface{}
+	// Carries a function which returns app specific info.
+	ExtraInfo func() map[string]string
+	// CustomAppHelpTemplate the text template for app help topic.
+	// cli.go uses text/template to render templates. You can
+	// render custom help text by setting this variable.
+	CustomAppHelpTemplate string
 
 	didSetup bool
 }
@@ -234,7 +240,6 @@ func (a *App) Run(arguments []string) (err error) {
 	if a.Before != nil {
 		beforeErr := a.Before(context)
 		if beforeErr != nil {
-			fmt.Fprintf(a.Writer, "%v\n\n", beforeErr)
 			ShowAppHelp(context)
 			HandleExitCoder(beforeErr)
 			err = beforeErr

--- a/vendor/github.com/urfave/cli/cli.go
+++ b/vendor/github.com/urfave/cli/cli.go
@@ -12,6 +12,7 @@
 //     app.Usage = "say a greeting"
 //     app.Action = func(c *cli.Context) error {
 //       println("Greetings")
+//       return nil
 //     }
 //
 //     app.Run(os.Args)

--- a/vendor/github.com/urfave/cli/command.go
+++ b/vendor/github.com/urfave/cli/command.go
@@ -59,6 +59,25 @@ type Command struct {
 	// Full name of command for help, defaults to full command name, including parent commands.
 	HelpName        string
 	commandNamePath []string
+
+	// CustomHelpTemplate the text template for the command help topic.
+	// cli.go uses text/template to render templates. You can
+	// render custom help text by setting this variable.
+	CustomHelpTemplate string
+}
+
+type CommandsByName []Command
+
+func (c CommandsByName) Len() int {
+	return len(c)
+}
+
+func (c CommandsByName) Less(i, j int) bool {
+	return c[i].Name < c[j].Name
+}
+
+func (c CommandsByName) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
 }
 
 // FullName returns the full name of the command.
@@ -140,19 +159,20 @@ func (c Command) Run(ctx *Context) (err error) {
 	}
 
 	context := NewContext(ctx.App, set, ctx)
+	context.Command = c
 	if checkCommandCompletions(context, c.Name) {
 		return nil
 	}
 
 	if err != nil {
 		if c.OnUsageError != nil {
-			err := c.OnUsageError(ctx, err, false)
+			err := c.OnUsageError(context, err, false)
 			HandleExitCoder(err)
 			return err
 		}
-		fmt.Fprintln(ctx.App.Writer, "Incorrect Usage:", err.Error())
-		fmt.Fprintln(ctx.App.Writer)
-		ShowCommandHelp(ctx, c.Name)
+		fmt.Fprintln(context.App.Writer, "Incorrect Usage:", err.Error())
+		fmt.Fprintln(context.App.Writer)
+		ShowCommandHelp(context, c.Name)
 		return err
 	}
 
@@ -177,9 +197,7 @@ func (c Command) Run(ctx *Context) (err error) {
 	if c.Before != nil {
 		err = c.Before(context)
 		if err != nil {
-			fmt.Fprintln(ctx.App.Writer, err)
-			fmt.Fprintln(ctx.App.Writer)
-			ShowCommandHelp(ctx, c.Name)
+			ShowCommandHelp(context, c.Name)
 			HandleExitCoder(err)
 			return err
 		}
@@ -189,7 +207,6 @@ func (c Command) Run(ctx *Context) (err error) {
 		c.Action = helpSubcommand.Action
 	}
 
-	context.Command = c
 	err = HandleAction(c.Action, context)
 
 	if err != nil {
@@ -230,14 +247,13 @@ func (c Command) startApp(ctx *Context) error {
 		app.HelpName = app.Name
 	}
 
-	if c.Description != "" {
-		app.Usage = c.Description
-	} else {
-		app.Usage = c.Usage
-	}
+	app.Usage = c.Usage
+	app.Description = c.Description
+	app.ArgsUsage = c.ArgsUsage
 
 	// set CommandNotFound
 	app.CommandNotFound = ctx.App.CommandNotFound
+	app.CustomAppHelpTemplate = c.CustomHelpTemplate
 
 	// set the flags and commands
 	app.Commands = c.Subcommands
@@ -250,6 +266,7 @@ func (c Command) startApp(ctx *Context) error {
 	app.Author = ctx.App.Author
 	app.Email = ctx.App.Email
 	app.Writer = ctx.App.Writer
+	app.ErrWriter = ctx.App.ErrWriter
 
 	app.categories = CommandCategories{}
 	for _, command := range c.Subcommands {
@@ -272,6 +289,7 @@ func (c Command) startApp(ctx *Context) error {
 	} else {
 		app.Action = helpSubcommand.Action
 	}
+	app.OnUsageError = c.OnUsageError
 
 	for index, cc := range app.Commands {
 		app.Commands[index].commandNamePath = []string{c.Name, cc.Name}

--- a/vendor/github.com/urfave/cli/context.go
+++ b/vendor/github.com/urfave/cli/context.go
@@ -39,11 +39,13 @@ func (c *Context) NumFlags() int {
 
 // Set sets a context flag to a value.
 func (c *Context) Set(name, value string) error {
+	c.setFlags = nil
 	return c.flagSet.Set(name, value)
 }
 
 // GlobalSet sets a context flag to a value on the global flagset
 func (c *Context) GlobalSet(name, value string) error {
+	globalContext(c).setFlags = nil
 	return globalContext(c).flagSet.Set(name, value)
 }
 

--- a/vendor/github.com/urfave/cli/errors.go
+++ b/vendor/github.com/urfave/cli/errors.go
@@ -74,7 +74,7 @@ func (ee *ExitError) ExitCode() int {
 // HandleExitCoder checks if the error fulfills the ExitCoder interface, and if
 // so prints the error to stderr (if it is non-empty) and calls OsExiter with the
 // given exit code.  If the given error is a MultiError, then this func is
-// called on all members of the Errors slice.
+// called on all members of the Errors slice and calls OsExiter with the last exit code.
 func HandleExitCoder(err error) {
 	if err == nil {
 		return
@@ -93,18 +93,23 @@ func HandleExitCoder(err error) {
 	}
 
 	if multiErr, ok := err.(MultiError); ok {
-		for _, merr := range multiErr.Errors {
-			HandleExitCoder(merr)
-		}
+		code := handleMultiError(multiErr)
+		OsExiter(code)
 		return
 	}
+}
 
-	if err.Error() != "" {
-		if _, ok := err.(ErrorFormatter); ok {
-			fmt.Fprintf(ErrWriter, "%+v\n", err)
+func handleMultiError(multiErr MultiError) int {
+	code := 1
+	for _, merr := range multiErr.Errors {
+		if multiErr2, ok := merr.(MultiError); ok {
+			code = handleMultiError(multiErr2)
 		} else {
-			fmt.Fprintln(ErrWriter, err)
+			fmt.Fprintln(ErrWriter, merr)
+			if exitErr, ok := merr.(ExitCoder); ok {
+				code = exitErr.ExitCode()
+			}
 		}
 	}
-	OsExiter(1)
+	return code
 }

--- a/vendor/github.com/urfave/cli/flag.go
+++ b/vendor/github.com/urfave/cli/flag.go
@@ -14,13 +14,13 @@ import (
 const defaultPlaceholder = "value"
 
 // BashCompletionFlag enables bash-completion for all commands and subcommands
-var BashCompletionFlag = BoolFlag{
+var BashCompletionFlag Flag = BoolFlag{
 	Name:   "generate-bash-completion",
 	Hidden: true,
 }
 
 // VersionFlag prints the version for the application
-var VersionFlag = BoolFlag{
+var VersionFlag Flag = BoolFlag{
 	Name:  "version, v",
 	Usage: "print the version",
 }
@@ -28,7 +28,7 @@ var VersionFlag = BoolFlag{
 // HelpFlag prints the help for all commands and subcommands
 // Set to the zero value (BoolFlag{}) to disable flag -- keeps subcommand
 // unless HideHelp is set to true)
-var HelpFlag = BoolFlag{
+var HelpFlag Flag = BoolFlag{
 	Name:  "help, h",
 	Usage: "show help",
 }
@@ -630,7 +630,8 @@ func (f Float64Flag) ApplyWithError(set *flag.FlagSet) error {
 func visibleFlags(fl []Flag) []Flag {
 	visible := []Flag{}
 	for _, flag := range fl {
-		if !flagValue(flag).FieldByName("Hidden").Bool() {
+		field := flagValue(flag).FieldByName("Hidden")
+		if !field.IsValid() || !field.Bool() {
 			visible = append(visible, flag)
 		}
 	}
@@ -723,9 +724,8 @@ func stringifyFlag(f Flag) string {
 
 	needsPlaceholder := false
 	defaultValueString := ""
-	val := fv.FieldByName("Value")
 
-	if val.IsValid() {
+	if val := fv.FieldByName("Value"); val.IsValid() {
 		needsPlaceholder = true
 		defaultValueString = fmt.Sprintf(" (default: %v)", val.Interface())
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Updates urfave/cli to v1.20.0.  Now when kpod has an error, it shows just the error and not the error and the stack dump.  Example below of the bad behaviour.

This Fixes #882 

``` kpod save 36b3c5f87501 
refusing to save to terminal. Use -o flag or redirect
main.saveCmd
	/builddir/build/BUILD/cri-o-bb1da978e30b3d32f988e30568b5161e8cfd700b/_build/src/github.com/kubernetes-incubator/cri-o/cmd/kpod/save.go:68
github.com/kubernetes-incubator/cri-o/vendor/github.com/urfave/cli.HandleAction
	/builddir/build/BUILD/cri-o-bb1da978e30b3d32f988e30568b5161e8cfd700b/_build/src/github.com/kubernetes-incubator/cri-o/vendor/github.com/urfave/cli/app.go:485
github.com/kubernetes-incubator/cri-o/vendor/github.com/urfave/cli.Command.Run
	/builddir/build/BUILD/cri-o-bb1da978e30b3d32f988e30568b5161e8cfd700b/_build/src/github.com/kubernetes-incubator/cri-o/vendor/github.com/urfave/cli/command.go:193
github.com/kubernetes-incubator/cri-o/vendor/github.com/urfave/cli.(*App).Run
	/builddir/build/BUILD/cri-o-bb1da978e30b3d32f988e30568b5161e8cfd700b/_build/src/github.com/kubernetes-incubator/cri-o/vendor/github.com/urfave/cli/app.go:250
main.main
	/builddir/build/BUILD/cri-o-bb1da978e30b3d32f988e30568b5161e8cfd700b/_build/src/github.com/kubernetes-incubator/cri-o/cmd/kpod/main.go:90
runtime.main
	/usr/lib/golang/src/runtime/proc.go:185
runtime.goexit
	/usr/lib/golang/src/runtime/asm_amd64.s:2197

```