### PR TITLE
pause: do not strip binary

### DIFF
--- a/pause/Makefile
+++ b/pause/Makefile
@@ -6,7 +6,6 @@ override CFLAGS += -std=c99 -Os -Wall -Wextra -static
 
 pause: $(obj)
 	$(CC) -o ../bin/$@ $^ $(CFLAGS) $(LIBS)
-	strip ../bin/$@
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Debug symbols are needed in distro-supplied debuginfo packages.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

disabled binary stripping for pause

**- How I did it**

by removing the strip command from `pause/Makefile`.

**- How to verify it**

generate pause binary with and without the change, compare both binaries.

**- Description for the changelog**

pause: do not strip binary (needed by distro's debuginfo packages)

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


@runcom @mrunalp 