### PR TITLE
More faster caching and testing

### DIFF
--- a/contrib/test/integration/ansible.cfg
+++ b/contrib/test/integration/ansible.cfg
@@ -57,11 +57,6 @@ gather_subset = network
 #host_key_checking = False
 host_key_checking = False
 
-# change the default callback
-#stdout_callback = skippy
-# enable additional callbacks
-#callback_whitelist = timer, mail
-
 # Determine whether includes in tasks and handlers are "static" by
 # default. As of 2.0, includes are dynamic by default. Setting these
 # values to True will make includes behave more like they did in the
@@ -165,7 +160,6 @@ deprecation_warnings = False
 # instead of shelling out to the git command.
 command_warnings = False
 
-
 # set plugin path directories here, separate with colons
 #action_plugins     = /usr/share/ansible/plugins/action
 #callback_plugins   = /usr/share/ansible/plugins/callback
@@ -219,7 +213,6 @@ nocolor = 0
 # When a playbook fails by default a .retry file will be created in ~/
 # You can disable this feature by setting retry_files_enabled to False
 # and you can change the location of the files by setting retry_files_save_path
-
 #retry_files_enabled = False
 retry_files_enabled = False
 
@@ -248,6 +241,7 @@ no_target_syslog = True
 # worker processes. At the default of 0, no compression
 # is used. This value must be an integer from 0 to 9.
 #var_compression_level = 9
+var_compression_level = 3
 
 # controls what compression method is used for new-style ansible modules when
 # they are sent to the remote system.  The compression types depend on having
@@ -298,6 +292,15 @@ ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/de
 # Example:
 # control_path = %(directory)s/%%h-%%r
 #control_path = %(directory)s/ansible-ssh-%%h-%%p-%%r
+# Using ssh's ControlPersist feature is desireable because of wide
+# compatibility and not needing to mess with /etc/sudoers
+# for pipelining (see below).  Unfortunately, in cloud environments,
+# auto-assigned VM hostnames tend to be rather longs.  Worse, in a CI
+# context, the default home-directory path may also be lengthy.  Fix
+# this to a short name, so Ansible doesn't fall back to opening new
+# connections for every task.
+control_path = /tmp/crio-%%n-%%p
+
 
 # Enabling pipelining reduces the number of SSH operations required to
 # execute a module on the remote server. This can result in a significant
@@ -308,7 +311,6 @@ ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/de
 # sudoers configurations that have requiretty (the default on many distros).
 #
 #pipelining = False
-pipelining=True
 
 # if True, make ansible use scp if the connection type is ssh
 # (default is sftp)

--- a/contrib/test/integration/system.yml
+++ b/contrib/test/integration/system.yml
@@ -1,59 +1,62 @@
 ---
 
+- name: Required packages are buffered so package module can install all at once
+  set_fact:
+    required_packages:
+        - container-selinux
+        - curl
+        - device-mapper-devel
+        - expect
+        - findutils
+        - gcc
+        - git
+        - glib2-devel
+        - glibc-devel
+        - glibc-static
+        - gpgme-devel
+        - hostname
+        - iproute
+        - iptables
+        - krb5-workstation
+        - libassuan-devel
+        - libffi-devel
+        - libgpg-error-devel
+        - libguestfs-tools
+        - libseccomp-devel
+        - libvirt-client
+        - libvirt-python
+        - libxml2-devel
+        - libxslt-devel
+        - make
+        - mlocate
+        - nfs-utils
+        - nmap-ncat
+        - oci-register-machine
+        - oci-systemd-hook
+        - oci-umount
+        - openssl
+        - openssl-devel
+        - ostree-devel
+        - pkgconfig
+        - python
+        - python2-boto
+        - python2-crypto
+        - python-devel
+        - python-virtualenv
+        - PyYAML
+        - redhat-rpm-config
+        - rpcbind
+        - rsync
+        - sed
+        - skopeo-containers
+        - socat
+        - tar
+        - wget
+
 - name: Make sure we have all required packages
   package:
-    name: "{{ item }}"
+    name: "{{ required_packages | join(', ') }}"
     state: present
-  with_items:
-    - container-selinux
-    - curl
-    - device-mapper-devel
-    - expect
-    - findutils
-    - gcc
-    - git
-    - glib2-devel
-    - glibc-devel
-    - glibc-static
-    - gpgme-devel
-    - hostname
-    - iproute
-    - iptables
-    - krb5-workstation
-    - libassuan-devel
-    - libffi-devel
-    - libgpg-error-devel
-    - libguestfs-tools
-    - libseccomp-devel
-    - libvirt-client
-    - libvirt-python
-    - libxml2-devel
-    - libxslt-devel
-    - make
-    - mlocate
-    - nfs-utils
-    - nmap-ncat
-    - oci-register-machine
-    - oci-systemd-hook
-    - oci-umount
-    - openssl
-    - openssl-devel
-    - ostree-devel
-    - pkgconfig
-    - python
-    - python2-boto
-    - python2-crypto
-    - python-devel
-    - python-virtualenv
-    - PyYAML
-    - redhat-rpm-config
-    - rpcbind
-    - rsync
-    - sed
-    - skopeo-containers
-    - socat
-    - tar
-    - wget
   async: 600
   poll: 10
 


### PR DESCRIPTION
**- What I did**

* In the future, should origin-ci utilize the ``ansible.con`` bundled with the repo, realize some performance gains by tweaking a few variables from their default values:

    * Reduce the vars compression level at the cost of network utilization.
    * Avoid ssh-reconnects by forcing the ControlPersist socket path to use a short path name.
    * Disable pipelining, since it breaks under older OS's unless special, security-breaking ``/etc/sudoers`` modifications are made.

* By default, ansible reproduces one task-per``with_items`` item.  This is incredibly slow for things like the ``package`` module, with a large collection of packages that could be installed all at once.
    * When future origin-ci utilize the ``ansible.con`` bundled with the repo, it can take advantage of the ``squash_actions`` setting.
    * With the default (no squashing actions), use a variable to hold the package list so that it can be formed into a CSV to the ``package`` module.  This will cause all packages to be installed as one task instead of N-packages.

**- How I did it**

* Read the comments in ansible.conf
* Move some tasks around

**- How to verify it**

A CI run will proceed past the ``system.yml`` include w/o any errors.  In the future, when origin-ci uses the ``ansible.conf``, future jobs will continue to proceed past the ``system.yaml`` include w/o any errors.