### PR TITLE
Move crio.conf to /usr/lib/crio/crio.conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,10 @@ PREFIX ?= ${DESTDIR}/usr/local
 BINDIR ?= ${PREFIX}/bin
 LIBEXECDIR ?= ${PREFIX}/libexec
 MANDIR ?= ${PREFIX}/share/man
-ETCDIR ?= ${DESTDIR}/etc
-ETCDIR_CRIO ?= ${ETCDIR}/crio
+CONFIGDIR ?= ${PREFIX}/lib/crio
 DATAROOTDIR ?= ${PREFIX}/share/containers
 BUILDTAGS ?= $(shell hack/btrfs_tag.sh) $(shell hack/libdm_installed.sh) $(shell hack/libdm_no_deferred_remove_tag.sh) $(shell hack/btrfs_installed_tag.sh) $(shell hack/ostree_tag.sh) $(shell hack/seccomp_tag.sh) $(shell hack/selinux_tag.sh)
 CRICTL_CONFIG_DIR=${DESTDIR}/etc
-
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 OCIUMOUNTINSTALLDIR=$(PREFIX)/share/oci-umount/oci-umount.d
 
@@ -157,8 +155,8 @@ install.man: $(MANPAGES)
 
 install.config: crio.conf
 	install ${SELINUXOPT} -d $(DATAROOTDIR)/oci/hooks.d
-	install ${SELINUXOPT} -D -m 644 crio.conf $(ETCDIR_CRIO)/crio.conf
-	install ${SELINUXOPT} -D -m 644 seccomp.json $(ETCDIR_CRIO)/seccomp.json
+	install ${SELINUXOPT} -D -m 644 crio.conf $(CONFIGDIR)/crio.conf
+	install ${SELINUXOPT} -D -m 644 seccomp.json $(CONFIGDIR)/seccomp.json
 	install ${SELINUXOPT} -D -m 644 crio-umount.conf $(OCIUMOUNTINSTALLDIR)/crio-umount.conf
 	install ${SELINUXOPT} -D -m 644 crictl.yaml $(CRICTL_CONFIG_DIR)
 

--- a/contrib/system_containers/centos/Dockerfile
+++ b/contrib/system_containers/centos/Dockerfile
@@ -16,10 +16,9 @@ RUN yum-config-manager --nogpgcheck --add-repo https://cbs.centos.org/repos/virt
     rpm -V iptables cri-o iproute runc && \
     yum clean all && \
     mkdir -p /exports/hostfs/etc/crio /exports/hostfs/opt/cni/bin/ /exports/hostfs/var/lib/containers/storage/ && \
-    cp /etc/crio/* /exports/hostfs/etc/crio && \
+    sed '/^#storage_option =/s/.*/storage_option = [\n\t"overlay.override_kernel_check=1",\n]/' /usr/lib/crio/crio.conf > /exports/hostfs/etc/crio/crio.conf && \
     if test -e /usr/libexec/cni; then cp -Lr /usr/libexec/cni/* /exports/hostfs/opt/cni/bin/; fi
 
-RUN sed -i '/^#storage_option =/s/.*/storage_option = [\n\t"overlay.override_kernel_check=1",\n]/' /exports/hostfs/etc/crio/crio.conf
 
 COPY manifest.json tmpfiles.template config.json.template service.template /exports/
 

--- a/contrib/system_containers/fedora/Dockerfile
+++ b/contrib/system_containers/fedora/Dockerfile
@@ -17,7 +17,6 @@ RUN dnf install --enablerepo=updates-testing --setopt=tsflags=nodocs -y iptables
     rpm -V iptables cri-o iproute runc && \
     dnf clean all && \
     mkdir -p /exports/hostfs/etc/crio /exports/hostfs/opt/cni/bin/ /exports/hostfs/var/lib/containers/storage/ && \
