### PR TITLE
Move crio default sock to /var/run/crio/crio.sock

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ You can run a local version of kubernetes with CRI-O using `local-up-cluster.sh`
 ```shell
 CGROUP_DRIVER=systemd \
 CONTAINER_RUNTIME=remote \
-CONTAINER_RUNTIME_ENDPOINT='/var/run/crio.sock  --runtime-request-timeout=15m' \
+CONTAINER_RUNTIME_ENDPOINT='/var/run/crio/crio.sock  --runtime-request-timeout=15m' \
 ./hack/local-up-cluster.sh
 ```
 

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -8,6 +8,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -427,6 +428,10 @@ func main() {
 		if _, err := os.Stat(config.Runtime); os.IsNotExist(err) {
 			// path to runtime does not exist
 			return fmt.Errorf("invalid --runtime value %q", err)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(config.Listen), 0755); err != nil {
+			return err
 		}
 
 		// Remove the socket if it already exists

--- a/cmd/crioctl/main.go
+++ b/cmd/crioctl/main.go
@@ -97,7 +97,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "connect",
-			Value: "/var/run/crio.sock",
+			Value: "/var/run/crio/crio.sock",
 			Usage: "Socket to connect to",
 		},
 		cli.DurationFlag{

--- a/contrib/test/integration/build/kubernetes.yml
+++ b/contrib/test/integration/build/kubernetes.yml
@@ -40,7 +40,7 @@
       export PATH=/usr/local/go/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/root/bin:{{ ansible_env.GOPATH }}/bin:{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes/third_party/etcd:{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes/_output/local/bin/linux/amd64/
       export CONTAINER_RUNTIME=remote
       export CGROUP_DRIVER=systemd
-      export CONTAINER_RUNTIME_ENDPOINT='/var/run/crio.sock --runtime-request-timeout=5m'
+      export CONTAINER_RUNTIME_ENDPOINT='/var/run/crio/crio.sock --runtime-request-timeout=5m'
       export ALLOW_SECURITY_CONTEXT=","
       export ALLOW_PRIVILEGED=1
       export DNS_SERVER_IP={{ ansible_eth0.ipv4.address }}

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -94,7 +94,7 @@ set the CPU profile file path
   ignore: All volumes are just ignored and no action is taken.
 
 **--listen**=""
-  Path to CRI-O socket (default: "/var/run/crio.sock")
+  Path to CRI-O socket (default: "/var/run/crio/crio.sock")
 
 **--log**=""
   Set the log file path where internal debug information is written

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -68,7 +68,7 @@ Example:
 ## CRIO.API TABLE
 
 **listen**=""
-  Path to crio socket (default: "/var/run/crio.sock")
+  Path to crio socket (default: "/var/run/crio/crio.sock")
 
 ## CRIO.RUNTIME TABLE
 

--- a/kubernetes.md
+++ b/kubernetes.md
@@ -79,7 +79,7 @@ KUBELET_ARGS="--pod-manifest-path=/etc/kubernetes/manifests
 You need to add following parameters to `KUBELET_ARGS`:
 * `--experimental-cri=true` - Use Container Runtime Interface. Will be true by default from kubernetes 1.6 release.
 * `--container-runtime=remote` - Use remote runtime with provided socket.
-* `--container-runtime-endpoint=/var/run/crio.sock` - Socket for remote runtime (default `crio` socket localization).
+* `--container-runtime-endpoint=/var/run/crio/crio.sock` - Socket for remote runtime (default `crio` socket localization).
 * `--runtime-request-timeout=10m` - Optional but useful. Some requests, especially pulling huge images, may take longer than default (2 minutes) and will cause an error. 
 
 Kubelet is prepared now.

--- a/server/config.go
+++ b/server/config.go
@@ -104,7 +104,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		Config: *libkpod.DefaultConfig(),
 		APIConfig: APIConfig{
-			Listen:        "/var/run/crio.sock",
+			Listen:        "/var/run/crio/crio.sock",
 			StreamAddress: "",
 			StreamPort:    "10010",
 		},


### PR DESCRIPTION
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

`master` is now tracking kubernetes 1.9 and we can switch to `/var/run/crio/crio.sock`. The behavior is still controllable via config and flags.
Refer to #1030 for old discussion
Fix #1028 

cAdvisor PR: https://github.com/google/cadvisor/pull/1773
Kubernetes PR: https://github.com/kubernetes/kubernetes/pull/54136

@mrunalp @rhatdan @derekwaynecarr @smarterclayton PTAL

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
