### PR TITLE
oci: kill all processes in a container not just the main one

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -553,7 +553,7 @@ func (r *Runtime) StopContainer(c *Container, timeout int64) error {
 		return nil
 	}
 
-	if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, r.Path(c), "kill", c.id, c.GetStopSignal()); err != nil {
+	if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, r.Path(c), "kill", "--all", c.id, c.GetStopSignal()); err != nil {
 		return fmt.Errorf("failed to stop container %s, %v", c.id, err)
 	}
 	if timeout == -1 {


### PR DESCRIPTION
Needed in v1.0.0

runc must kill all processes in a container or we may get something like (during stress testing):
```
TERM failed: exit status 1
```

@mrunalp @rhatdan PTAL (cri-containerd is also behaving like this)

Signed-off-by: Antonio Murdaca <runcom@redhat.com>