### PR TITLE
Make sure log-size-max is atleast as big as read buffer

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -40,6 +40,11 @@ func validateConfig(config *server.Config) error {
 		return fmt.Errorf("Unrecognized image volume type specified")
 
 	}
+
+	// This needs to match the read buffer size in conmon
+	if config.LogSizeMax >= 0 && config.LogSizeMax < 8192 {
+		return fmt.Errorf("log size max should be negative or >= 8192")
+	}
 	return nil
 }
 

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -106,7 +106,8 @@ set the CPU profile file path
   Set the format used by logs ('text' (default), or 'json') (default: "text")
 
 **--log-size-max**=""
-  Maximum log size in bytes for a container (default: -1 (no limit))
+  Maximum log size in bytes for a container (default: -1 (no limit)).
+  If it is positive, it must be >= 8192 (to match/exceed conmon read buffer).
 
 **--pause-command**=""
   Path to the pause executable in the pause image (default: "/pause")

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -81,6 +81,7 @@ Example:
 **log_size_max**=""
   Maximum sized allowed for the container log file (default: -1)
   Negative numbers indicate that no size limit is imposed.
+  If it is positive, it must be >= 8192 (to match/exceed conmon read buffer).
   The file is truncated and re-opened so the limit is never exceeded.
 
 **pids_limit**=""


### PR DESCRIPTION
We need log-size-max to be bigger than the read buffer in conmon
to accurately truncate it.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>