### PR TITLE
integration-playbook: Don't re-swap

### DIFF
--- a/contrib/test/integration/swap.yml
+++ b/contrib/test/integration/swap.yml
@@ -1,0 +1,42 @@
+---
+
+- name: Obtain current state of swap
+  command: swapon --noheadings --show=NAME
+  register: swapon
+
+- name: Setup swap if none already, to prevent kernel firing off the OOM killer
+  block:
+
+    - name: A unique swapfile path is generated
+      command: mktemp --tmpdir=/root swapfile_XXX
+      register: swapfilepath
+
+    - name: Swap file path is buffered
+      set_fact:
+        swapfilepath: '{{ swapfilepath.stdout | trim }}'
+
+    - name: Set swap file permissions
+      file:
+        path: "{{ swapfilepath }}"
+        owner: root
+        group: root
+        mode: 0600
+
+    - name: Swapfile padded to swapfile_size & timed to help debug any performance problems
+      shell: 'time dd if=/dev/zero of={{ swapfilepath }} bs={{ swapfileGB }}M count=1024'
+
+    - name: Swap file is formatted
+      command: 'mkswap {{ swapfilepath }}'
+
+    - name: Write swap entry in fstab
+      mount:
+        path: none
+        src: "{{ swapfilepath }}"
+        fstype: swap
+        opts: sw
+        state: present
+
+    - name: Mount swap
+      command: "swapon -a"
+
+  when: not (swapon.stdout_lines | length)

--- a/contrib/test/integration/system.yml
+++ b/contrib/test/integration/system.yml
@@ -72,13 +72,8 @@
   async: 600
   poll: 10
 
-- name: Setup swap to prevent kernel firing off the OOM killer
-  shell: |
-    truncate -s 8G /root/swap && \
-    export SWAPDEV=$(losetup --show -f /root/swap | head -1) && \
-    mkswap $SWAPDEV && \
-    swapon $SWAPDEV && \
-    swapon --show
+- name: Check / setup swap
+  include: "swap.yml"
 
 - name: ensure directories exist as needed
   file:

--- a/contrib/test/integration/vars.yml
+++ b/contrib/test/integration/vars.yml
@@ -1,5 +1,8 @@
 ---
 
+# When swap setup is necessary, make it this size
+swapfileGB: 8
+
 # For results.yml Paths use rsync 'source' conventions
 artifacts: "/tmp/artifacts"  # Base-directory for collection
 crio_integration_filepath: "{{ artifacts }}/testout.txt"


### PR DESCRIPTION
If the playbook is run multiple times or a host already has
swap configured, re-adding swap from a file can be problematic.
Avoid this by checking if swap is active, if not, also check
if the swapfile is in-use before truncating/formatting it.

Perform these steps again outside of the ``setup`` tag to ensure
swap is enabled/in use during testing-time as well.

Signed-off-by: Chris Evich <cevich@redhat.com>