### PR TITLE
share pid namespace for Pod container

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -115,6 +115,9 @@ default_mounts = [
 # pids_limit is the number of processes allowed in a container
 pids_limit = {{ .PidsLimit }}
 
+# disable using a shared PID namespace for containers in a pod
+disable_shared_pid_namespace = {{ .DisableSharedPIDNamespace }}
+
 # log_size_max is the max limit for the container log size in bytes.
 # Negative values indicate that no limit is imposed.
 log_size_max = {{ .LogSizeMax }}

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -131,6 +131,9 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("pids-limit") {
 		config.PidsLimit = ctx.GlobalInt64("pids-limit")
 	}
+	if ctx.GlobalIsSet("disable-shared-pid-namespace") {
+		config.DisableSharedPIDNamespace = ctx.GlobalBool("disable-shared-pid-namespace")
+	}
 	if ctx.GlobalIsSet("log-size-max") {
 		config.LogSizeMax = ctx.GlobalInt64("log-size-max")
 	}
@@ -295,6 +298,10 @@ func main() {
 			Name:  "pids-limit",
 			Value: libkpod.DefaultPidsLimit,
 			Usage: "maximum number of processes allowed in a container",
+		},
+		cli.BoolFlag{
+			Name:  "disable-shared-pid-namespace",
+			Usage: "disable using a shared PID namespace for containers in a pod",
 		},
 		cli.Int64Flag{
 			Name:  "log-size-max",

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -118,6 +118,9 @@ set the CPU profile file path
 **--pids-limit**=""
   Maximum number of processes allowed in a container (default: 1024)
 
+**--disable-shared-pid-namespace**=""
+  Disable using a shared PID namespace for containers in a pod (default: false)
+
 **--root**=""
   The crio root dir (default: "/var/lib/containers/storage")
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -87,6 +87,9 @@ Example:
 **pids_limit**=""
   Maximum number of processes allowed in a container (default: 1024)
 
+**disable_shared_pid_namespace**=""
+  Disable using a shared PID namespace for containers in a pod (default: false)
+
 **runtime**=""
   OCI runtime path (default: "/usr/bin/runc")
 

--- a/libkpod/config.go
+++ b/libkpod/config.go
@@ -121,6 +121,9 @@ type RuntimeConfig struct {
 	// NoPivot instructs the runtime to not use `pivot_root`, but instead use `MS_MOVE`
 	NoPivot bool `toml:"no_pivot"`
 
+	// DisableSharePidNamespace instructs the runtime to disable share pid namespace
+	DisableSharedPIDNamespace bool `toml:"disable_shared_pid_namespace"`
+
 	// Conmon is the path to conmon binary, used for managing the runtime.
 	Conmon string `toml:"conmon"`
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -56,6 +56,8 @@ IMAGE_VOLUMES=${IMAGE_VOLUMES:-mkdir}
 PIDS_LIMIT=${PIDS_LIMIT:-1024}
 # Log size max limit
 LOG_SIZE_MAX_LIMIT=${LOG_SIZE_MAX_LIMIT:--1}
+# enable share container pid namespace
+DISABLE_SHARED_PID_NAMESPACE=${DISABLE_SHARED_PID_NAMESPACE:-false}
 
 TESTDIR=$(mktemp -d)
 
@@ -240,7 +242,7 @@ function start_crio() {
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=mrunalp/image-volume-test --import-from=dir:"$ARTIFACTS_PATH"/image-volume-test-image --add-name=docker.io/library/mrunalp/image-volume-test --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=busybox:latest --import-from=dir:"$ARTIFACTS_PATH"/busybox-image --add-name=docker.io/library/busybox:latest --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=runcom/stderr-test:latest --import-from=dir:"$ARTIFACTS_PATH"/stderr-test --add-name=docker.io/runcom/stderr-test:latest --signature-policy="$INTEGRATION_ROOT"/policy.json
-	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --cgroup-manager "$CGROUP_MANAGER" --registry "docker.io" --runtime "$RUNTIME_BINARY" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --log-size-max "$LOG_SIZE_MAX_LIMIT" --config /dev/null config >$CRIO_CONFIG
+	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --cgroup-manager "$CGROUP_MANAGER" --registry "docker.io" --runtime "$RUNTIME_BINARY" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --disable-shared-pid-namespace=${DISABLE_SHARED_PID_NAMESPACE} --log-size-max "$LOG_SIZE_MAX_LIMIT" --config /dev/null config >$CRIO_CONFIG
 
 	# Prepare the CNI configuration files, we're running with non host networking by default
 	if [[ -n "$4" ]]; then

--- a/test/namespaces.bats
+++ b/test/namespaces.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function teardown() {
+	cleanup_test
+}
+
+@test "pod disable shared pid namespace" {
+	DISABLE_SHARED_PID_NAMESPACE="true" start_crio
+
+	run crictl runs "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+	run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run crictl start "$ctr_id"
+	[ "$status" -eq 0 ]
+
+	run crictl exec --sync "$ctr_id" cat /proc/1/cmdline
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "redis" ]]
+
+	run crictl stops "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crictl rms "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}
+
+@test "pod enable shared pid namespace" {
+	DISABLE_SHARED_PID_NAMESPACE="false" start_crio
+
+	run crictl runs "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+	run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run crictl start "$ctr_id"
+	[ "$status" -eq 0 ]
+
+	run crictl exec --sync "$ctr_id" cat /proc/1/cmdline
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "pause" ]]
+
+	run crictl stops "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crictl rms "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}


### PR DESCRIPTION
Signed-off-by: Wei Wei <weiwei.inf@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

enable share pid namespace for containers in a pod, and add a --disable-share-pid-namespace flag to disable this feature

**- How I did it**

vim

**- How to verify it**

start crio with/without `--disable-shared-pid-namespace`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

enable share pid namespace for containers in a pod and add a --disable-share-pid-namespace flag to disable this feature

closes #1135
closes https://github.com/kubernetes-incubator/cri-o/issues/488

