### PR TITLE
server: correctly return and close ch from exits routine

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -418,6 +418,7 @@ func (s *Server) StartExitMonitor() {
 	}()
 	if err := watcher.Add(s.config.ContainerExitsDir); err != nil {
 		logrus.Errorf("watcher.Add(%q) failed: %s", s.config.ContainerExitsDir, err)
+		close(done)
 	}
 	<-done
 }


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>