### PR TITLE
Issue #1024: don't chmod a nonexistent file

### DIFF
--- a/test/network.bats
+++ b/test/network.bats
@@ -171,11 +171,11 @@ function teardown() {
 
 	# make conmon non-executable to cause the sandbox setup to fail after
 	# networking has been configured
-	chmod 0644 /go/src/github.com/kubernetes-incubator/cri-o/conmon/conmon
+	chmod 0644 $CONMON_BINARY
 	run crioctl pod run --config "$TESTDATA"/sandbox_config.json
+	chmod 0755 $CONMON_BINARY
 	echo "$output"
 	[ "$status" -ne 0 ]
-	chmod 0755 /go/src/github.com/kubernetes-incubator/cri-o/conmon/conmon
 
 	# ensure that the server cleaned up sandbox networking if the sandbox
 	# failed after network setup

--- a/test/network.bats
+++ b/test/network.bats
@@ -7,6 +7,7 @@ function teardown() {
 	cleanup_pods
 	stop_crio
 	rm -f /var/lib/cni/networks/crionet_test_args/*
+	chmod 0755 $CONMON_BINARY
 	cleanup_test
 }
 


### PR DESCRIPTION
New network test makes improper assumptions about conmon path.
Use predefined CONMON_BINARY variable instead. And, restore
permissions earlier so a test failure doesn't result in a broken system.

Signed-off-by: Ed Santiago <santiago@redhat.com>