### PR TITLE
Changed debug flag to log-level in kpod/main.go

### DIFF
--- a/cmd/kpod/main.go
+++ b/cmd/kpod/main.go
@@ -58,11 +58,21 @@ func main() {
 		waitCommand,
 	}
 	app.Before = func(c *cli.Context) error {
-		logrus.SetLevel(logrus.ErrorLevel)
-		if c.GlobalBool("debug") {
-			debug = true
-			logrus.SetLevel(logrus.DebugLevel)
+		logLevel := c.GlobalString("log-level")
+		if logLevel != "" {
+			level, err := logrus.ParseLevel(logLevel)
+			if err != nil {
+				return err
+			}
+
+			logrus.SetLevel(level)
 		}
+
+		if logLevel == "debug" {
+			debug = true
+
+		}
+
 		return nil
 	}
 	app.After = func(*cli.Context) error {
@@ -80,9 +90,10 @@ func main() {
 			Name:  "config, c",
 			Usage: "path of a config file detailing container server configuration options",
 		},
-		cli.BoolFlag{
-			Name:  "debug",
-			Usage: "print debugging information",
+		cli.StringFlag{
+			Name:  "log-level",
+			Usage: "log messages above specified level: debug, info, warn, error (default), fatal or panic",
+			Value: "error",
 		},
 		cli.StringFlag{
 			Name:  "root",

--- a/completions/bash/kpod
+++ b/completions/bash/kpod
@@ -438,9 +438,9 @@ _kpod_kpod() {
            --runroot
            --storage-driver
            --storage-opt
+           --log-level
     "
      local boolean_options="
-           --debug
            --help -h
            --version -v
      "

--- a/docs/kpod.1.md
+++ b/docs/kpod.1.md
@@ -26,8 +26,8 @@ has the capability to debug pods/images created by crio.
 **--config value, -c**=**"config.file"**
    Path of a config file detailing container server configuration options
 
-**--debug**
-   Print debugging information
+**--log-level**
+   log messages above specified level: debug, info, warn, error (default), fatal or panic
 
 **--root**=**value**
    Path to the root directory in which data, including images, is stored


### PR DESCRIPTION
The change in flag from debug to log-level was causing cri-o to fail when started
There was a reference to the debug flag in kpod/main.go that had not been changed

Signed-off-by: umohnani8 <umohnani@redhat.com>