### PR TITLE
Add tests for server/config.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@
 /test/bin2img/bin2img
 /test/checkseccomp/checkseccomp
 /test/copyimg/copyimg
+
+Vagrantfile
+.vagrant/
+
+.vscode/

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/kubernetes-incubator/cri-o/libkpod"
+)
+
+const fixturePath = "fixtures/crio.conf"
+
+func must(t *testing.T, err error) {
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func assertAllFieldsEquality(t *testing.T, c Config) {
+	testCases := []struct {
+		fieldValue, expected interface{}
+	}{
+		{c.RootConfig.Root, "/var/lib/containers/storage"},
+		{c.RootConfig.RunRoot, "/var/run/containers/storage"},
+		{c.RootConfig.Storage, "overlay"},
+		{c.RootConfig.StorageOptions[0], "overlay.override_kernel_check=1"},
+
+		{c.APIConfig.Listen, "/var/run/crio.sock"},
+		{c.APIConfig.StreamPort, "10010"},
+		{c.APIConfig.StreamAddress, "localhost"},
+
+		{c.RuntimeConfig.Runtime, "/usr/local/bin/runc"},
+		{c.RuntimeConfig.RuntimeUntrustedWorkload, "untrusted"},
+		{c.RuntimeConfig.DefaultWorkloadTrust, "trusted"},
+		{c.RuntimeConfig.Conmon, "/usr/local/libexec/crio/conmon"},
+		{c.RuntimeConfig.ConmonEnv[0], "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+		{c.RuntimeConfig.SELinux, true},
+		{c.RuntimeConfig.SeccompProfile, "/etc/crio/seccomp.json"},
+		{c.RuntimeConfig.ApparmorProfile, "crio-default"},
+		{c.RuntimeConfig.CgroupManager, "cgroupfs"},
+		{c.RuntimeConfig.PidsLimit, int64(1024)},
+
+		{c.ImageConfig.DefaultTransport, "docker://"},
+		{c.ImageConfig.PauseImage, "kubernetes/pause"},
+		{c.ImageConfig.PauseCommand, "/pause"},
+		{c.ImageConfig.SignaturePolicyPath, "/tmp"},
+		{c.ImageConfig.ImageVolumes, libkpod.ImageVolumesType("mkdir")},
+		{c.ImageConfig.InsecureRegistries[0], "insecure-registry:1234"},
+		{c.ImageConfig.Registries[0], "registry:4321"},
+
+		{c.NetworkConfig.NetworkDir, "/etc/cni/net.d/"},
+		{c.NetworkConfig.PluginDir, "/opt/cni/bin/"},
+	}
+	for _, tc := range testCases {
+		if tc.fieldValue != tc.expected {
+			t.Errorf(`Expecting: "%s", got: "%s"`, tc.expected, tc.fieldValue)
+		}
+	}
+}
+
+func TestUpdateFromFile(t *testing.T) {
+	c := Config{}
+
+	must(t, c.UpdateFromFile(fixturePath))
+
+	assertAllFieldsEquality(t, c)
+}
+
+func TestToFile(t *testing.T) {
+	configFromFixture := Config{}
+
+	must(t, configFromFixture.UpdateFromFile(fixturePath))
+
+	f, err := ioutil.TempFile("", "crio.conf")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.Remove(f.Name())
+
+	must(t, configFromFixture.ToFile(f.Name()))
+
+	writtenConfig := Config{}
+	err = writtenConfig.UpdateFromFile(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertAllFieldsEquality(t, writtenConfig)
+}

--- a/server/fixtures/crio.conf
+++ b/server/fixtures/crio.conf
@@ -1,0 +1,41 @@
+[crio]
+root = "/var/lib/containers/storage"
+runroot = "/var/run/containers/storage"
+storage_driver = "overlay"
+storage_option = ["overlay.override_kernel_check=1"]
+
+[crio.api]
+listen = "/var/run/crio.sock"
+stream_address = "localhost"
+stream_port = "10010"
+
+[crio.runtime]
+runtime = "/usr/local/bin/runc"
+runtime_untrusted_workload = "untrusted"
+default_workload_trust = "trusted"
+conmon = "/usr/local/libexec/crio/conmon"
+conmon_env = [
+	"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+]
+selinux = true
+seccomp_profile = "/etc/crio/seccomp.json"
+apparmor_profile = "crio-default"
+cgroup_manager = "cgroupfs"
+pids_limit = 1024
+
+[crio.image]
+default_transport = "docker://"
+pause_image = "kubernetes/pause"
+pause_command = "/pause"
+signature_policy = "/tmp"
+image_volumes = "mkdir"
+insecure_registries = [
+	"insecure-registry:1234",
+]
+registries = [
+	"registry:4321",
+]
+
+[crio.network]
+network_dir = "/etc/cni/net.d/"
+plugin_dir = "/opt/cni/bin/"


### PR DESCRIPTION
This change is the first of several needed to address #893.

**- What I did**
I added tests to the functions in `server/config.go`.

**- How I did it**
I am using a fixture I saved on `server/fixtures/crio.conf` to check that the functions in `config.go` are reading and writing conf files properly.

**- How to verify it**
Run the tests.

**- Description for the changelog**
`Add tests for server/config.go`

Note: some extra paths about Vagrant and VSCode were added to gitignore. Let me know if you want me to remote those.

Note 2: I added a `TODO` on the `.conf` file because I am not sure what to do with that configuration.