### PR TITLE
container_create: setup cwd for containers

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1139,6 +1139,12 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		containerCwd = runtimeCwd
 	}
 	specgen.SetProcessCwd(containerCwd)
+	if err := setupWorkingDirectory(mountPoint, mountLabel, containerCwd); err != nil {
+		if err1 := s.StorageRuntimeServer().StopContainer(containerID); err1 != nil {
+			return nil, fmt.Errorf("can't umount container after cwd error %v: %v", err, err1)
+		}
+		return nil, err
+	}
 
 	var secretMounts []rspec.Mount
 	if len(s.config.DefaultMounts) > 0 {
@@ -1317,4 +1323,20 @@ func clearReadOnly(m *rspec.Mount) {
 		}
 	}
 	m.Options = opt
+}
+
+func setupWorkingDirectory(rootfs, mountLabel, containerCwd string) error {
+	fp, err := symlink.FollowSymlinkInScope(filepath.Join(rootfs, containerCwd), rootfs)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(fp, 0755); err != nil {
+		return err
+	}
+	if mountLabel != "" {
+		if err1 := label.Relabel(fp, mountLabel, true); err1 != nil && err1 != unix.ENOTSUP {
+			return fmt.Errorf("relabel failed %s: %v", fp, err1)
+		}
+	}
+	return nil
 }

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -928,3 +928,32 @@ function teardown() {
 	cleanup_pods
 	stop_crio
 }
+
+@test "ctr correctly setup working directory" {
+	start_crio
+	run crioctl pod run --config "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+	notexistcwd=$(cat "$TESTDATA"/container_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["working_dir"] = "/thisshouldntexistatall"; json.dump(obj, sys.stdout)')
+	echo "$notexistcwd" > "$TESTDIR"/container_cwd_notexist.json
+	run crioctl ctr create --config "$TESTDIR"/container_cwd_notexist.json --pod "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run crioctl ctr start --id "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+
+	filecwd=$(cat "$TESTDATA"/container_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["working_dir"] = "/etc/passwd"; obj["metadata"]["name"] = "container2"; json.dump(obj, sys.stdout)')
+	echo "$filecwd" > "$TESTDIR"/container_cwd_file.json
+	run crioctl ctr create --config "$TESTDIR"/container_cwd_file.json --pod "$pod_id"
+	echo "$output"
+	[ "$status" -ne 0 ]
+	ctr_id="$output"
+	[[ "$output" =~ "not a directory" ]]
+
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed https://bugzilla.redhat.com/show_bug.cgi?id=1508391
CRI-O wasn't setting up the cwd in case it didn't exist. Docker does that and this patch fixes the BZ indeed.

**- How I did it**

handle cwd setup on container creation

**- How to verify it**

added an integration test which fails on master

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

@rhatdan @mrunalp PTAL