### PR TITLE
integration-playbook: Add hidden dependencies

### DIFF
--- a/contrib/test/crio-integration-playbook.yaml
+++ b/contrib/test/crio-integration-playbook.yaml
@@ -7,6 +7,7 @@
   vars:
     xunit: false
     cni_commit: dcf7368eeab15e2affc6256f0bb1e84dd46a34de
+    integration_timeout_seconds: "{{ 60 * 60 * 2 }}"
   pre_tasks:
     # Assumes subscription stuff won't get in the way
     - name: Install pre-requesites for ansible on all platforms
@@ -337,7 +338,7 @@
     shell: 'CGROUP_MANAGER=cgroupfs STORAGE_OPTS="--storage-driver=overlay2 --storage-opt overlay2.override_kernel_check=1" make localintegration 2>&1 > testout.txt'
     args:
       chdir: /root/src/github.com/kubernetes-incubator/cri-o
-    async: 3600
+    async: "{{ integration_timeout_seconds | int }}"
     poll: 10
     ignore_errors: yes
     when: ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS'
@@ -345,7 +346,7 @@
     shell: 'CGROUP_MANAGER=cgroupfs STORAGE_OPTS="--storage-driver=overlay2 --storage-opt overlay2.override_kernel_check=1" make localintegration'
     args:
       chdir: /root/src/github.com/kubernetes-incubator/cri-o
