### PR TITLE
Add pause state to ps, touchup kpod man page

### DIFF
--- a/docs/kpod.1.md
+++ b/docs/kpod.1.md
@@ -79,6 +79,9 @@ Display the logs of a container
 ### mount
 Mount a working container's root filesystem
 
+### pause
+Pause one or more containers
+
 ### ps
 Prints out information about containers
 
@@ -105,6 +108,9 @@ Display a live stream of one or more containers' resource usage statistics
 
 ### stop
 Stops one or more running containers.
+
+### unpause
+Unpause one or more containers
 
 ### tag
 Add an additional name to a local image


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Adds a pause state to kpod-ps and touches up the main kpod man page to list pause and unpause.