### PR TITLE
server/sandbox_list.go: No error on filtered list find by ID

### DIFF
--- a/server/sandbox_list.go
+++ b/server/sandbox_list.go
@@ -42,7 +42,11 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxReque
 		if filter.Id != "" {
 			id, err := s.PodIDIndex().Get(filter.Id)
 			if err != nil {
-				return nil, err
+				// Not finding an ID in a filtered list should not be considered
+				// and error; it might have been deleted when stop was done.
+				// Log and return an empty struct.
+				logrus.Warn("unable to find pod %s with filter", filter.Id)
+				return &pb.ListPodSandboxResponse{}, nil
 			}
 			sb := s.getSandbox(id)
 			if sb == nil {


### PR DESCRIPTION
We should not error when we try to find a pod ID in a filtered
list of sandboxes; instead we should return an empty struct
and log it.

This fixes another cri-test failure.

Signed-off-by: baude <bbaude@redhat.com>