### PR TITLE
server: Do not suppress image repull in cri-o

### DIFF
--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -66,14 +66,6 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (*pb.P
 			continue
 		}
 
-		// let's be smart, docker doesn't repull if image already exists.
-		_, err = s.StorageImageServer().ImageStatus(s.ImageContext(), img)
-		if err == nil {
-			logrus.Debugf("image %s already in store, skipping pull", img)
-			pulled = img
-			break
-		}
-
 		_, err = s.StorageImageServer().PullImage(s.ImageContext(), img, options)
 		if err != nil {
 			logrus.Debugf("error pulling image %s: %v", img, err)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did and How I did it**

The PullImage function is trying to be too smart and as a result suppressing pulls where the imagePullPolicy is Always. This policy is not plumbed down and so we must trust the caller to do this check. This change removes the check from cri-o. This matches the behavior of docker, which does repull if the tag has changed.

While Kubernetes implements the check for an existing image (gated by the imagePullPolicy), performance may be impacted if the caller does not. To avoid that we need the image library to avoid redownloading a layer already in the cache. Unfortunately that doesn't work reliably today: containers/image#155

**- How to verify it**

1. Push image to docker registry.
2. Create pod with image.
3. Delete pod.
4. Push a new image with the same tag name to the docker registry.
5. Create a new pod with the imagePullPolicy as Always (or use the image tag of latest).
6. Verify the new pod is running the new image.

This involves pushing images to a docker registry, making it difficult to add automated tests.

**- Description for the changelog**

server: Do not suppress image repull