### PR TITLE
test: Add a version var for kube branches

### DIFF
--- a/contrib/test/integration/build/kubernetes.yml
+++ b/contrib/test/integration/build/kubernetes.yml
@@ -5,7 +5,7 @@
     repo: "https://github.com/runcom/kubernetes.git"
     dest: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
     # based on kube v1.9.0-alpha.2, update as needed
-    version: "cri-o-patched-1.9"
+    version: "{{ k8s_git_version }}"
     force: "{{ force_clone | default(False) | bool}}"
 
 - name: install etcd

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -21,6 +21,8 @@
 
     - name: clone build and install kubernetes
       include: "build/kubernetes.yml"
+      vars:
+        k8s_git_version: "cri-o-node-e2e-patched-logs"
 
     - name: clone build and install runc
       include: "build/runc.yml"
@@ -64,6 +66,7 @@
       include: "build/kubernetes.yml"
       vars:
           force_clone: True
+          k8s_git_version: "cri-o-patched-1.9"
 
     - name: run k8s e2e tests
       include: e2e.yml


### PR DESCRIPTION
This allows us to cache a k8s branch for cri-o 1.0 branch
while allowing overriding of k8s branch in master and other
newer cri-o branches.

@runcom @cevich PTAL

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>


**- What I did**
Added support for switching between k8s branches in different cri-o branches.

**- How I did it**
Added a var for specifying kubernetes checkout version in ansible for tests.

**- How to verify it**
Verify tests work for 1.0 and other branches. 

**- Description for the changelog**
Add var for kubernetes branch in ansible.
