### PR TITLE
Handle container creation failures gracefully

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -151,7 +151,7 @@ func getOCIVersion(name string, args ...string) (string, error) {
 }
 
 // CreateContainer creates a container.
-func (r *Runtime) CreateContainer(c *Container, cgroupParent string) error {
+func (r *Runtime) CreateContainer(c *Container, cgroupParent string) (err error) {
 	var stderrBuf bytes.Buffer
 	parentPipe, childPipe, err := newPipe()
 	childStartPipe, parentStartPipe, err := newPipe()
@@ -247,6 +247,13 @@ func (r *Runtime) CreateContainer(c *Container, cgroupParent string) error {
 	if err != nil {
 		return err
 	}
+
+	// We will delete all container resources if creation fails
+	defer func() {
+		if err != nil {
+			r.DeleteContainer(c)
+		}
+	}()
 
 	// Wait to get container pid from conmon
 	type syncStruct struct {

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -31,7 +31,7 @@ const (
 	// ContainerStateStopped represents the stopped state of a container
 	ContainerStateStopped = "stopped"
 	// ContainerCreateTimeout represents the value of container creating timeout
-	ContainerCreateTimeout = 10 * time.Second
+	ContainerCreateTimeout = 240 * time.Second
 
 	// CgroupfsCgroupsManager represents cgroupfs native cgroup manager
 	CgroupfsCgroupsManager = "cgroupfs"


### PR DESCRIPTION
Under very heavy load, VM based containers can take more than 10s to start VMs, triggering the CRI-O container creation timeout. To gracefully handling that situation this PR:

- Increases the container creation timeout
- Asks the runtime for container deletion when creation fails.