### PR TITLE
container_create: set the seccomp profile in the container object

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1066,7 +1066,6 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		}
 	}
 	specgen.AddAnnotation(annotations.SeccompProfilePath, spp)
-	// TODO(runcom): add spp to container...
 
 	metaname := metadata.Name
 	attempt := metadata.Attempt
@@ -1213,6 +1212,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	}
 	container.SetSpec(specgen.Spec())
 	container.SetMountPoint(mountPoint)
+	container.SetSeccompProfilePath(spp)
 
 	for _, cv := range containerVolumes {
 		container.AddVolume(cv)


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

If you're wondering, this is not a bug since the profile is set directly in spec and run. Just adding for consistency and fixing the TODO

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
