### PR TITLE
Various test-scaffolding fixes

### DIFF
--- a/test/ctr_seccomp.bats
+++ b/test/ctr_seccomp.bats
@@ -15,7 +15,7 @@ function teardown() {
 		skip "skip this test since seccomp is not enabled."
 	fi
 
-	sed -e 's/"chmod",//' "$CRIO_ROOT"/cri-o/seccomp.json > "$TESTDIR"/seccomp_profile1.json
+	sed -e 's/"chmod",//' "$SECCOMP_PROFILE" > "$TESTDIR"/seccomp_profile1.json
 	sed -i 's/"fchmod",//' "$TESTDIR"/seccomp_profile1.json
 	sed -i 's/"fchmodat",//g' "$TESTDIR"/seccomp_profile1.json
 
@@ -51,7 +51,7 @@ function teardown() {
 		skip "skip this test since seccomp is not enabled."
 	fi
 
-	sed -e 's/"chmod",//' "$CRIO_ROOT"/cri-o/seccomp.json > "$TESTDIR"/seccomp_profile1.json
+	sed -e 's/"chmod",//' "$SECCOMP_PROFILE" > "$TESTDIR"/seccomp_profile1.json
 	sed -i 's/"fchmod",//' "$TESTDIR"/seccomp_profile1.json
 	sed -i 's/"fchmodat",//g' "$TESTDIR"/seccomp_profile1.json
 
@@ -89,7 +89,7 @@ function teardown() {
 		skip "skip this test since seccomp is not enabled."
 	fi
 
-	sed -e 's/"chmod",//' "$CRIO_ROOT"/cri-o/seccomp.json > "$TESTDIR"/seccomp_profile1.json
+	sed -e 's/"chmod",//' "$SECCOMP_PROFILE" > "$TESTDIR"/seccomp_profile1.json
 	sed -i 's/"fchmod",//' "$TESTDIR"/seccomp_profile1.json
 	sed -i 's/"fchmodat",//g' "$TESTDIR"/seccomp_profile1.json
 
@@ -124,7 +124,7 @@ function teardown() {
 		skip "skip this test since seccomp is not enabled."
 	fi
 
-	sed -e 's/"chmod",//' "$CRIO_ROOT"/cri-o/seccomp.json > "$TESTDIR"/seccomp_profile1.json
+	sed -e 's/"chmod",//' "$SECCOMP_PROFILE" > "$TESTDIR"/seccomp_profile1.json
 	sed -i 's/"fchmod",//' "$TESTDIR"/seccomp_profile1.json
 	sed -i 's/"fchmodat",//g' "$TESTDIR"/seccomp_profile1.json
 
@@ -156,7 +156,7 @@ function teardown() {
 
 	start_crio
 
-	sed -e 's/"chmod",//' "$CRIO_ROOT"/cri-o/seccomp.json > "$TESTDIR"/seccomp_profile1.json
+	sed -e 's/"chmod",//' "$SECCOMP_PROFILE" > "$TESTDIR"/seccomp_profile1.json
 	sed -i 's/"fchmod",//' "$TESTDIR"/seccomp_profile1.json
 	sed -i 's/"fchmodat",//g' "$TESTDIR"/seccomp_profile1.json
 
@@ -191,7 +191,7 @@ function teardown() {
 		skip "skip this test since seccomp is not enabled."
 	fi
 
-	sed -e 's/"chmod",//' "$CRIO_ROOT"/cri-o/seccomp.json > "$TESTDIR"/seccomp_profile1.json
+	sed -e 's/"chmod",//' "$SECCOMP_PROFILE" > "$TESTDIR"/seccomp_profile1.json
 	sed -i 's/"fchmod",//' "$TESTDIR"/seccomp_profile1.json
 	sed -i 's/"fchmodat",//g' "$TESTDIR"/seccomp_profile1.json
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -290,8 +290,8 @@ function start_crio() {
 }
 
 function cleanup_ctrs() {
-	run crictl ps --quiet
-	if [ "$status" -eq 0 ]; then
+	output=$(crictl ps --quiet)
+	if [ $? -eq 0 ]; then
 		if [ "$output" != "" ]; then
 			printf '%s\n' "$output" | while IFS= read -r line
 			do
@@ -304,8 +304,8 @@ function cleanup_ctrs() {
 }
 
 function cleanup_images() {
-	run crictl images --quiet
-	if [ "$status" -eq 0 ]; then
+	output=$(crictl images --quiet)
+	if [ $? -eq 0 ]; then
 		if [ "$output" != "" ]; then
 			printf '%s\n' "$output" | while IFS= read -r line
 			do
@@ -316,8 +316,8 @@ function cleanup_images() {
 }
 
 function cleanup_pods() {
-	run crictl sandboxes --quiet
-	if [ "$status" -eq 0 ]; then
+	output=$(crictl sandboxes --quiet)
+	if [ $? -eq 0 ]; then
 		if [ "$output" != "" ]; then
 			printf '%s\n' "$output" | while IFS= read -r line
 			do

--- a/test/network.bats
+++ b/test/network.bats
@@ -127,6 +127,9 @@ function teardown() {
 }
 
 @test "Ensure correct CNI plugin namespace/name/container-id arguments" {
+	if [[ ! -e "$CRIO_CNI_PLUGIN"/bridge-custom ]]; then
+		skip "bridge-custom plugin not available"
+	fi
 	start_crio "" "" "" "prepare_plugin_test_args_network_conf"
 	run crioctl pod run --config "$TESTDATA"/sandbox_config.json
 	[ "$status" -eq 0 ]
@@ -168,6 +171,9 @@ function teardown() {
 }
 
 @test "Clean up network if pod sandbox fails" {
+	if [[ ! -e "$CRIO_CNI_PLUGIN"/bridge-custom ]]; then
+		skip "bridge-custom plugin not available"
+	fi
 	start_crio "" "" "" "prepare_plugin_test_args_network_conf"
 
 	# make conmon non-executable to cause the sandbox setup to fail after


### PR DESCRIPTION
* Skip some tests if the bridge-custom plugin is
  unavailable. This CNI plugin is not distributed in
  any RPM, it is only available by compiling from a
  side branch in runcom's private github. We can't
  use it in a real integration-test setting.

* Don't use `run()` inside cleanup handlers. It will
  override $status, which is a double whammy:
   - successful cleanup will mask a test failure
   - when a test is `skip()`ed, crictl may fail,
     and $status will indicate failure.

* seccomp test: use existing $SECCOMP_PROFILE instead of
  assuming a path under $CRIO_ROOT

Signed-off-by: Ed Santiago <santiago@redhat.com>