### PR TITLE
libpod: set the default Store to match a Runtime

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -3,6 +3,7 @@ package libpod
 import (
 	"sync"
 
+	is "github.com/containers/image/storage"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
 	"github.com/kubernetes-incubator/cri-o/server/apparmor"
@@ -80,6 +81,7 @@ func NewRuntime(options ...RuntimeOption) (*Runtime, error) {
 		return nil, err
 	}
 	runtime.store = store
+	is.Transport.SetStore(store)
 
 	// Set up containers/image
 	runtime.imageContext = &types.SystemContext{

--- a/test/kpod_push.bats
+++ b/test/kpod_push.bats
@@ -12,7 +12,7 @@ function teardown() {
     run ${KPOD_BINARY} $KPOD_OPTIONS pull "$IMAGE"
     echo "$output"
     [ "$status" -eq 0 ]
-    run ${KPOD_BINARY} $KPOD_OPTIONS push "$IMAGE" containers-storage:[${TESTDIR}/crio]busybox:test
+    run ${KPOD_BINARY} $KPOD_OPTIONS push "$IMAGE" containers-storage:busybox:test
     echo "$output"
     [ "$status" -eq 0 ]
     run ${KPOD_BINARY} $KPOD_OPTIONS rmi "$IMAGE" busybox:test


### PR DESCRIPTION
When initializing a Runtime, set the default Store for the containers-storage transport in the image library to the same one that we're using, so that the calling process sees the same set of images
in the Runtime that it sees when going through the image library.

Update the `kpod_push` test so that it no longer has to specify a location in the destination image reference, since the default should already be passed to kpod as global options.