### PR TITLE
Bump v1.0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN set -x \
        && rm -rf "$GOPATH"
 
 # Install crictl
-ENV CRICTL_COMMIT 16e6fe4d7199c5689db4630a9330e6a8a12cecd1
+ENV CRICTL_COMMIT b42fc3f364dd48f649d55926c34492beeb9b2e99
 RUN set -x \
        && export GOPATH="$(mktemp -d)" \
        && git clone https://github.com/kubernetes-incubator/cri-tools.git "$GOPATH/src/github.com/kubernetes-incubator/cri-tools" \

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ MANDIR ?= ${PREFIX}/share/man
 ETCDIR ?= ${DESTDIR}/etc
 ETCDIR_CRIO ?= ${ETCDIR}/crio
 BUILDTAGS ?= seccomp $(shell hack/btrfs_tag.sh) $(shell hack/libdm_tag.sh) $(shell hack/btrfs_installed_tag.sh) $(shell hack/ostree_tag.sh) $(shell hack/selinux_tag.sh)
+CRICTL_CONFIG_DIR=${DESTDIR}/etc
 
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 OCIUMOUNTINSTALLDIR=$(PREFIX)/share/oci-umount/oci-umount.d
@@ -165,6 +166,7 @@ install.config:
 	install ${SELINUXOPT} -D -m 644 crio.conf $(ETCDIR_CRIO)/crio.conf
 	install ${SELINUXOPT} -D -m 644 seccomp.json $(ETCDIR_CRIO)/seccomp.json
 	install ${SELINUXOPT} -D -m 644 crio-umount.conf $(OCIUMOUNTINSTALLDIR)/crio-umount.conf
+	install ${SELINUXOPT} -D -m 644 crictl.yaml $(CRICTL_CONFIG_DIR)
 
 install.completions:
 	install ${SELINUXOPT} -d -m 755 ${BASHINSTALLDIR}

--- a/contrib/test/integration/build/cri-tools.yml
+++ b/contrib/test/integration/build/cri-tools.yml
@@ -4,7 +4,7 @@
   git:
     repo: "https://github.com/kubernetes-incubator/cri-tools.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-tools"
-    version: "16e6fe4d7199c5689db4630a9330e6a8a12cecd1"
+    version: "b42fc3f364dd48f649d55926c34492beeb9b2e99"
 
 - name: install crictl
   command: "/usr/bin/go install github.com/kubernetes-incubator/cri-tools/cmd/crictl"

--- a/crictl.yaml
+++ b/crictl.yaml
@@ -1,0 +1,1 @@
+runtime-endpoint: /var/run/crio.sock

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -620,6 +620,10 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 
 	labels := containerConfig.GetLabels()
 
+	if err := validateLabels(labels); err != nil {
+		return nil, err
+	}
+
 	metadata := containerConfig.GetMetadata()
 
 	kubeAnnotations := containerConfig.GetAnnotations()

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -38,38 +38,40 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 	logrus.Debugf("ListContainersRequest %+v", req)
 
 	var ctrs []*pb.Container
-	filter := req.Filter
+	filter := req.GetFilter()
 	ctrList, err := s.ContainerServer.ListContainers()
 	if err != nil {
 		return nil, err
 	}
 
