### PR TITLE
main: Define -log-level option

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -197,10 +197,6 @@ func main() {
 			Name:  "conmon",
 			Usage: "path to the conmon executable",
 		},
-		cli.BoolFlag{
-			Name:  "debug",
-			Usage: "enable debug output for logging",
-		},
 		cli.StringFlag{
 			Name:  "listen",
 			Usage: "path to crio socket",
@@ -223,6 +219,11 @@ func main() {
 			Value: "text",
 			Usage: "set the format used by logs ('text' (default), or 'json')",
 		},
+		cli.StringFlag{
+			Name:  "log-level",
+			Usage: "log messages above specified level: debug, info (default), warn, error, fatal or panic",
+		},
+
 		cli.StringFlag{
 			Name:  "pause-command",
 			Usage: "name of the pause command in the pause image",
@@ -361,8 +362,13 @@ func main() {
 
 		logrus.SetFormatter(cf)
 
-		if c.GlobalBool("debug") {
-			logrus.SetLevel(logrus.DebugLevel)
+		if loglevel := c.GlobalString("log-level"); loglevel != "" {
+			level, err := logrus.ParseLevel(loglevel)
+			if err != nil {
+				return err
+			}
+
+			logrus.SetLevel(level)
 		}
 
 		if path := c.GlobalString("log"); path != "" {

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -13,13 +13,13 @@ crio - OCI Kubernetes Container Runtime daemon
 [**--config**=[*value*]]
 [**--conmon**=[*value*]]
 [**--cpu-profile**=[*value*]]
-[**--debug**]
 [**--default-transport**=[*value*]]
 [**--help**|**-h**]
 [**--insecure-registry**=[*value*]]
 [**--listen**=[*value*]]
 [**--log**=[*value*]]
 [**--log-format value**]
+[**--log-level value**]
 [**--pause-command**=[*value*]]
 [**--pause-image**=[*value*]]
 [**--registry**=[*value*]]
@@ -66,9 +66,6 @@ crio is meant to provide an integration path between OCI conformant runtimes and
 **--cpu-profile**=""
 set the CPU profile file path
 
-**--debug**
-  Enable debug output for logging
-
 **--default-transport**
   A prefix to prepend to image names that can't be pulled as-is.
 
@@ -104,6 +101,9 @@ set the CPU profile file path
 
 **--log-format**=""
   Set the format used by logs ('text' (default), or 'json') (default: "text")
+
+**--log-level**=""
+  log CRI-O messages above specified level: debug, info (default), warn, error, fatal or panic
 
 **--log-size-max**=""
   Maximum log size in bytes for a container (default: -1 (no limit))

--- a/kubernetes.md
+++ b/kubernetes.md
@@ -36,7 +36,7 @@ Description=CRI-O daemon
 Documentation=https://github.com/kubernetes-incubator/cri-o
 
 [Service]
-ExecStart=/bin/crio --runtime /bin/runc --log /root/crio.log --debug
+ExecStart=/bin/crio --runtime /bin/runc --log /root/crio.log --log-level debug
 Restart=always
 RestartSec=10s
 

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -271,13 +271,14 @@ func (r *Runtime) CreateContainer(c *Container, cgroupParent string) error {
 		logrus.Debugf("Received container pid: %d", ss.si.Pid)
 		if ss.si.Pid == -1 {
 			if ss.si.Message != "" {
-				logrus.Debugf("Container creation error: %s", ss.si.Message)
+				logrus.Errorf("Container creation error: %s", ss.si.Message)
 				return fmt.Errorf("container create failed: %s", ss.si.Message)
 			}
-			logrus.Debugf("Container creation failed")
+			logrus.Errorf("Container creation failed")
 			return fmt.Errorf("container create failed")
 		}
 	case <-time.After(ContainerCreateTimeout):
+		logrus.Errorf("Container creation timeout (%v)", ContainerCreateTimeout)
 		return fmt.Errorf("create container timeout")
 	}
 	return nil

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -245,7 +245,7 @@ function start_crio() {
 	fi
 	${netfunc} $POD_CIDR
 
-	"$CRIO_BINARY" --debug --config "$CRIO_CONFIG" & CRIO_PID=$!
+	"$CRIO_BINARY" --log-level debug --config "$CRIO_CONFIG" & CRIO_PID=$!
 	wait_until_reachable
 
 	run crictl inspecti redis:alpine

--- a/tutorial.md
+++ b/tutorial.md
@@ -163,7 +163,7 @@ Description=OCI-based implementation of Kubernetes Container Runtime Interface
 Documentation=https://github.com/kubernetes-incubator/cri-o
 
 [Service]
-ExecStart=/usr/local/bin/crio --debug
+ExecStart=/usr/local/bin/crio --log-level debug
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
Running crio with `-debug` is very verbose. Having more granularity
on the log level can be useful when e.g. only looking for errors.

This PR replaces `-debug` with `-log-level` and also fixes an OCI container creation log level.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>