### PR TITLE
We need to release the SELinux label when we destroy the sandbox

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -10,7 +10,7 @@ github.com/ostreedev/ostree-go master
 github.com/containers/storage 64bf27465d0d1edd89e7a4ce49866fea01145782
 github.com/containernetworking/cni v0.4.0
 google.golang.org/grpc v1.0.4 https://github.com/grpc/grpc-go
-github.com/opencontainers/selinux v1.0.0-rc1
+github.com/opencontainers/selinux b29023b86e4a69d1b46b7e7b4e2b6fda03f0b9cd
 github.com/opencontainers/go-digest v1.0.0-rc0
 github.com/opencontainers/runtime-tools d3f7e9e9e631c7e87552d67dc7c86de33c3fb68a
 github.com/opencontainers/runc 45bde006ca8c90e089894508708bcf0e2cdf9e13

--- a/vendor/github.com/opencontainers/selinux/go-selinux/label/label_selinux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/label/label_selinux.go
@@ -49,8 +49,10 @@ func InitLabels(options []string) (string, string, error) {
 				mcon[con[0]] = con[1]
 			}
 		}
+		_ = ReleaseLabel(processLabel)
 		processLabel = pcon.Get()
 		mountLabel = mcon.Get()
+		_ = ReserveLabel(processLabel)
 	}
 	return processLabel, mountLabel, nil
 }

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux.go
@@ -213,7 +213,7 @@ func SetFileLabel(path string, label string) error {
 	return lsetxattr(path, xattrNameSelinux, []byte(label), 0)
 }
 
-// Filecon returns the SELinux label for this path or returns an error.
+// FileLabel returns the SELinux label for this path or returns an error.
 func FileLabel(path string) (string, error) {
 	label, err := lgetxattr(path, xattrNameSelinux)
 	if err != nil {
@@ -331,7 +331,7 @@ func EnforceMode() int {
 }
 
 /*
-SetEnforce sets the current SELinux mode Enforcing, Permissive.
+SetEnforceMode sets the current SELinux mode Enforcing, Permissive.
 Disabled is not valid, since this needs to be set at boot time.
 */
 func SetEnforceMode(mode int) error {


### PR DESCRIPTION
This will release the MCS Label to be used again.  Only do this if we
don't have another sandbox using the same label.

Also vendor in the latest selinux go bindings, which fixes a leak and
properly reserves the SELinux label we are going to use.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>