### PR TITLE
test: Add a version var for kube branches

### DIFF
--- a/contrib/test/integration/build/kubernetes.yml
+++ b/contrib/test/integration/build/kubernetes.yml
@@ -4,7 +4,7 @@
   git:
     repo: "https://github.com/runcom/kubernetes.git"
     dest: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
-    version: "cri-o-patched-1.8"
+    version: "{{ k8s_git_version }}"
     force: "{{ force_clone | default(False) | bool}}"
 
 - name: install etcd

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -19,6 +19,8 @@
 
     - name: clone build and install kubernetes
       include: "build/kubernetes.yml"
+      vars:
+        k8s_git_version: "cri-o-node-e2e-patched-logs"
 
     - name: clone build and install runc
       include: "build/runc.yml"
@@ -58,6 +60,7 @@
       include: "build/kubernetes.yml"
       vars:
           force_clone: True
+          k8s_git_version: "cri-o-patched-1.8"
 
     - name: run k8s e2e tests
       include: e2e.yml


### PR DESCRIPTION
This allows us to cache a k8s branch for cri-o 1.0 branch
while allowing overriding of k8s branch in master and other
newer cri-o branches.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

#1153 ported to release-1.8 branch.
