### PR TITLE
cmd: crio: set ReadTimeout on the info endpoint

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/kubernetes-incubator/cri-o/libkpod"
@@ -470,7 +471,8 @@ func main() {
 
 		infoMux := service.GetInfoMux()
 		srv := &http.Server{
-			Handler: infoMux,
+			Handler:     infoMux,
+			ReadTimeout: 5 * time.Second,
 		}
 
 		graceful := false


### PR DESCRIPTION
This will avoid the goroutines leak we've been seeing during
performance tests. Goroutines count returns to normal after containers
cleanup.

This is actually a better fix than #1082 as we're not changing the socket for the info endpoint but that's still something to consider for 1.8/1.9.

@mrunalp PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>