### PR TITLE
add golang-github-cpuguy83-go-md2man dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ yum install -y \
   glibc-devel \
   glibc-static \
   go \
+  golang-github-cpuguy83-go-md2man \
   gpgme-devel \
   libassuan-devel \
   libgpg-error-devel \


### PR DESCRIPTION
On CentOS, I needed this for `make` build step to complete