### PR TITLE
conmon,pause: strip binary only if non-distro build

### DIFF
--- a/conmon/Makefile
+++ b/conmon/Makefile
@@ -6,6 +6,9 @@ override CFLAGS += -std=c99 -Os -Wall -Wextra $(shell pkg-config --cflags glib-2
 
 conmon: $(obj)
 	$(CC) -o ../bin/$@ $^ $(CFLAGS) $(LIBS)
+ifndef DISTRO_BUILD
+	strip ../bin/$@
+endif
 
 .PHONY: clean
 clean:

--- a/pause/Makefile
+++ b/pause/Makefile
@@ -6,7 +6,9 @@ override CFLAGS += -std=c99 -Os -Wall -Wextra -static
 
 pause: $(obj)
 	$(CC) -o ../bin/$@ $^ $(CFLAGS) $(LIBS)
+ifndef DISTRO_BUILD
 	strip ../bin/$@
+endif
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
strip binaries only if $DISTRO_BUILD isn't defined

rpmbuild handles binary stripping automagically, so running the strip
command via Makefile isn't any use to distro packages.

With this commit, the rpm specfile can use
`DISTRO_BUILD=1 make conmon pause` to generate unstripped binaries.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
conditional binary stripping for conmon and pause

**- How I did it**
added a `DISTRO_BUILD` Makefile env var

**- How to verify it**
run `make conmon pause` and `DISTRO_BUILD=1 make conmon pause`.
Compare resulting binaries

**- Description for the changelog**
conmon,pause: conditional binary stripping if non-distro build

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
