### PR TITLE
fixes runc install path on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN set -x \
 	&& git fetch origin --tags \
 	&& git checkout -q "$RUNC_COMMIT" \
 	&& make static BUILDTAGS="seccomp selinux" \
-	&& cp runc /usr/local/bin/runc \
+	&& cp runc /usr/bin/runc \
 	&& rm -rf "$GOPATH"
 
 # Install CNI plugins


### PR DESCRIPTION
In the config file (/etc/crio/crio.conf) installed by `make install.config` , runc runtime path is specified "/usr/bin/runc"