-    cp /etc/crio/* /exports/hostfs/etc/crio && \
     if test -e /usr/libexec/cni; then cp -Lr /usr/libexec/cni/* /exports/hostfs/opt/cni/bin/; fi
 
 COPY manifest.json tmpfiles.template config.json.template service.template /exports/

--- a/contrib/system_containers/rhel/Dockerfile
+++ b/contrib/system_containers/rhel/Dockerfile
@@ -14,10 +14,8 @@ RUN \
     rpm -V socat iptables cri-o iproute runc skopeo-containers container-selinux && \
     yum clean all && \
     mkdir -p /exports/hostfs/etc/crio /exports/hostfs/opt/cni/bin/ /exports/hostfs/var/lib/containers/storage/ && \
-    cp /etc/crio/* /exports/hostfs/etc/crio && \
+    sed '/^#storage_option =/s/.*/storage_option = [\n\t"overlay.override_kernel_check=1",\n]/' /usr/lib/crio/crio.conf > /exports/hostfs/etc/crio/crio.conf && \
     if test -e /usr/libexec/cni; then cp -Lr /usr/libexec/cni/* /exports/hostfs/opt/cni/bin/; fi
-
-RUN sed -i '/^#storage_option =/s/.*/storage_option = [\n\t"overlay.override_kernel_check=1",\n]/' /exports/hostfs/etc/crio/crio.conf
 
 COPY manifest.json tmpfiles.template config.json.template service.template /exports/
 

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -104,7 +104,7 @@ crio [GLOBAL OPTIONS] config [OPTIONS]
 
 **--selinux**=**true**|**false**: Enable selinux support (default: false)
 
-**--seccomp-profile**="": Path to the seccomp json profile to be used as the runtime's default (default: "/etc/crio/seccomp.json")
+**--seccomp-profile**="": Path to the seccomp json profile to be used as the runtime's default (default: "/usr/lib/crio/seccomp.json")
 
 **--signature-policy**="": Path to the signature policy json file (default: "", to use the system-wide default)
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -10,6 +10,11 @@ The CRI-O configuration file specifies all of the available command-line options
 for the crio(8) program, but in a TOML format that can be more easily modified
 and versioned.
 
+The default location for the crio.conf file is /usr/lib/crio/crio.conf.  You can
+override the contents by copying crio.conf to /etc/crio/crio.conf and making your changes there.
+Tools that read crio.conf will attempt to read /etc/crio/crio.conf if it exists, if not they
+fail over to read /usr/lib/crio/crio.conf.
+
 # FORMAT
 The [TOML format][toml] is used as the encoding of the configuration file.
 Every option and subtable listed here is nested under a global "crio" table.
@@ -97,7 +102,7 @@ Example:
   Path to the signature policy json file (default: "", to use the system-wide default)
 
 **seccomp_profile**=""
-  Path to the seccomp json profile to be used as the runtime's default (default: "/etc/crio/seccomp.json")
+  Path to the seccomp json profile to be used as the runtime's default (default: "/usr/lib/crio/seccomp.json")
 
 **apparmor_profile**=""
   Name of the apparmor profile to be used as the runtime's default (default: "crio-default")

--- a/lib/config.go
+++ b/lib/config.go
@@ -15,7 +15,7 @@ const (
 	pauseImage          = "kubernetes/pause"
 	pauseCommand        = "/pause"
 	defaultTransport    = "docker://"
-	seccompProfilePath  = "/etc/crio/seccomp.json"
+	seccompProfilePath  = "/usr/lib/crio/seccomp.json"
 	apparmorProfileName = "crio-default"
 	cniConfigDir        = "/etc/cni/net.d/"
 	cniBinDir           = "/opt/cni/bin/"

--- a/lib/testdata/config.toml
+++ b/lib/testdata/config.toml
@@ -11,7 +11,7 @@
     conmon = "/usr/local/libexec/crio/conmon"
     conmon_env = ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]
     selinux = true
-    seccomp_profile = "/etc/crio/seccomp.json"
+    seccomp_profile = "/usr/lib/crio/seccomp.json"
     apparmor_profile = "crio-default"
     cgroup_manager = "cgroupfs"
     hooks_dir_path = "/usr/share/containers/oci/hooks.d"

--- a/server/config.go
+++ b/server/config.go
@@ -9,7 +9,10 @@ import (
 )
 
 //CrioConfigPath is the default location for the conf file
-const CrioConfigPath = "/etc/crio/crio.conf"
+const CrioConfigPath = "/usr/lib/crio/crio.conf"
+
+//OverrideCrioConfigPath is the default location for the conf file
+const OverrideCrioConfigPath = "/etc/crio/crio.conf"
 
 // Config represents the entire set of configuration values that can be set for
 // the server. This is intended to be loaded from a toml-encoded config file.


### PR DESCRIPTION
Rather then /etc/crio/crio.conf, this allows users to reset defaults
by removing /etc/crio/crio.conf file.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>