### PR TITLE
oci: Remove useless crio-conmon- cgroup deletion

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -224,11 +224,12 @@ func (r *Runtime) CreateContainer(c *Container, cgroupParent string) (err error)
 		if err != nil {
 			logrus.Warnf("Failed to add conmon to cgroupfs sandbox cgroup: %v", err)
 		} else {
-			// XXX: this defer does nothing as the cgroup can't be deleted cause
-			// it contains the conmon pid in tasks
-			// we need to remove this defer and delete the cgroup once conmon exits
-			// maybe need a conmon monitor?
-			defer control.Delete()
+			// Here we should defer a crio-connmon- cgroup hierarchy deletion, but it will
+			// always fail as conmon's pid is still there.
+			// Fortunately, kubelet takes care of deleting this for us, so the leak will
+			// only happens in corner case where one does a manual deletion of the container
+			// through e.g. runc. This should be handled by implementing a conmon monitoring
+			// routine that does the cgroup cleanup once conmon is terminated.
 			if err := control.Add(cgroups.Process{Pid: cmd.Process.Pid}); err != nil {
 				logrus.Warnf("Failed to add conmon to cgroupfs sandbox cgroup: %v", err)
 			}


### PR DESCRIPTION
It always fails because conmon is still there.
But more importantly it adds a 2 seconds delay to the container
creation as we're trying to delete a cgroup but we can't.

With this patch a container creation is down to typically less than
150ms instead of 2+ seconds.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>