### PR TITLE
Update kpod load to add signature-policy

### DIFF
--- a/cmd/kpod/load.go
+++ b/cmd/kpod/load.go
@@ -21,6 +21,11 @@ var (
 			Name:  "quiet, q",
 			Usage: "Suppress the output",
 		},
+		cli.StringFlag{
+			Name:   "signature-policy",
+			Usage:  "`pathname` of signature policy file (not usually used)",
+			Hidden: true,
+		},
 	}
 	loadDescription = "Loads the image from docker-archive stored on the local machine."
 	loadCommand     = cli.Command{
@@ -39,9 +44,6 @@ func loadCmd(c *cli.Context) error {
 
 	args := c.Args()
 	var image string
-	if len(args) == 1 {
-		image = args[0]
-	}
 	if len(args) > 1 {
 		return errors.New("too many arguments. Requires exactly 1")
 	}
@@ -92,7 +94,7 @@ func loadCmd(c *cli.Context) error {
 	}
 
 	src := libpod.DockerArchive + ":" + input
-	if err := runtime.PullImage(src, false, "", output); err != nil {
+	if err := runtime.PullImage(src, false, c.String("signature-policy"), output); err != nil {
 		src = libpod.OCIArchive + ":" + input
 		// generate full src name with specified image:tag
 		if image != "" {

--- a/completions/bash/kpod
+++ b/completions/bash/kpod
@@ -170,6 +170,7 @@ _kpod_logs() {
 
 _kpod_pull() {
     local options_with_args="
+    --signature-policy
     "
     local boolean_options="
     --all-tags -a
@@ -424,6 +425,7 @@ _complete_() {
 _kpod_load() {
     local options_with_args="
     --input -i
+    --signature-policy
     "
     local boolean_options="
     --quiet -q

--- a/docs/kpod-load.1.md
+++ b/docs/kpod-load.1.md
@@ -31,6 +31,12 @@ Read from archive file, default is STDIN
 **--quiet, -q**
 Suppress the output
 
+**--signature-policy="PATHNAME"**
+
+Pathname of a signature policy file to use.  It is not recommended that this
+option be used, as the default behavior of using the system-wide default policy
+(frequently */etc/containers/policy.json*) is most often preferred
+
 ## EXAMPLES
 
 ```

--- a/docs/kpod-pull.1.md
+++ b/docs/kpod-pull.1.md
@@ -52,6 +52,14 @@ Image stored in local container/storage
 
 **kpod pull NAME[:TAG|@DIGEST]**
 
+## OPTIONS
+
+**--signature-policy="PATHNAME"**
+
+Pathname of a signature policy file to use.  It is not recommended that this
+option be used, as the default behavior of using the system-wide default policy
+(frequently */etc/containers/policy.json*) is most often preferred
+
 ## SEE ALSO
 kpod(1), crio(8), crio.conf(5)
 

--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -160,7 +160,7 @@ func (r *Runtime) PullImage(imgName string, allTags bool, signaturePolicyPath st
 		images = append(images, imgName)
 	}
 
-	policy, err := signature.DefaultPolicy(r.imageContext)
+	policy, err := signature.DefaultPolicy(sc)
 	if err != nil {
 		return err
 	}

--- a/test/kpod_load.bats
+++ b/test/kpod_load.bats
@@ -42,6 +42,21 @@ function teardown() {
 	[ "$status" -eq 0 ]
 }
 
+@test "kpod load oci-archive image with signature-policy" {
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
+	[ "$status" -eq 0 ]
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar --format oci-archive $IMAGE
+	[ "$status" -eq 0 ]
+	run ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
+	[ "$status" -eq 0 ]
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} load --signature-policy ${INTEGRATION_ROOT}/policy.json -i alpine.tar
+	echo "$output"
+	[ "$status" -eq 0 ]
+	rm -f alpine.tar
+	run ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
+	[ "$status" -eq 0 ]
+}
+
 @test "kpod load using quiet flag" {
 	run ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
 	echo "$output"


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat tsweeney@redhat.com

Adds signature-policy to kpod load and adds doc to kpod push and kpod pull.  The default signature policy was always being used, this includes a fix for that.