### PR TITLE
nc (netcat): don't block when run interactively

### DIFF
--- a/test/network.bats
+++ b/test/network.bats
@@ -159,7 +159,7 @@ function teardown() {
 	run crioctl ctr start --id "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run nc -w 5 $host_ip 4888
+	run nc -w 5 $host_ip 4888 </dev/null
 	echo "$output"
 	[ "$output" = "crioctl_host" ]
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
When running the test suite interactively, "Connect to pod
hostport from the host" test hangs because nc thinks it's
got a bidirectional connection. Running with --recv-only
closes the connection after receiving the expected data,
letting the tests proceed.

This is just a suggestion for n00b-friendliness. Running
interactively is rare, but it's exactly where a n00b
will begin, and the hang costs a little time and energy
to track down.

Signed-off-by: Ed Santiago <santiago@redhat.com>