### PR TITLE
[release-1.0] Fix process exec v1

### DIFF
--- a/libkpod/container_server.go
+++ b/libkpod/container_server.go
@@ -388,6 +388,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	if err != nil {
 		return err
 	}
+	scontainer.SetSpec(&m)
 	scontainer.SetMountPoint(m.Annotations[annotations.MountPoint])
 
 	if m.Annotations[annotations.Volumes] != "" {
@@ -511,6 +512,7 @@ func (c *ContainerServer) LoadContainer(id string) error {
 	if err != nil {
 		return err
 	}
+	ctr.SetSpec(&m)
 	ctr.SetMountPoint(m.Annotations[annotations.MountPoint])
 
 	c.ContainerStateFromDisk(ctr)

--- a/oci/container.go
+++ b/oci/container.go
@@ -48,6 +48,7 @@ type Container struct {
 	imageRef   string
 	volumes    []ContainerVolume
 	mountPoint string
+	spec       *specs.Spec
 }
 
 // ContainerVolume is a bind mount for the container.
@@ -97,6 +98,16 @@ func NewContainer(id string, name string, bundlePath string, logPath string, net
 		opLock:          new(sync.Mutex),
 	}
 	return c, nil
+}
+
+// SetSpec loads the OCI spec in the container struct
+func (c *Container) SetSpec(s *specs.Spec) {
+	c.spec = s
+}
+
+// Spec returns a copy of the spec for the container
+func (c *Container) Spec() specs.Spec {
+	return *c.spec
 }
 
 // GetStopSignal returns the container's own stop signal configured from the

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -435,11 +435,9 @@ func (r *Runtime) ExecSync(c *Container, command []string, timeout int64) (resp 
 	}
 	args = append(args, "-l", logPath)
 
-	pspec := rspec.Process{
-		Env:  r.conmonEnv,
-		Args: command,
-		Cwd:  "/",
-	}
+	pspec := c.Spec().Process
+	pspec.Env = append(pspec.Env, r.conmonEnv...)
+	pspec.Args = command
 	processJSON, err := json.Marshal(pspec)
 	if err != nil {
 		return nil, ExecSyncError{

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1032,6 +1032,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	if err != nil {
 		return nil, err
 	}
+	container.SetSpec(specgen.Spec())
 	container.SetMountPoint(mountPoint)
 
 	for _, cv := range containerVolumes {

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -492,6 +492,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	if err != nil {
 		return nil, err
 	}
+	container.SetSpec(g.Spec())
 	container.SetMountPoint(mountPoint)
 
 	sb.SetInfraContainer(container)


### PR DESCRIPTION
This patch fixes exec to use the original (start-time) process exec
configuration. Otherwise, we were creating a brand new spec process w/o
additional groups for instance.
Spotted while integrating CRI-O with cri-test...The test was failing
with:
```
• Failure [10.640 seconds]
[k8s.io] Security Context
/home/amurdaca/go/src/github.com/kubernetes-incubator/cri-tools/pkg/framework/framework.go:72
  bucket
  /home/amurdaca/go/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/security_context.go:407
    runtime should support SupplementalGroups [It]
    /home/amurdaca/go/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/security_context.go:272

    Expected
        <[]string | len:1, cap:1>: ["0"]
    to contain element matching
        <string>: 1234
```

Signed-off-by: Antonio Murdaca <runcom@redhat.com>