### PR TITLE
Bump github.com/vbatts/tar-split

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -82,7 +82,7 @@ github.com/emicklei/go-restful-swagger12 1.0.1
 github.com/pkg/errors v0.8.0
 github.com/godbus/dbus a389bdde4dd695d414e47b755e95e72b7826432c
 github.com/urfave/cli v1.20.0
-github.com/vbatts/tar-split v0.10.1
+github.com/vbatts/tar-split v0.10.2
 github.com/renstrom/dedent v1.0.0
 github.com/hpcloud/tail v1.0.0
 gopkg.in/fsnotify.v1 v1.4.2

--- a/vendor/github.com/vbatts/tar-split/README.md
+++ b/vendor/github.com/vbatts/tar-split/README.md
@@ -1,6 +1,7 @@
 # tar-split
 
 [![Build Status](https://travis-ci.org/vbatts/tar-split.svg?branch=master)](https://travis-ci.org/vbatts/tar-split)
+[![Go Report Card](https://goreportcard.com/badge/github.com/vbatts/tar-split)](https://goreportcard.com/report/github.com/vbatts/tar-split)
 
 Pristinely disassembling a tar archive, and stashing needed raw bytes and offsets to reassemble a validating original archive.
 
@@ -50,7 +51,7 @@ For example stored sparse files that have "holes" in them, will be read as a
 contiguous file, though the archive contents may be recorded in sparse format.
 Therefore when adding the file payload to a reassembled tar, to achieve
 identical output, the file payload would need be precisely re-sparsified. This
-is not something I seek to fix imediately, but would rather have an alert that
+is not something I seek to fix immediately, but would rather have an alert that
 precise reassembly is not possible.
 (see more http://www.gnu.org/software/tar/manual/html_node/Sparse-Formats.html)
 


### PR DESCRIPTION
Update vendor/github.com/vbatts/tar-split to v0.10.2, to fix CVE-2017-14992, per https://github.com/vbatts/tar-split/pull/42.