### PR TITLE
Fixed logic flaw in the secrets mounts

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -393,7 +393,6 @@ func addSecretsBindMounts(mountLabel, ctrRunDir string, defaultMounts []string, 
 	}
 	for _, m := range mounts {
 		specgen.AddBindMount(m.Source, m.Destination, nil)
-
 	}
 	return nil
 }

--- a/server/secrets.go
+++ b/server/secrets.go
@@ -113,18 +113,18 @@ func secretMounts(defaultMountsPaths []string, mountLabel, containerWorkingDir s
 			continue
 		}
 
-		ctrDir = filepath.Join(containerWorkingDir, ctrDir)
+		ctrDirOnHost := filepath.Join(containerWorkingDir, ctrDir)
 		// skip if ctrDir has already been mounted by caller
 		if isAlreadyMounted(runtimeMounts, ctrDir) {
 			logrus.Warnf("%q has already been mounted; cannot override mount", ctrDir)
 			continue
 		}
 
-		if err := os.RemoveAll(ctrDir); err != nil {
+		if err := os.RemoveAll(ctrDirOnHost); err != nil {
 			return nil, fmt.Errorf("remove container directory failed: %v", err)
 		}
 
-		if err := os.MkdirAll(ctrDir, 0755); err != nil {
+		if err := os.MkdirAll(ctrDirOnHost, 0755); err != nil {
 			return nil, fmt.Errorf("making container directory failed: %v", err)
 		}
 
@@ -138,12 +138,12 @@ func secretMounts(defaultMountsPaths []string, mountLabel, containerWorkingDir s
 			return nil, errors.Wrapf(err, "getting host secret data failed")
 		}
 		for _, s := range data {
-			s.SaveTo(ctrDir)
+			s.SaveTo(ctrDirOnHost)
 		}
-		label.Relabel(ctrDir, mountLabel, false)
+		label.Relabel(ctrDirOnHost, mountLabel, false)
 
 		m := rspec.Mount{
-			Source:      hostDir,
+			Source:      ctrDirOnHost,
 			Destination: ctrDir,
 		}
 

--- a/test/crio_secrets.bats
+++ b/test/crio_secrets.bats
@@ -24,7 +24,7 @@ function teardown() {
     echo "$output"
     [ "$status" -eq 0 ]
     mount_info="$output"
-    grep $ctr_id/userdata/container/path1 <<< "$mount_info"
+    grep /container/path1 <<< "$mount_info"
     echo "$output"
     [ "$status" -eq 0 ]
     rm -rf MOUNT_PATH


### PR DESCRIPTION
Tested on a REHL box and found out that the mounts were not showing up
Had a logic flaw, where if the mount was "host:container"
Was setting the mount source to "host" and destination to "ctrRunDir/container"
When instead, the mount source should be "ctrRunDir/container" and destination "container"
with the data copied from "host" to "ctrRunDir/container"

Signed-off-by: umohnani8 <umohnani@redhat.com>