### PR TITLE
Revert Revert "Idempotent Swapping"

### DIFF
--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -52,7 +52,18 @@
 - name: disable SELinux
   command: setenforce 0
 
-- name: run e2e tests
-  shell: "{{ e2e_shell_cmd | regex_replace('\\s+', ' ') }}"
-  args:
-    chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
+- block:
+
+    - name: Disable swap during e2e tests
+      command: 'swapoff -a'
+      when: not e2e_swap_enabled
+
+    - name: run e2e tests
+      shell: "{{ e2e_shell_cmd | regex_replace('\\s+', ' ') }}"
+      args:
+        chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
+
+  always:
+
+    - name: Re-enable swap after e2e tests
+      command: 'swapon -a'

--- a/contrib/test/integration/swap.yml
+++ b/contrib/test/integration/swap.yml
@@ -1,0 +1,42 @@
+---
+
+- name: Obtain current state of swap
+  command: swapon --noheadings --show=NAME
+  register: swapon
+
+- name: Setup swap if none already, to prevent kernel firing off the OOM killer
+  block:
+
+    - name: A unique swapfile path is generated
+      command: mktemp --tmpdir=/root swapfile_XXX
+      register: swapfilepath
+
+    - name: Swap file path is buffered
+      set_fact:
+        swapfilepath: '{{ swapfilepath.stdout | trim }}'
+
+    - name: Set swap file permissions
+      file:
+        path: "{{ swapfilepath }}"
+        owner: root
+        group: root
+        mode: 0600
+
+    - name: Swapfile padded to swapfile_size & timed to help debug any performance problems
+      shell: 'time dd if=/dev/zero of={{ swapfilepath }} bs={{ swapfileGB }}M count=1024'
+
+    - name: Swap file is formatted
+      command: 'mkswap {{ swapfilepath }}'
+
+    - name: Write swap entry in fstab
+      mount:
+        path: none
+        src: "{{ swapfilepath }}"
+        fstype: swap
+        opts: sw
+        state: present
+
+    - name: Mount swap
+      command: "swapon -a"
+
+  when: not (swapon.stdout_lines | length)

--- a/contrib/test/integration/system.yml
+++ b/contrib/test/integration/system.yml
@@ -89,13 +89,8 @@
   async: 600
   poll: 10
 
-- name: Setup swap to prevent kernel firing off the OOM killer
-  shell: |
-    truncate -s 8G /root/swap && \
-    export SWAPDEV=$(losetup --show -f /root/swap | head -1) && \
-    mkswap $SWAPDEV && \
-    swapon $SWAPDEV && \
-    swapon --show
+- name: Check / setup swap
+  include: "swap.yml"
 
 - name: ensure directories exist as needed
   file:

--- a/contrib/test/integration/test.yml
+++ b/contrib/test/integration/test.yml
@@ -17,9 +17,20 @@
     path: "{{ artifacts }}"
     state: directory
 
-- name: run integration tests
-  shell: "CGROUP_MANAGER=cgroupfs STORAGE_OPTIONS='--storage-driver=overlay{{ extra_storage_opts | default('') }}' make localintegration >& {{ artifacts }}/testout.txt"
-  args:
-    chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o"
-  async: 5400
-  poll: 30
+- block:
+
+    - name: Disable swap during integration tests
+      command: 'swapoff -a'
+      when: not integration_swap_enabled
+
+    - name: run integration tests
+      shell: "CGROUP_MANAGER=cgroupfs STORAGE_OPTIONS='--storage-driver=overlay{{ extra_storage_opts | default('') }}' make localintegration >& {{ artifacts }}/testout.txt"
+      args:
+        chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o"
+      async: 5400
+      poll: 30
+
+  always:
+
+    - name: Re-enable swap after integration tests
+      command: 'swapon -a'

--- a/contrib/test/integration/vars.yml
+++ b/contrib/test/integration/vars.yml
@@ -1,5 +1,13 @@
 ---
 
+# When swap setup is necessary, make it this size
+swapfileGB: 8
+
+# When False, turn off all swapping on the system only during
+# particular tests.
+integration_swap_enabled: False
+e2e_swap_enabled: True
+
 # For results.yml Paths use rsync 'source' conventions
 artifacts: "/tmp/artifacts"  # Base-directory for collection
 crio_integration_filepath: "{{ artifacts }}/testout.txt"


### PR DESCRIPTION
This puts back the better qualified Idempotent Swapping, but
adds two variables which control whether or not swapping is
enabled during testing.  This addresses a short-term issue of
occasionally failing integration tests under some scenarios,
but not others.

The integration OOM-test isn't properly failing because
the cgroup memory control doesn't account for swap usage
(by design) in ``limit_in_bytes``.

Fixing this for the long-term requires repairing the
test to also set ``memory.memsw.limit_in_bytes=0``
(in addition to memory.limit_in_bytes=5m).

N/B: Normally these things are passed down from k8s,
which is why the same fix isn't currently needed
for the e2e tests - hence the new variable is ``True`` by
default.

Signed-off-by: Chris Evich <cevich@redhat.com>