### PR TITLE
hack: validate tests for crioctl deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ jobs:
         - make .gitvalidation
         - make gofmt
         - make lint
+        - make verify
         - make testunit
         - make docs
         - make
@@ -41,12 +42,14 @@ jobs:
         - make .gitvalidation
         - make gofmt
         - make lint
+        - make verify
         - make testunit
         - make docs
         - make
       go: 1.9.x
     - script:
         - make .gitvalidation
+        - make verify
         - make testunit
         - make docs
         - make

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ lint: .gopathok
 gofmt:
 	@./hack/verify-gofmt.sh
 
+verify:
+	@./hack/validate/deprecate-crioctl
+
 conmon:
 	$(MAKE) -C $@
 

--- a/hack/validate/.validate
+++ b/hack/validate/.validate
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+if [ -z "$VALIDATE_UPSTREAM" ]; then
+	# this is kind of an expensive check, so let's not do this twice if we
+	# are running more than one validate bundlescript
+
+	VALIDATE_REPO='https://github.com/kubernetes-incubator/cri-o.git'
+	VALIDATE_BRANCH='master'
+
+	VALIDATE_HEAD="$(git rev-parse --verify HEAD)"
+
+	git fetch -q "$VALIDATE_REPO" "refs/heads/$VALIDATE_BRANCH"
+	VALIDATE_UPSTREAM="$(git rev-parse --verify FETCH_HEAD)"
+
+	VALIDATE_COMMIT_LOG="$VALIDATE_UPSTREAM..$VALIDATE_HEAD"
+	VALIDATE_COMMIT_DIFF="$VALIDATE_UPSTREAM...$VALIDATE_HEAD"
+
+	validate_diff() {
+		if [ "$VALIDATE_UPSTREAM" != "$VALIDATE_HEAD" ]; then
+			git diff "$VALIDATE_COMMIT_DIFF" "$@"
+		fi
+	}
+	validate_log() {
+		if [ "$VALIDATE_UPSTREAM" != "$VALIDATE_HEAD" ]; then
+			git log "$VALIDATE_COMMIT_LOG" "$@"
+		fi
+	}
+fi

--- a/hack/validate/deprecate-crioctl
+++ b/hack/validate/deprecate-crioctl
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Check that no new tests are being added using crioctl
+
+export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPTDIR}/.validate"
+
+IFS=$'\n'
+files=( $(validate_diff --diff-filter=ACMR --name-only -- 'test/*.bats' || true) )
+unset IFS
+
+badFiles=()
+for f in "${files[@]}"; do
+	# we use "git show" here to validate that what's committed doesn't contain crioctl calls
+	if git show "$VALIDATE_HEAD:$f" | grep -q crioctl; then
+		badFiles+=( "$f" )
+	fi
+done
+
+if [ ${#badFiles[@]} -eq 0 ]; then
+	echo 'Congratulations!  No new tests have been added using crioctl.'
+else
+	{
+		echo "These files use crioctl instead of crictl:"
+		echo ""
+		for f in "${badFiles[@]}"; do
+			echo " - $f"
+		done
+		echo
+	} >&2
+	false
+fi


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

`crioctl` is deprecated in favor of  `crictl` from `kubernetes-incubator/cri-tools`. We already wired in the project `crictl` but there are tests still relying on `crioctl`. This patch adds a verification target which if you're adding a test with crioctl, it'll tell you to use `crictl` instead. This would ease the transaction to `crictl`.

**- How I did it**

added a deprecation script

**- How to verify it**

commit a new test which uses crioctl and notice it's failing here in travis, output looks like the following:
```
$ make verify                                         
These files use crioctl instead of crictl:

 - test/ctr.bats

make: *** [Makefile:70: verify] Error 1
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
