### PR TITLE
integration-playbook: Don't re-swap

### DIFF
--- a/contrib/test/crio-integration-playbook.yaml
+++ b/contrib/test/crio-integration-playbook.yaml
@@ -88,8 +88,11 @@
       truncate -s 8G /root/swap && \
       export SWAPDEV=$(losetup --show -f /root/swap | head -1) && \
       mkswap $SWAPDEV && \
-      swapon $SWAPDEV && \
-      swapon --show || true
+      swapon $SWAPDEV || true
+  - name: Capture current state of swap for debugging
+    command: swapon --show
+    register: result
+  - debug: var=result
   - name: Make testing directories to conform to testing standards
     file:
       path: "{{ item }}"

--- a/contrib/test/crio-integration-playbook.yaml
+++ b/contrib/test/crio-integration-playbook.yaml
@@ -84,11 +84,12 @@
     when: ansible_distribution == 'Fedora'
   - name: Setup swap to prevent kernel firing off the OOM killer
     shell: |
+      [ ! -f /root/swap ] && \
       truncate -s 8G /root/swap && \
       export SWAPDEV=$(losetup --show -f /root/swap | head -1) && \
       mkswap $SWAPDEV && \
       swapon $SWAPDEV && \
-      swapon --show
+      swapon --show || true
   - name: Make testing directories to conform to testing standards
     file:
       path: "{{ item }}"


### PR DESCRIPTION
If the playbook is run multiple times, it can result in the in-use swap
file being truncated.  A decidedly bad thing that can be avoided by
checking for it's existence first.

Signed-off-by: Chris Evich <cevich@redhat.com>