### PR TITLE
Only update kernel commandline to add quota on RHEL

### DIFF
--- a/contrib/test/integration/system.yml
+++ b/contrib/test/integration/system.yml
@@ -67,3 +67,4 @@
 
 - name: Update the kernel cmdline to include quota support
   command: grubby --update-kernel=ALL --args="rootflags=pquota"
+  when: ansible_distribution in ['RedHat', 'CentOS']


### PR DESCRIPTION
Fedora amis are still ext4 based and ext4 doesn't like this flag.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>