### PR TITLE
BUGFIX: If runtime (runc) cannot be found, error out

### DIFF
--- a/cmd/kpod/common.go
+++ b/cmd/kpod/common.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 
+	"fmt"
 	is "github.com/containers/image/storage"
 	"github.com/containers/storage"
 	"github.com/fatih/camelcase"
@@ -92,6 +93,10 @@ func getConfig(c *cli.Context) (*libkpod.Config, error) {
 	}
 	if c.GlobalIsSet("runtime") {
 		config.Runtime = c.GlobalString("runtime")
+	}
+	if _, err := os.Stat(config.Runtime); os.IsNotExist(err) {
+		// path to runtime does not exist
+		return config, fmt.Errorf("invalid --runtime value %q", err)
 	}
 	return config, nil
 }

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -60,6 +60,9 @@ PIDS_LIMIT=${PIDS_LIMIT:-1024}
 LOG_SIZE_MAX_LIMIT=${LOG_SIZE_MAX_LIMIT:--1}
 
 TESTDIR=$(mktemp -d)
+ROOT="$TESTDIR/crio"
+RUNROOT="$TESTDIR/crio-run"
+KPOD_OPTIONS="--root $ROOT --runroot $RUNROOT ${STORAGE_OPTS} --runtime ${RUNTIME_BINARY}"
 
 # kpod pull needs a configuration file for shortname pulls
 export REGISTRIES_CONFIG_PATH="$INTEGRATION_ROOT/registries.conf"

--- a/test/kpod.bats
+++ b/test/kpod.bats
@@ -3,9 +3,6 @@
 load helpers
 
 IMAGE="alpine:latest"
-ROOT="$TESTDIR/crio"
-RUNROOT="$TESTDIR/crio-run"
-KPOD_OPTIONS="--root $ROOT --runroot $RUNROOT --storage-driver vfs"
 
 function teardown() {
     cleanup_test

--- a/test/kpod_diff.bats
+++ b/test/kpod_diff.bats
@@ -3,9 +3,6 @@
 load helpers
 
 IMAGE="alpine:latest"
-ROOT="$TESTDIR/crio"
-RUNROOT="$TESTDIR/crio-run"
-KPOD_OPTIONS="--root $ROOT --runroot $RUNROOT $STORAGE_OPTS"
 
 function teardown() {
     cleanup_test

--- a/test/kpod_export.bats
+++ b/test/kpod_export.bats
@@ -3,10 +3,6 @@
 load helpers
 
 IMAGE="redis:alpine"
-ROOT="$TESTDIR/crio"
-RUNROOT="$TESTDIR/crio-run"
-KPOD_OPTIONS="--root $ROOT --runroot $RUNROOT ${STORAGE_OPTS}"
-
 
 @test "kpod export output flag" {
     start_crio

--- a/test/kpod_load.bats
+++ b/test/kpod_load.bats
@@ -3,9 +3,6 @@
 load helpers
 
 IMAGE="alpine:latest"
-ROOT="$TESTDIR/crio"
-RUNROOT="$TESTDIR/crio-run"
-KPOD_OPTIONS="--root $ROOT --runroot $RUNROOT $STORAGE_OPTS"
 
 function teardown() {
     cleanup_test

--- a/test/kpod_logs.bats
+++ b/test/kpod_logs.bats
@@ -3,9 +3,6 @@
 load helpers
 
 IMAGE="alpine:latest"
-ROOT="$TESTDIR/crio"
-RUNROOT="$TESTDIR/crio-run"
-KPOD_OPTIONS="--root $ROOT --runroot $RUNROOT ${STORAGE_OPTS}"
 
 function teardown() {
     cleanup_test

--- a/test/kpod_mount.bats
+++ b/test/kpod_mount.bats
@@ -7,9 +7,6 @@ function teardown() {
 load helpers
 
 IMAGE="redis:alpine"
-ROOT="$TESTDIR/crio"
-RUNROOT="$TESTDIR/crio-run"
-KPOD_OPTIONS="--root $ROOT --runroot $RUNROOT ${STORAGE_OPTS}"
 
 @test "mount" {
     start_crio

--- a/test/kpod_ps.bats
+++ b/test/kpod_ps.bats
@@ -3,9 +3,6 @@
 load helpers
 
 IMAGE="redis:alpine"
-ROOT="$TESTDIR/crio"
-RUNROOT="$TESTDIR/crio-run"
-KPOD_OPTIONS="--root $ROOT --runroot $RUNROOT ${STORAGE_OPTS}"
 
 @test "kpod ps with no containers" {
     run ${KPOD_BINARY} ${KPOD_OPTIONS} ps

--- a/test/kpod_pull.bats
+++ b/test/kpod_pull.bats
@@ -3,9 +3,6 @@
 load helpers
 
 IMAGE="alpine:latest"
-ROOT="$TESTDIR/crio"
-RUNROOT="$TESTDIR/crio-run"
-KPOD_OPTIONS="--root $ROOT --runroot $RUNROOT ${STORAGE_OPTS}"
 
 function teardown() {
   cleanup_test

--- a/test/kpod_rename.bats
+++ b/test/kpod_rename.bats
@@ -3,9 +3,6 @@
 load helpers
 
 IMAGE="redis:alpine"
-ROOT="$TESTDIR/crio"
-RUNROOT="$TESTDIR/crio-run"
-KPOD_OPTIONS="--root $ROOT --runroot $RUNROOT $STORAGE_OPTS"
 NEW_NAME="rename-test"
 
 function teardown() {

--- a/test/kpod_rm.bats
+++ b/test/kpod_rm.bats
@@ -3,9 +3,6 @@
 load helpers
 
 IMAGE="alpine:latest"
-ROOT="$TESTDIR/crio"
-RUNROOT="$TESTDIR/crio-run"
-KPOD_OPTIONS="--root $ROOT --runroot $RUNROOT $STORAGE_OPTS --runtime $RUNTIME_BINARY"
 function teardown() {
     cleanup_test
 }

--- a/test/kpod_save.bats
+++ b/test/kpod_save.bats
@@ -3,9 +3,6 @@
 load helpers
 
 IMAGE="alpine:latest"
-ROOT="$TESTDIR/crio"
-RUNROOT="$TESTDIR/crio-run"
-KPOD_OPTIONS="--root $ROOT --runroot $RUNROOT $STORAGE_OPTS"
 
 function teardown() {
     cleanup_test

--- a/test/kpod_stats.bats
+++ b/test/kpod_stats.bats
@@ -2,9 +2,6 @@
 
 load helpers
 
-ROOT="$TESTDIR/crio"
-RUNROOT="$TESTDIR/crio-run"
-KPOD_OPTIONS="--root $ROOT --runroot $RUNROOT $STORAGE_OPTS"
 
 function teardown() {
     cleanup_test

--- a/test/kpod_stop.bats
+++ b/test/kpod_stop.bats
@@ -2,9 +2,6 @@
 
 load helpers
 
-ROOT="$TESTDIR/crio"
-RUNROOT="$TESTDIR/crio-run"
-KPOD_OPTIONS="--root $ROOT --runroot $RUNROOT --storage-driver vfs"
 function teardown() {
     cleanup_test
 }


### PR DESCRIPTION
In the case where the runtime cannot be found, kpod should error
out.  This occurs in kpod ps when iterating through the containers
to get details.

Signed-off-by: baude <bbaude@redhat.com>