### PR TITLE
CI: use a fixed runc version, not master

### DIFF
--- a/contrib/test/integration/build/runc.yml
+++ b/contrib/test/integration/build/runc.yml
@@ -4,6 +4,7 @@
   git:
     repo: "https://github.com/opencontainers/runc.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/opencontainers/runc"
+    version: "84a082bfef6f932de921437815355186db37aeb1"
 
 - name: build runc
   make:


### PR DESCRIPTION
CI broke cause we're using runc from master - https://github.com/kubernetes-incubator/cri-o/pull/1014#issuecomment-336870378

Let's get this to how it was before the CI refactor by using the same runc commit we have in the Dockerfile

@rhatdan @mrunalp PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>