-	// Filter using container id and pod id first.
-	if filter.Id != "" {
-		id, err := s.CtrIDIndex().Get(filter.Id)
-		if err != nil {
-			return nil, err
-		}
-		c := s.ContainerServer.GetContainer(id)
-		if c != nil {
-			if filter.PodSandboxId != "" {
-				if c.Sandbox() == filter.PodSandboxId {
-					ctrList = []*oci.Container{c}
-				} else {
-					ctrList = []*oci.Container{}
-				}
-
-			} else {
-				ctrList = []*oci.Container{c}
+	if filter != nil {
+		// Filter using container id and pod id first.
+		if filter.Id != "" {
+			id, err := s.CtrIDIndex().Get(filter.Id)
+			if err != nil {
+				return nil, err
 			}
-		}
-	} else {
-		if filter.PodSandboxId != "" {
-			pod := s.ContainerServer.GetSandbox(filter.PodSandboxId)
-			if pod == nil {
-				ctrList = []*oci.Container{}
-			} else {
-				ctrList = pod.Containers().List()
+			c := s.ContainerServer.GetContainer(id)
+			if c != nil {
+				if filter.PodSandboxId != "" {
+					if c.Sandbox() == filter.PodSandboxId {
+						ctrList = []*oci.Container{c}
+					} else {
+						ctrList = []*oci.Container{}
+					}
+
+				} else {
+					ctrList = []*oci.Container{c}
+				}
+			}
+		} else {
+			if filter.PodSandboxId != "" {
+				pod := s.ContainerServer.GetSandbox(filter.PodSandboxId)
+				if pod == nil {
+					ctrList = []*oci.Container{}
+				} else {
+					ctrList = pod.Containers().List()
+				}
 			}
 		}
 	}

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -227,6 +227,10 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	// add labels
 	labels := req.GetConfig().GetLabels()
 
+	if err := validateLabels(labels); err != nil {
+		return nil, err
+	}
+
 	// Add special container name label for the infra container
 	labelsJSON := []byte{}
 	if labels != nil {

--- a/server/utils.go
+++ b/server/utils.go
@@ -18,6 +18,8 @@ const (
 	// According to http://man7.org/linux/man-pages/man5/resolv.conf.5.html:
 	// "The search list is currently limited to six domains with a total of 256 characters."
 	maxDNSSearches = 6
+
+	maxLabelSize = 4096
 )
 
 func copyFile(src, dest string) error {
@@ -195,4 +197,16 @@ func recordError(operation string, err error) {
 		// TODO(runcom): handle timeout from ctx as well
 		metrics.CRIOOperationsErrors.WithLabelValues(operation).Inc()
 	}
+}
+
+func validateLabels(labels map[string]string) error {
+	for k, v := range labels {
+		if (len(k) + len(v)) > maxLabelSize {
+			if len(k) > 10 {
+				k = k[:10]
+			}
+			return fmt.Errorf("label key and value greater than maximum size (%d bytes), key: %s", maxLabelSize, k)
+		}
+	}
+	return nil
 }

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -211,9 +211,9 @@ function retry() {
 	false
 }
 
-# Waits until the given crio becomes reachable.
+# Waits until crio becomes reachable.
 function wait_until_reachable() {
-	retry 15 1 crictl status
+	retry 15 1 crictl version
 }
 
 # Start crio.

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.0.4"
+const Version = "1.0.5-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.0.4-dev"
+const Version = "1.0.4"


### PR DESCRIPTION
Will tag 88dd6f325bcbb0be6d7ffe70c7d44b69721715b1 v1.0.4

Release notes:
```
Welcome to the release of CRI-O v1.0.4!


This last patch release mainly adds additional Prometheus metrics focusing
on the CRI API itself. It also includes various bug fixes.

Please try out the release binaries and report any issues at
https://github.com/kubernetes-incubator/cri-o/issues.



### Contributors

* Antonio Murdaca
* Daniel J Walsh
* Mrunal Patel

### Changes

* 88dd6f325 version: bump to v1.0.4
* 97bbc8cd1 container_list: guard against list filter being nil
* 544396a0e *: add crictl.yaml
* ed34ff325 server: validate labels size to avoid dos
* ce319adcf Merge pull request #1140 from runcom/backports-image-pull-metrics
* 12cb42483 server: add prometheus metrics for CRI operations
* 5488bfeb9 image_pull: repull when image ID (config digest) changed
* 8a39d94a0 Merge pull request #1134 from runcom/fix-cve-2017-14992
* dc8d1e938 version: bump to v1.0.4-dev

### Dependency Changes

Previous release can be found at [v1.0.3](https://github.com/kubernetes-incubator/cri-o/releases/tag/v1.0.3)

```