### PR TITLE
version: fix version handling and kube info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
 BUILD_INFO := $(shell date +%s)
 
-VERSION := ${shell cat ./VERSION}
 KPOD_VERSION := ${shell cat ./KPOD_VERSION}
 
 # If GOPATH not specified, use one in the local directory
@@ -36,7 +35,7 @@ GOPKGBASEDIR := $(shell dirname "$(GOPKGDIR)")
 # Update VPATH so make finds .gopathok
 VPATH := $(VPATH):$(GOPATH)
 
-LDFLAGS := -ldflags '-X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${BUILD_INFO} -X main.version=${VERSION} -X main.kpodVersion=${KPOD_VERSION}'
+LDFLAGS := -ldflags '-X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${BUILD_INFO} -X main.kpodVersion=${KPOD_VERSION}'
 
 all: binaries crio.conf docs
 

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/kubernetes-incubator/cri-o/libkpod"
 	"github.com/kubernetes-incubator/cri-o/server"
+	"github.com/kubernetes-incubator/cri-o/version"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/sirupsen/logrus"
 	"github.com/soheilhy/cmux"
@@ -22,10 +23,6 @@ import (
 	"google.golang.org/grpc"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
-
-// This is populated by the Makefile from the VERSION file
-// in the repository
-var version = ""
 
 // gitCommit is the commit that the binary is being built from.
 // It will be populated by the Makefile.
@@ -182,9 +179,7 @@ func main() {
 	app := cli.NewApp()
 
 	var v []string
-	if version != "" {
-		v = append(v, version)
-	}
+	v = append(v, version.Version)
 	if gitCommit != "" {
 		v = append(v, fmt.Sprintf("commit: %s", gitCommit))
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -35,8 +35,7 @@ import (
 )
 
 const (
-	runtimeAPIVersion = "v1alpha1"
-	shutdownFile      = "/var/lib/crio/crio.shutdown"
+	shutdownFile = "/var/lib/crio/crio.shutdown"
 )
 
 func isTrue(annotaton string) bool {

--- a/server/version.go
+++ b/server/version.go
@@ -1,29 +1,27 @@
 package server
 
 import (
+	"github.com/kubernetes-incubator/cri-o/version"
 	"golang.org/x/net/context"
 	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
 
+const (
+	// kubeAPIVersion is the api version of kubernetes.
+	// TODO: Track upstream code. For now it expects 0.1.0
+	kubeAPIVersion = "0.1.0"
+	// containerName is the name prepended in kubectl describe->Container ID:
+	// cri-o://<CONTAINER_ID>
+	containerName     = "cri-o"
+	runtimeAPIVersion = "v1alpha1"
+)
+
 // Version returns the runtime name, runtime version and runtime API version
 func (s *Server) Version(ctx context.Context, req *pb.VersionRequest) (*pb.VersionResponse, error) {
-
-	runtimeVersion, err := s.Runtime().Version()
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: Track upstream code. For now it expects 0.1.0
-	version := "0.1.0"
-
-	// taking const address
-	rav := runtimeAPIVersion
-	runtimeName := s.Runtime().Name()
-
 	return &pb.VersionResponse{
-		Version:           version,
-		RuntimeName:       runtimeName,
-		RuntimeVersion:    runtimeVersion,
-		RuntimeApiVersion: rav,
+		Version:           kubeAPIVersion,
+		RuntimeName:       containerName,
+		RuntimeVersion:    version.Version,
+		RuntimeApiVersion: runtimeAPIVersion,
 	}, nil
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version is the version of the build.
+const Version = "1.8.0-dev"


### PR DESCRIPTION
Version handling with a VERSION file isn't really flexible as we can't actually use the version anywhere else in Go code.
This patch switches the crio version to use a new pkg called `version` (you guys can move kpod_version to this later).

This patch is also fixing some stuff with the version CRI api call. We used to return container names as `runc://<CONTAINER_ID>` whether we must have returned `cri-o://<CONTAINER_ID>` (so this patch fixes this as well).

@mrunalp PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>