-    async: 3600
+    async: "{{ integration_timeout_seconds | int }}"
     poll: 10
     ignore_errors: yes
     when: (ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS') and xunit
@@ -353,7 +354,7 @@
     shell: 'CGROUP_MANAGER=cgroupfs STORAGE_OPTS="--storage-driver=overlay2" make localintegration 2>&1 > testout.txt'
     args:
       chdir: /root/src/github.com/kubernetes-incubator/cri-o
-    async: 3600
+    async: "{{ integration_timeout_seconds | int }}"
     poll: 10
     ignore_errors: yes
     when: ansible_distribution == 'Fedora'
@@ -361,7 +362,7 @@
     shell: 'CGROUP_MANAGER=cgroupfs STORAGE_OPTS="--storage-driver=overlay2" make localintegration'
     args:
       chdir: /root/src/github.com/kubernetes-incubator/cri-o
-    async: 3600
+    async: "{{ integration_timeout_seconds | int }}"
     poll: 10
     ignore_errors: yes
     when: (ansible_distribution == 'Fedora' and xunit)

--- a/contrib/test/crio-integration-playbook.yaml
+++ b/contrib/test/crio-integration-playbook.yaml
@@ -3,10 +3,37 @@
 ## --skip-tags pr
 - hosts: all
   remote_user: root
+  gather_facts: False  # Ansible dependencies need installing first
   vars:
     xunit: false
     cni_commit: dcf7368eeab15e2affc6256f0bb1e84dd46a34de
+  pre_tasks:
+    # Assumes subscription stuff won't get in the way
+    - name: Install pre-requesites for ansible on all platforms
+      raw: $(type -P dnf || type -P yum) install -y python libselinux-python yum-utils python3-pycurl
+    # Gather facts
+    - setup:
+    # Just one more thing...
+    - name: Install special ansible deps. for fedora
+      raw: dnf install -y python2-dnf python3-dnf
+      when: ansible_distribution == 'Fedora'
   tasks:
+  - name: Enable EPEL on RHEL & CentOS
+    yum_repository:
+      name: epel
+      description: "Extra Packages for Enterprise Linux"
+      baseurl: "http://dl.fedoraproject.org/pub/epel/7/$basearch"
+      metalink: "https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch"
+      gpgcheck: True
+      gpgcakey: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7Server"
+    when: (ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS')
+  - name: import EPEL GPG keys on RHEL & CentOS
+    command: 'rpm --import {{ item }}'
+    with_items:
+      - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7Server
+      - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+      - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL
+    when: (ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS')
   - name: Update all packages
     yum:
       name: '*'
@@ -27,28 +54,57 @@
       name: "{{ item }}"
       state: latest
     with_items:
-      - wget
-      - git
-      - make
-      - gcc
-      - tar
-      - libseccomp-devel
-      - golang
-      - glib2-devel
-      - glibc-static
-      - container-selinux
       - btrfs-progs-devel
-      - device-mapper-devel
-      - ostree-devel
-      - glibc-devel
-      - gpgme-devel
-      - libassuan-devel
-      - libgpg-error-devel
-      - pkgconfig
+      - container-selinux
       - skopeo-containers
-      - oci-systemd-hook
+      - curl
+      - device-mapper-devel
+      - expect
+      - findutils
+      - gcc
+      - git
+      - glib2-devel
+      - glibc-devel
+      - glibc-static
+      - golang
+      - gpgme-devel
+      - hostname
+      - iproute
+      - iptables
+      - krb5-workstation
+      - libassuan-devel
+      - libffi-devel
+      - libgpg-error-devel
+      - libguestfs-tools
+      - libseccomp-devel
+      - libvirt-client
+      - libvirt-python
+      - libxml2-devel
+      - libxslt-devel
+      - make
+      - mlocate
+      - nfs-utils
+      - nmap-ncat
+      - npm
       - oci-register-machine
+      - oci-systemd-hook
       - oci-umount
+      - openssl
+      - openssl-devel
+      - ostree-devel
+      - pkgconfig
+      - python
+      - python2-boto
+      - python2-crypto
+      - python2-mock
+      - python-click
+      - python-devel
+      - python-virtualenv
+      - PyYAML
+      - redhat-rpm-config
+      - rpcbind
+      - rsync
+      - sed
       - socat
     async: 600
     poll: 10
@@ -58,6 +114,8 @@
       name: "{{ item }}"
       state: latest
     with_items:
+      - nmap-ncat
+      - iptables
       - wget
       - git
       - make
@@ -264,6 +322,7 @@
       regexp: 'export PATH=/usr/local/go/bin:$PATH'
       state: present
     when: ansible_distribution == 'Fedora' or ansible_distribution == 'RedHat'
+  # dest dir depends on skopeo-containers package
   - name: Copy redhat sigstore file to test host
     copy:
       remote_src: yes

--- a/contrib/test/crio-integration-playbook.yaml
+++ b/contrib/test/crio-integration-playbook.yaml
@@ -1,6 +1,8 @@
 ## This playbook expects --extra-vars "commit=<commit>"
 ## and either --extra-vars "pullrequest=<PR #>" or
-## --skip-tags pr
+## --skip-tags pr.
+##
+## Required: --extra-vars extras_repo_baseurl=<HTTP or HTTPS>
 - hosts: all
   remote_user: root
   gather_facts: False  # Ansible dependencies need installing first
@@ -9,7 +11,11 @@
     cni_commit: dcf7368eeab15e2affc6256f0bb1e84dd46a34de
     integration_timeout_seconds: "{{ 60 * 60 * 2 }}"
   pre_tasks:
-    # Assumes subscription stuff won't get in the way
+    # Assert subscription stuff won't get in the way
+    - assert:
+        that:
+          - 'extras_repo_baseurl | default(False)'
+          - 'server_repo_baseurl | default(False)'
     - name: Install pre-requesites for ansible on all platforms
       raw: $(type -P dnf || type -P yum) install -y python libselinux-python yum-utils python3-pycurl
     # Gather facts
@@ -25,6 +31,7 @@
       description: "Extra Packages for Enterprise Linux"
       baseurl: "http://dl.fedoraproject.org/pub/epel/7/$basearch"
       metalink: "https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch"
+      enabled: True
       gpgcheck: True
       gpgcakey: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7Server"
     when: (ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS')
@@ -35,6 +42,26 @@
       - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
       - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL
     when: (ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS')
+  - name: Enable required RHEL repositories
+    yum_repository:
+      name: "{{ item.key }}"
+      description: Required repo. for RHEL
+      baseurl: "{{ item.value }}"
+      gpgcheck: False
+      enabled: True
+    with_dict:
+      extras: '{{ extras_repo_baseurl | mandatory }}'
+      server: '{{ server_repo_baseurl | mandatory }}'
+    when: (ansible_distribution == 'RedHat')
+  - name: Don't let old cache interfere with new efforts
+    shell: $(type -P dnf || type -P yum) clean all && rm -rf /var/cache/{yum,dnf}
+  - name: disable redhat yum plugin
+    ini_file:
+      path: "/etc/yum/pluginconf.d/subscription-manager.conf"
+      section: main
+      option: enabled
+      value: 0
+    when: (ansible_distribution == 'RedHat')
   - name: Update all packages
     yum:
       name: '*'

--- a/contrib/test/venv-ansible-playbook.sh
+++ b/contrib/test/venv-ansible-playbook.sh
@@ -56,27 +56,29 @@ echo
 (
     set -x
     cd "$WORKSPACE"
-    # N/B: local system's virtualenv binary - uncontrolled version fixed below
-    virtualenv --no-site-packages --python=python2.7 ./.venvbootstrap
-    # Set up paths to install/operate out of $WORKSPACE/.venvbootstrap
-    source ./.venvbootstrap/bin/activate
-    # N/B: local system's pip binary - uncontrolled version fixed below
-    # pip may not support --cache-dir, force it's location into $WORKSPACE the ugly-way
-    OLD_HOME="$HOME"
-    export HOME="$WORKSPACE"
-    export PIPCACHE="$WORKSPACE/.cache/pip"
-    pip install --force-reinstall --upgrade pip==9.0.1
-    # Undo --cache-dir workaround
-    export HOME="$OLD_HOME"
-    # Install fixed, trusted, hashed versions of all requirements (including pip and virtualenv)
-    pip --cache-dir="$PIPCACHE" install --require-hashes \
-        --requirement "$SCRIPT_PATH/requirements.txt"
+    # When running more than once, make it fast by skipping the bootstrap
+    if [ ! -d "./.cri-o_venv" ]; then
+        # N/B: local system's virtualenv binary - uncontrolled version fixed below
+        virtualenv --no-site-packages --python=python2.7 ./.venvbootstrap
+        # Set up paths to install/operate out of $WORKSPACE/.venvbootstrap
+        source ./.venvbootstrap/bin/activate
+        # N/B: local system's pip binary - uncontrolled version fixed below
+        # pip may not support --cache-dir, force it's location into $WORKSPACE the ugly-way
+        OLD_HOME="$HOME"
+        export HOME="$WORKSPACE"
+        export PIPCACHE="$WORKSPACE/.cache/pip"
+        pip install --force-reinstall --upgrade pip==9.0.1
+        # Undo --cache-dir workaround
+        export HOME="$OLD_HOME"
+        # Install fixed, trusted, hashed versions of all requirements (including pip and virtualenv)
+        pip --cache-dir="$PIPCACHE" install --require-hashes \
+            --requirement "$SCRIPT_PATH/requirements.txt"
 
-    # Setup trusted virtualenv using hashed binary from requirements.txt
-    ./.venvbootstrap/bin/virtualenv --no-site-packages --python=python2.7 ./.cri-o_venv
-    # Exit untrusted virtualenv
-    deactivate
-
+        # Setup trusted virtualenv using hashed binary from requirements.txt
+        ./.venvbootstrap/bin/virtualenv --no-site-packages --python=python2.7 ./.cri-o_venv
+        # Exit untrusted virtualenv
+        deactivate
+    fi
     # Enter trusted virtualenv
     source ./.cri-o_venv/bin/activate
     # Re-install from cache


### PR DESCRIPTION
Previously, an internal playbook installed many extra
necessary/unnecessary packages before this playbook even started.  Since
this is a terrible design, move all dependencies here so that nothing is
unwritten.  This includes installing some deps. for ansible itself
(which must be done as a raw command).

Signed-off-by: Chris Evich <cevich@redhat.com>