### PR TITLE
Initial fixes for cri-tests

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -146,7 +146,7 @@ func resolveSymbolicLink(path string) (string, error) {
 
 func addDevices(sb *sandbox.Sandbox, containerConfig *pb.ContainerConfig, specgen *generate.Generator) error {
 	sp := specgen.Spec()
-	if containerConfig.GetLinux().GetSecurityContext().Privileged {
+	if containerConfig.GetLinux().GetSecurityContext().GetPrivileged() {
 		hostDevices, err := devices.HostDevices()
 		if err != nil {
 			return err

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -40,7 +40,10 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 	if filter.Id != "" {
 		id, err := s.CtrIDIndex().Get(filter.Id)
 		if err != nil {
-			return nil, err
+			// If we don't find a container ID with a filter, it should not
+			// be considered an error.  Log a warning and return an empty struct
+			logrus.Warn("unable to find container ID %s", filter.Id)
+			return &pb.ListContainersResponse{}, nil
 		}
 		c := s.ContainerServer.GetContainer(id)
 		if c != nil {


### PR DESCRIPTION
We now can pass 40/55 tests with this PR.  Remaining tests include may be fixed
with 1.8.

[Fail] [k8s.io] PodSandbox runtime should support sysctls [It] should support safe sysctls
[Fail] [k8s.io] Security Context SeccompProfilePath docker/default [It] should support seccomp docker/default on the container
[Fail] [k8s.io] Security Context SeccompProfilePath [It] runtime should not support a custom seccomp profile without using localhost/ as a prefix
[Fail] [k8s.io] Security Context bucket [It] runtime should support RunAsUser
[Fail] [k8s.io] PodSandbox runtime should support basic operations on PodSandbox [It] runtime should support removing PodSandbox [Conformance]
[Fail] [k8s.io] Container runtime should support mount propagation [It] mount with 'rshared' should support propagation from host to container and vice versa
[Fail] [k8s.io] PodSandbox runtime should support sysctls [It] should support unsafe sysctls
[Fail] [k8s.io] Security Context NoNewPrivs [It] should not allow privilege escalation when true
[Fail] [k8s.io] Security Context bucket [It] runtime should support RunAsUserName
[Fail] [k8s.io] Security Context bucket [It] runtime should support SupplementalGroups
[Fail] [k8s.io] Security Context NamespaceOption [It] runtime should support HostPID
[Fail] [k8s.io] Container runtime should support mount propagation [It] mount with 'rslave' should support propagation from host to container
[Fail] [k8s.io] Security Context SeccompProfilePath [It] runtime should support an seccomp profile that blocks setting hostname with SYS_ADMIN
[Fail] [k8s.io] Networking runtime should support networking [It] runtime should support port mapping with host port and container port [Conformance]
[Fail] [k8s.io] Security Context SeccompProfilePath [It] should support seccomp localhost/profile on the container

Signed-off-by: baude <bbaude@redhat.com>