### PR TITLE
test: Fix partial log line parsing

### DIFF
--- a/contrib/test/integration/build/kubernetes.yml
+++ b/contrib/test/integration/build/kubernetes.yml
@@ -2,7 +2,7 @@
 
 - name: clone kubernetes source repo
   git:
-    repo: "https://github.com/runcom/kubernetes.git"
+    repo: "https://github.com/mrunalp/kubernetes.git"
     dest: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
     version: "cri-o-node-e2e-patched"
 


### PR DESCRIPTION
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

**- What I did**
Removed our test patch and added a fix to parse partial lines in https://github.com/mrunalp/kubernetes/commit/945f530782dbf4c5069a4df9bbe6d6e60284d44d
https://github.com/mrunalp/kubernetes/commits/cri-o-node-e2e-patched

**- How I did it**
We don't just ignore an incomplete line (missing \n) but attempt to parse it and write to the output if possible.

**- How to verify it**
```
# kubectl create -f https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/configmap/configmap.yaml
# kubectl create -f https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/configmap/pod-configmap-volume1.yaml 
# kubectl logs dapi-test-pod-1
very# 
```

**- Description for the changelog**
Switch to kube branch that has a fix for parsing incomplete lines. 
