### PR TITLE
Drop btrfs support from RHEL and CentOS

### DIFF
--- a/contrib/test/integration/system.yml
+++ b/contrib/test/integration/system.yml
@@ -19,6 +19,14 @@
   async: 600
   poll: 10
 
+- name: Add Btrfs for Fedora
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+   - btrfs-progs-devel
+  when: ansible_distribution in ['Fedora']
+
 - name: Update all packages
   package:
     name: '*'

--- a/contrib/test/integration/vars.yml
+++ b/contrib/test/integration/vars.yml
@@ -4,7 +4,6 @@
 xunit: false
 
 rpm_pkgs:
-    - btrfs-progs-devel
     - container-selinux
     - curl
     - device-mapper-devel


### PR DESCRIPTION
Packages are no longer available to build on RHEL and CentOS and
btrfs is not longer supported, so we should not build with it.
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>