### PR TITLE
Update kpod load to add signature-policy (2)

### DIFF
--- a/cmd/kpod/load.go
+++ b/cmd/kpod/load.go
@@ -21,6 +21,10 @@ var (
 			Name:  "quiet, q",
 			Usage: "Suppress the output",
 		},
+		cli.StringFlag{
+			Name:  "signature-policy",
+			Usage: "`pathname` of signature policy file (not usually used)",
+		},
 	}
 	loadDescription = "Loads the image from docker-archive stored on the local machine."
 	loadCommand     = cli.Command{
@@ -92,7 +96,7 @@ func loadCmd(c *cli.Context) error {
 	}
 
 	src := libpod.DockerArchive + ":" + input
-	if err := runtime.PullImage(src, false, "", output); err != nil {
+	if err := runtime.PullImage(src, false, c.String("signature-policy"), output); err != nil {
 		src = libpod.OCIArchive + ":" + input
 		// generate full src name with specified image:tag
 		if image != "" {

--- a/cmd/kpod/pull.go
+++ b/cmd/kpod/pull.go
@@ -23,9 +23,8 @@ var (
 			Usage:  "Download all tagged images in the repository",
 		},
 		cli.StringFlag{
-			Name:   "signature-policy",
-			Usage:  "`pathname` of signature policy file (not usually used)",
-			Hidden: true,
+			Name:  "signature-policy",
+			Usage: "`pathname` of signature policy file (not usually used)",
 		},
 	}
 

--- a/completions/bash/kpod
+++ b/completions/bash/kpod
@@ -170,6 +170,7 @@ _kpod_logs() {
 
 _kpod_pull() {
     local options_with_args="
+    --signature-policy
     "
     local boolean_options="
     --all-tags -a
@@ -424,6 +425,7 @@ _complete_() {
 _kpod_load() {
     local options_with_args="
     --input -i
+    --signature-policy
     "
     local boolean_options="
     --quiet -q

--- a/docs/kpod-load.1.md
+++ b/docs/kpod-load.1.md
@@ -31,10 +31,20 @@ Read from archive file, default is STDIN
 **--quiet, -q**
 Suppress the output
 
+**--signature-policy="PATHNAME"**
+
+Pathname of a signature policy file to use.  It is not recommended that this
+option be used, as the default behavior of using the system-wide default policy
+(frequently */etc/containers/policy.json*) is most often preferred
+
 ## EXAMPLES
 
 ```
 # kpod load --quiet -i fedora.tar
+```
+
+```
+# kpod load -q --signature-policy /etc/containers/policy.json -i fedora.tar
 ```
 
 ```

--- a/docs/kpod-pull.1.md
+++ b/docs/kpod-pull.1.md
@@ -52,6 +52,29 @@ Image stored in local container/storage
 
 **kpod pull NAME[:TAG|@DIGEST]**
 
+## OPTIONS
+
+**--signature-policy="PATHNAME"**
+
+Pathname of a signature policy file to use.  It is not recommended that this
+option be used, as the default behavior of using the system-wide default policy
+(frequently */etc/containers/policy.json*) is most often preferred
+
+## EXAMPLES
+
+```
+# kpod pull --signature-policy /etc/containers/policy.json alpine:latest
+Trying to pull registry.access.redhat.com/alpine:latest... Failed
+Trying to pull registry.fedoraproject.org/alpine:latest... Failed
+Trying to pull docker.io/library/alpine:latest...Getting image source signatures
+Copying blob sha256:88286f41530e93dffd4b964e1db22ce4939fffa4a4c665dab8591fbab03d4926
+ 1.90 MB / 1.90 MB [========================================================] 0s
+Copying config sha256:76da55c8019d7a47c347c0dceb7a6591144d232a7dd616242a367b8bed18ecbc
+ 1.48 KB / 1.48 KB [========================================================] 0s
+Writing manifest to image destination
+Storing signatures
+```
+
 ## SEE ALSO
 kpod(1), crio(8), crio.conf(5)
 

--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -160,7 +160,7 @@ func (r *Runtime) PullImage(imgName string, allTags bool, signaturePolicyPath st
 		images = append(images, imgName)
 	}
 
-	policy, err := signature.DefaultPolicy(r.imageContext)
+	policy, err := signature.DefaultPolicy(sc)
 	if err != nil {
 		return err
 	}

--- a/test/kpod_load.bats
+++ b/test/kpod_load.bats
@@ -42,6 +42,23 @@ function teardown() {
 	[ "$status" -eq 0 ]
 }
 
+@test "kpod load oci-archive image with signature-policy" {
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
+	[ "$status" -eq 0 ]
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} save -o alpine.tar --format oci-archive $IMAGE
+	[ "$status" -eq 0 ]
+	run ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
+	[ "$status" -eq 0 ]
+	cp /etc/containers/policy.json /tmp
+	run ${KPOD_BINARY} ${KPOD_OPTIONS} load --signature-policy /tmp/policy.json -i alpine.tar
+	echo "$output"
+	[ "$status" -eq 0 ]
+	rm -f /tmp/policy.json
+	rm -f alpine.tar
+	run ${KPOD_BINARY} $KPOD_OPTIONS rmi $IMAGE
+	[ "$status" -eq 0 ]
+}
+
 @test "kpod load using quiet flag" {
 	run ${KPOD_BINARY} ${KPOD_OPTIONS} pull $IMAGE
 	echo "$output"


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add signature-policy parameter to kpod load and documentation to the kpod load and pull man pages to cover the parameter.  In testing I discovered that only the default location for policy.json was being used, so that's the cause of the change in runtime_image.go.  This is the second PR for these changes.  This PR contains the fixes per @mheon.  I had a weird CLA issue with the first PR, so closed it.