### PR TITLE
Make attach sockets directory an argument in Conmon

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -96,6 +96,8 @@ static inline void strv_cleanup(char ***strv)
 #define CMD_SIZE 1024
 #define MAX_EVENTS 10
 
+#define DEFAULT_SOCKET_PATH "/var/lib/crio"
+
 static bool opt_terminal = false;
 static bool opt_stdin = false;
 static char *opt_cid = NULL;
@@ -111,7 +113,7 @@ static char *opt_log_path = NULL;
 static char *opt_exit_dir = NULL;
 static int opt_timeout = 0;
 static int64_t opt_log_size_max = -1;
-static char *opt_socket_path = NULL;
+static char *opt_socket_path = DEFAULT_SOCKET_PATH;
 static GOptionEntry opt_entries[] =
 {
   { "terminal", 't', 0, G_OPTION_ARG_NONE, &opt_terminal, "Terminal", NULL },
@@ -1158,9 +1160,6 @@ int main(int argc, char *argv[])
 
 	if (opt_log_path == NULL)
 		nexit("Log file path not provided. Use --log-path");
-
-	if (opt_socket_path == NULL)
-		nexit("Socket path not provided. Use --socket-path");
 
 	start_pipe_fd = get_pipe_fd_from_env("_OCI_STARTPIPE");
 	if (start_pipe_fd >= 0) {

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -131,7 +131,7 @@ static GOptionEntry opt_entries[] =
   { "log-path", 'l', 0, G_OPTION_ARG_STRING, &opt_log_path, "Log file path", NULL },
   { "timeout", 'T', 0, G_OPTION_ARG_INT, &opt_timeout, "Timeout in seconds", NULL },
   { "log-size-max", 0, 0, G_OPTION_ARG_INT64, &opt_log_size_max, "Maximum size of log file", NULL },
-  { "socket-path", 0, 0, G_OPTION_ARG_STRING, &opt_socket_path, "Location of container attach sockets", NULL },
+  { "socket-dir-path", 0, 0, G_OPTION_ARG_STRING, &opt_socket_path, "Location of container attach sockets", NULL },
   { NULL }
 };
 

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -179,7 +179,7 @@ func (r *Runtime) CreateContainer(c *Container, cgroupParent string) (err error)
 	args = append(args, "-p", filepath.Join(c.bundlePath, "pidfile"))
 	args = append(args, "-l", c.logPath)
 	args = append(args, "--exit-dir", r.containerExitsDir)
-	args = append(args, "--socket-path", ContainerAttachSocketDir)
+	args = append(args, "--socket-dir-path", ContainerAttachSocketDir)
 	if r.logSizeMax >= 0 {
 		args = append(args, "--log-size-max", fmt.Sprintf("%v", r.logSizeMax))
 	}
@@ -437,7 +437,7 @@ func (r *Runtime) ExecSync(c *Container, command []string, timeout int64) (resp 
 		args = append(args, fmt.Sprintf("%d", timeout))
 	}
 	args = append(args, "-l", logPath)
-	args = append(args, "--socket-path", ContainerAttachSocketDir)
+	args = append(args, "--socket-dir-path", ContainerAttachSocketDir)
 
 	pspec := rspec.Process{
 		Env:  r.conmonEnv,

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -40,6 +40,8 @@ const (
 	SystemdCgroupsManager = "systemd"
 	// ContainerExitsDir is the location of container exit dirs
 	ContainerExitsDir = "/var/run/crio/exits"
+	// ContainerAttachSocketDir is the location for container attach sockets
+	ContainerAttachSocketDir = "/var/run/crio"
 
 	// killContainerTimeout is the timeout that we wait for the container to
 	// be SIGKILLed.
@@ -177,6 +179,7 @@ func (r *Runtime) CreateContainer(c *Container, cgroupParent string) (err error)
 	args = append(args, "-p", filepath.Join(c.bundlePath, "pidfile"))
 	args = append(args, "-l", c.logPath)
 	args = append(args, "--exit-dir", r.containerExitsDir)
+	args = append(args, "--socket-path", ContainerAttachSocketDir)
 	if r.logSizeMax >= 0 {
 		args = append(args, "--log-size-max", fmt.Sprintf("%v", r.logSizeMax))
 	}
@@ -434,6 +437,7 @@ func (r *Runtime) ExecSync(c *Container, command []string, timeout int64) (resp 
 		args = append(args, fmt.Sprintf("%d", timeout))
 	}
 	args = append(args, "-l", logPath)
+	args = append(args, "--socket-path", ContainerAttachSocketDir)
 
 	pspec := rspec.Process{
 		Env:  r.conmonEnv,

--- a/server/container_attach.go
+++ b/server/container_attach.go
@@ -67,7 +67,7 @@ func (ss streamService) Attach(containerID string, inputStream io.Reader, output
 		}
 	})
 
-	attachSocketPath := filepath.Join("/var/run/crio", c.ID(), "attach")
+	attachSocketPath := filepath.Join(oci.ContainerAttachSocketDir, c.ID(), "attach")
 	conn, err := net.DialUnix("unixpacket", nil, &net.UnixAddr{Name: attachSocketPath, Net: "unixpacket"})
 	if err != nil {
 		return fmt.Errorf("failed to connect to container %s attach socket: %v", c.ID(), err)


### PR DESCRIPTION
Convert a constant in `conmon` into an argument. This removes a few unexplained instances of `/var/run/crio` in the code and replaces them with a single constant in the oci package that is passed through to conmon.

This is necessary for some of the work ongoing in libpod.