### PR TITLE
Add ability to enable/disable SELinux during tests

### DIFF
--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -63,12 +63,20 @@
             &> {{ artifacts }}/e2e.log
   # Fix vim syntax hilighting: "
 
-- name: disable SELinux
-  command: setenforce 0
+- block:
 
-- name: run e2e tests
-  shell: "{{ e2e_shell_cmd | regex_replace('\\s+', ' ') }}"
-  args:
-    chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
-  async: '{{ 60 * 60 * 4 }}'  # seconds
-  poll: 60
+    - name: Disable selinux during e2e tests
+      command: 'setenforce 0'
+      when: not e2e_selinux_enabled
+
+    - name: run e2e tests
+      shell: "{{ e2e_shell_cmd | regex_replace('\\s+', ' ') }}"
+      args:
+        chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
+      async: '{{ 60 * 60 * 4 }}'  # seconds
+      poll: 60
+
+  always:
+
+    - name: Re-enable SELinux after e2e tests
+      command: 'setenforce 1'

--- a/contrib/test/integration/node-e2e.yml
+++ b/contrib/test/integration/node-e2e.yml
@@ -13,14 +13,25 @@
 - name: Flush the iptables
   command: iptables -F
 
-- name: run node-e2e tests
-  shell: |
-    # parametrize crio socket
-    # cgroup-driver???
-    # TODO(runcom): remove conformance focus, we want everything for testgrid
-    make test-e2e-node PARALLELISM=1 RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/crio.sock IMAGE_SERVICE_ENDPOINT=/var/run/crio/crio.sock TEST_ARGS='--prepull-images=true --kubelet-flags="--cgroup-driver=systemd"' FOCUS="\[Conformance\]" &> {{ artifacts }}/node-e2e.log
-  args:
-    chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
-  async: '{{ 60 * 60 * 2 }}'  # seconds
-  poll: 60
-  ignore_errors: true
+- block:
+
+    - name: Disable selinux during node-e2e tests
+      command: 'setenforce 0'
+      when: not node_e2e_selinux_enabled
+
+    - name: run node-e2e tests
+      shell: |
+        # parametrize crio socket
+        # cgroup-driver???
+        # TODO(runcom): remove conformance focus, we want everything for testgrid
+        make test-e2e-node PARALLELISM=1 RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/crio.sock IMAGE_SERVICE_ENDPOINT=/var/run/crio/crio.sock TEST_ARGS='--prepull-images=true --kubelet-flags="--cgroup-driver=systemd"' FOCUS="\[Conformance\]" &> {{ artifacts }}/node-e2e.log
+      args:
+        chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
+      async: '{{ 60 * 60 * 2 }}'  # seconds
+      poll: 60
+      ignore_errors: true
+
+  always:
+
+    - name: Re-enable SELinux after node-e2e tests
+      command: 'setenforce 1'

--- a/contrib/test/integration/test.yml
+++ b/contrib/test/integration/test.yml
@@ -17,9 +17,20 @@
     path: "{{ artifacts }}"
     state: directory
 
-- name: run integration tests
-  shell: "CGROUP_MANAGER=cgroupfs STORAGE_OPTIONS='--storage-driver=overlay{{ extra_storage_opts | default('') }}' make localintegration >& {{ artifacts }}/testout.txt"
-  args:
-    chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o"
-  async: '{{ 60 * 30 }}'  # seconds
-  poll: 30
+- block:
+
+    - name: Disable selinux during integration tests
+      command: 'setenforce 0'
+      when: not integration_selinux_enabled
+
+    - name: run integration tests
+      shell: "CGROUP_MANAGER=cgroupfs STORAGE_OPTIONS='--storage-driver=overlay{{ extra_storage_opts | default('') }}' make localintegration >& {{ artifacts }}/testout.txt"
+      args:
+        chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o"
+      async: '{{ 60 * 30 }}'  # seconds
+      poll: 30
+
+  always:
+
+    - name: Re-enable SELinux after integration tests
+      command: 'setenforce 1'

--- a/contrib/test/integration/vars.yml
+++ b/contrib/test/integration/vars.yml
@@ -1,5 +1,10 @@
 ---
 
+# When False, disable SELinux on the system during specific tests
+integration_selinux_enabled: True
+e2e_selinux_enabled: False
+node_e2e_selinux_enabled: False
+
 # For results.yml Paths use rsync 'source' conventions
 artifacts: "/tmp/artifacts"  # Base-directory for collection
 crio_integration_filepath: "{{ artifacts }}/testout.txt"


### PR DESCRIPTION

**- What I did**
Add a boolean variables that control whether or not SELinux is enabled during particular tests.

**- How I did it**
Used the Ansible ``block`` construct to group the SELinux-permissive task along with the test-task.  Utilized the ``always`` clause of the block to ensure SELinux-enforcing happens no matter what.

**- How to verify it**
Execute all CI tests.  This change preserves existing behaviors.  In other PRs, as needed,  change ``vars.yml`` variables as to see what breaks:

```
# When False, disable SELinux on the system during specific tests
integration_selinux_enabled: True
e2e_selinux_enabled: True
node_e2e_selinux_enabled: True
```