### PR TITLE
Don't ignore failures in the e2e suite

### DIFF
--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -41,4 +41,3 @@
     go run hack/e2e.go -v --test -test_args="-host=https://{{ ansible_default_ipv4.address }}:6443 --ginkgo.focus=\[Conformance\]" >e2e.log 2>&1
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
-  ignore_errors: yes


### PR DESCRIPTION
There are no tasks that we need to run after the suite has finished,
like we do with the integration suite, so it does not make sense to
ignore the errors coming out of the e2e suite.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @runcom @mrunalp 