### PR TITLE
validateFlags command line options to make sure the user entered a value

### DIFF
--- a/cmd/kpod/diff.go
+++ b/cmd/kpod/diff.go
@@ -77,6 +77,9 @@ func diffCmd(c *cli.Context) error {
 	if len(c.Args()) != 1 {
 		return errors.Errorf("container, layer, or image name must be specified: kpod diff [options [...]] ID-NAME")
 	}
+	if err := validateFlags(c, diffFlags); err != nil {
+		return err
+	}
 	config, err := getConfig(c)
 	if err != nil {
 		return errors.Wrapf(err, "could not get config")

--- a/cmd/kpod/export.go
+++ b/cmd/kpod/export.go
@@ -48,6 +48,9 @@ func exportCmd(c *cli.Context) error {
 		return errors.Errorf("too many arguments given, need 1 at most.")
 	}
 	container := args[0]
+	if err := validateFlags(c, exportFlags); err != nil {
+		return err
+	}
 
 	config, err := getConfig(c)
 	if err != nil {

--- a/cmd/kpod/history.go
+++ b/cmd/kpod/history.go
@@ -85,6 +85,9 @@ var (
 )
 
 func historyCmd(c *cli.Context) error {
+	if err := validateFlags(c, historyFlags); err != nil {
+		return err
+	}
 	config, err := getConfig(c)
 	if err != nil {
 		return errors.Wrapf(err, "Could not get config")

--- a/cmd/kpod/images.go
+++ b/cmd/kpod/images.go
@@ -52,6 +52,9 @@ var (
 )
 
 func imagesCmd(c *cli.Context) error {
+	if err := validateFlags(c, imagesFlags); err != nil {
+		return err
+	}
 	config, err := getConfig(c)
 	if err != nil {
 		return errors.Wrapf(err, "Could not get config")

--- a/cmd/kpod/info.go
+++ b/cmd/kpod/info.go
@@ -36,6 +36,9 @@ var (
 )
 
 func infoCmd(c *cli.Context) error {
+	if err := validateFlags(c, infoFlags); err != nil {
+		return err
+	}
 	info := map[string]interface{}{}
 
 	infoGivers := []infoGiverFunc{

--- a/cmd/kpod/inspect.go
+++ b/cmd/kpod/inspect.go
@@ -49,6 +49,9 @@ func inspectCmd(c *cli.Context) error {
 	if len(args) > 1 {
 		return errors.Errorf("too many arguments specified")
 	}
+	if err := validateFlags(c, inspectFlags); err != nil {
+		return err
+	}
 
 	itemType := c.String("type")
 	size := c.Bool("size")

--- a/cmd/kpod/kill.go
+++ b/cmd/kpod/kill.go
@@ -35,6 +35,9 @@ func killCmd(c *cli.Context) error {
 	if len(args) == 0 {
 		return errors.Errorf("specify one or more containers to kill")
 	}
+	if err := validateFlags(c, killFlags); err != nil {
+		return err
+	}
 	config, err := getConfig(c)
 	if err != nil {
 		return errors.Wrapf(err, "could not get config")

--- a/cmd/kpod/load.go
+++ b/cmd/kpod/load.go
@@ -45,6 +45,9 @@ func loadCmd(c *cli.Context) error {
 	if len(args) > 1 {
 		return errors.New("too many arguments. Requires exactly 1")
 	}
+	if err := validateFlags(c, loadFlags); err != nil {
+		return err
+	}
 
 	runtime, err := getRuntime(c)
 	if err != nil {

--- a/cmd/kpod/logs.go
+++ b/cmd/kpod/logs.go
@@ -46,6 +46,9 @@ func logsCmd(c *cli.Context) error {
 	if len(args) != 1 {
 		return errors.Errorf("'kpod logs' requires exactly one container name/ID")
 	}
+	if err := validateFlags(c, logsFlags); err != nil {
+		return err
+	}
 	container := c.Args().First()
 	var opts libkpod.LogOptions
 	opts.Details = c.Bool("details")

--- a/cmd/kpod/mount.go
+++ b/cmd/kpod/mount.go
@@ -64,6 +64,9 @@ func mountCmd(c *cli.Context) error {
 	if len(args) > 1 {
 		return errors.Errorf("too many arguments specified")
 	}
+	if err := validateFlags(c, mountFlags); err != nil {
+		return err
+	}
 	config, err := getConfig(c)
 	if err != nil {
 		return errors.Wrapf(err, "Could not get config")

--- a/cmd/kpod/ps.go
+++ b/cmd/kpod/ps.go
@@ -143,6 +143,9 @@ var (
 )
 
 func psCmd(c *cli.Context) error {
+	if err := validateFlags(c, psFlags); err != nil {
+		return err
+	}
 	config, err := getConfig(c)
 	if err != nil {
 		return errors.Wrapf(err, "could not get config")

--- a/cmd/kpod/pull.go
+++ b/cmd/kpod/pull.go
@@ -129,6 +129,9 @@ func pullCmd(c *cli.Context) error {
 		logrus.Errorf("too many arguments. Requires exactly 1")
 		return nil
 	}
+	if err := validateFlags(c, pullFlags); err != nil {
+		return err
+	}
 	image := args[0]
 	srcRef, err := alltransports.ParseImageName(image)
 	if err != nil {

--- a/cmd/kpod/push.go
+++ b/cmd/kpod/push.go
@@ -68,6 +68,9 @@ func pushCmd(c *cli.Context) error {
 	if len(args) < 2 {
 		return errors.New("kpod push requires exactly 2 arguments")
 	}
+	if err := validateFlags(c, pushFlags); err != nil {
+		return err
+	}
 	srcName := c.Args().Get(0)
 	destName := c.Args().Get(1)
 

--- a/cmd/kpod/rename.go
+++ b/cmd/kpod/rename.go
@@ -23,6 +23,9 @@ func renameCmd(c *cli.Context) error {
 	if len(c.Args()) != 2 {
 		return errors.Errorf("Rename requires a src container name/ID and a dest container name")
 	}
+	if err := validateFlags(c, renameFlags); err != nil {
+		return err
+	}
 
 	config, err := getConfig(c)
 	if err != nil {

--- a/cmd/kpod/rm.go
+++ b/cmd/kpod/rm.go
@@ -33,6 +33,9 @@ func rmCmd(c *cli.Context) error {
 	if len(args) == 0 {
 		return errors.Errorf("specify one or more containers to remove")
 	}
+	if err := validateFlags(c, rmFlags); err != nil {
+		return err
+	}
 
 	config, err := getConfig(c)
 	if err != nil {

--- a/cmd/kpod/rmi.go
+++ b/cmd/kpod/rmi.go
@@ -28,6 +28,9 @@ var (
 )
 
 func rmiCmd(c *cli.Context) error {
+	if err := validateFlags(c, rmiFlags); err != nil {
+		return err
+	}
 
 	force := false
 	if c.IsSet("force") {

--- a/cmd/kpod/save.go
+++ b/cmd/kpod/save.go
@@ -47,6 +47,9 @@ func saveCmd(c *cli.Context) error {
 	if len(args) == 0 {
 		return errors.Errorf("need at least 1 argument")
 	}
+	if err := validateFlags(c, saveFlags); err != nil {
+		return err
+	}
 
 	runtime, err := getRuntime(c)
 	if err != nil {

--- a/cmd/kpod/stats.go
+++ b/cmd/kpod/stats.go
@@ -62,6 +62,9 @@ var (
 )
 
 func statsCmd(c *cli.Context) error {
+	if err := validateFlags(c, statsFlags); err != nil {
+		return err
+	}
 	config, err := getConfig(c)
 	if err != nil {
 		return errors.Wrapf(err, "could not read config")

--- a/cmd/kpod/stop.go
+++ b/cmd/kpod/stop.go
@@ -42,6 +42,9 @@ func stopCmd(c *cli.Context) error {
 	if len(args) < 1 {
 		return errors.Errorf("you must provide at least one container name or id")
 	}
+	if err := validateFlags(c, stopFlags); err != nil {
+		return err
+	}
 
 	config, err := getConfig(c)
 	if err != nil {


### PR DESCRIPTION
When a user enters a CLI with a StringFlags or StringSliceFlags and does not add
a value the CLI mistakently takes the next option and uses it as a value.

This usually ends up with an error like not enough options or others.  Some times
it could also succeed, with weird results.  This patch looks for any values that
begin with a "-" and return an error.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>