### PR TITLE
*: allow to not use pivot_root

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -77,6 +77,9 @@ runtime_untrusted_workload = "{{ .RuntimeUntrustedWorkload }}"
 # container runtime for all containers.
 default_workload_trust = "{{ .DefaultWorkloadTrust }}"
 
+# no_pivot instructs the runtime to not use pivot_root, but instead use MS_MOVE
+no_pivot = {{ .NoPivot }}
+
 # conmon is the path to conmon binary, used for managing the runtime.
 conmon = "{{ .Conmon }}"
 

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -104,6 +104,7 @@ static char *opt_runtime_path = NULL;
 static char *opt_bundle_path = NULL;
 static char *opt_pid_file = NULL;
 static bool opt_systemd_cgroup = false;
+static bool opt_no_pivot = false;
 static char *opt_exec_process_spec = NULL;
 static bool opt_exec = false;
 static char *opt_log_path = NULL;
@@ -117,6 +118,7 @@ static GOptionEntry opt_entries[] =
   { "cid", 'c', 0, G_OPTION_ARG_STRING, &opt_cid, "Container ID", NULL },
   { "cuuid", 'u', 0, G_OPTION_ARG_STRING, &opt_cuuid, "Container UUID", NULL },
   { "runtime", 'r', 0, G_OPTION_ARG_STRING, &opt_runtime_path, "Runtime path", NULL },
+  { "no-pivot", 0, 0, G_OPTION_ARG_NONE, &opt_no_pivot, "do not use pivot_root", NULL },
   { "bundle", 'b', 0, G_OPTION_ARG_STRING, &opt_bundle_path, "Bundle path", NULL },
   { "pidfile", 'p', 0, G_OPTION_ARG_STRING, &opt_pid_file, "PID file", NULL },
   { "systemd-cgroup", 's', 0, G_OPTION_ARG_NONE, &opt_systemd_cgroup, "Enable systemd cgroup manager", NULL },
@@ -1263,6 +1265,12 @@ int main(int argc, char *argv[])
 			 "--bundle", opt_bundle_path,
 			 "--pid-file", opt_pid_file,
 			 NULL);
+	}
+
+	if (!opt_exec && opt_no_pivot) {
+		add_argv(runtime_argv,
+			"--no-pivot",
+			NULL);
 	}
 
 	if (csname != NULL) {

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -77,6 +77,9 @@ The `crio` table supports the following options:
 **apparmor_profile**=""
   Name of the apparmor profile to be used as the runtime's default (default: "crio-default")
 
+**no_pivot**=*true*|*false*
+  Instructs the runtime to not use pivot_root, but instead use MS_MOVE
+
 ## CRIO.IMAGE TABLE
 
 **default_transport**

--- a/libkpod/config.go
+++ b/libkpod/config.go
@@ -118,6 +118,9 @@ type RuntimeConfig struct {
 	// container runtime for all containers.
 	DefaultWorkloadTrust string `toml:"default_workload_trust"`
 
+	// NoPivot instructs the runtime to not use `pivot_root`, but instead use `MS_MOVE`
+	NoPivot bool `toml:"no_pivot"`
+
 	// Conmon is the path to conmon binary, used for managing the runtime.
 	Conmon string `toml:"conmon"`
 

--- a/libkpod/container_server.go
+++ b/libkpod/container_server.go
@@ -121,7 +121,7 @@ func New(config *Config) (*ContainerServer, error) {
 		return nil, err
 	}
 
-	runtime, err := oci.New(config.Runtime, config.RuntimeUntrustedWorkload, config.DefaultWorkloadTrust, config.Conmon, config.ConmonEnv, config.CgroupManager, config.ContainerExitsDir, config.LogSizeMax)
+	runtime, err := oci.New(config.Runtime, config.RuntimeUntrustedWorkload, config.DefaultWorkloadTrust, config.Conmon, config.ConmonEnv, config.CgroupManager, config.ContainerExitsDir, config.LogSizeMax, config.NoPivot)
 	if err != nil {
 		return nil, err
 	}

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -38,7 +38,15 @@ const (
 )
 
 // New creates a new Runtime with options provided
-func New(runtimeTrustedPath string, runtimeUntrustedPath string, trustLevel string, conmonPath string, conmonEnv []string, cgroupManager string, containerExitsDir string, logSizeMax int64) (*Runtime, error) {
+func New(runtimeTrustedPath string,
+	runtimeUntrustedPath string,
+	trustLevel string,
+	conmonPath string,
+	conmonEnv []string,
+	cgroupManager string,
+	containerExitsDir string,
+	logSizeMax int64,
+	noPivot bool) (*Runtime, error) {
 	r := &Runtime{
 		name:              filepath.Base(runtimeTrustedPath),
 		trustedPath:       runtimeTrustedPath,
@@ -49,6 +57,7 @@ func New(runtimeTrustedPath string, runtimeUntrustedPath string, trustLevel stri
 		cgroupManager:     cgroupManager,
 		containerExitsDir: containerExitsDir,
 		logSizeMax:        logSizeMax,
+		noPivot:           noPivot,
 	}
 	return r, nil
 }
@@ -64,6 +73,7 @@ type Runtime struct {
 	cgroupManager     string
 	containerExitsDir string
 	logSizeMax        int64
+	noPivot           bool
 }
 
 // syncInfo is used to return data from monitor process to daemon
@@ -160,6 +170,9 @@ func (r *Runtime) CreateContainer(c *Container, cgroupParent string) error {
 	args = append(args, "--exit-dir", r.containerExitsDir)
 	if r.logSizeMax >= 0 {
 		args = append(args, "--log-size-max", fmt.Sprintf("%v", r.logSizeMax))
+	}
+	if r.noPivot {
+		args = append(args, "--no-pivot")
 	}
 	if c.terminal {
 		args = append(args, "-t")


### PR DESCRIPTION
runc has a `--no-pivot` flag, that uses MS_MOVE instead.

This patch set bubbles up a runtime config to enable using no-pivot
globally.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>