### PR TITLE
Make pid namespace sharing optional and disabled by default

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -115,8 +115,8 @@ default_mounts = [
 # pids_limit is the number of processes allowed in a container
 pids_limit = {{ .PidsLimit }}
 
-# disable using a shared PID namespace for containers in a pod
-disable_shared_pid_namespace = {{ .DisableSharedPIDNamespace }}
+# enable using a shared PID namespace for containers in a pod
+enable_shared_pid_namespace = {{ .EnableSharedPIDNamespace }}
 
 # log_size_max is the max limit for the container log size in bytes.
 # Negative values indicate that no limit is imposed.

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -132,8 +132,8 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("pids-limit") {
 		config.PidsLimit = ctx.GlobalInt64("pids-limit")
 	}
-	if ctx.GlobalIsSet("disable-shared-pid-namespace") {
-		config.DisableSharedPIDNamespace = ctx.GlobalBool("disable-shared-pid-namespace")
+	if ctx.GlobalIsSet("enable-shared-pid-namespace") {
+		config.EnableSharedPIDNamespace = ctx.GlobalBool("enable-shared-pid-namespace")
 	}
 	if ctx.GlobalIsSet("log-size-max") {
 		config.LogSizeMax = ctx.GlobalInt64("log-size-max")
@@ -301,8 +301,8 @@ func main() {
 			Usage: "maximum number of processes allowed in a container",
 		},
 		cli.BoolFlag{
-			Name:  "disable-shared-pid-namespace",
-			Usage: "disable using a shared PID namespace for containers in a pod",
+			Name:  "enable-shared-pid-namespace",
+			Usage: "enable using a shared PID namespace for containers in a pod",
 		},
 		cli.Int64Flag{
 			Name:  "log-size-max",

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -118,8 +118,8 @@ set the CPU profile file path
 **--pids-limit**=""
   Maximum number of processes allowed in a container (default: 1024)
 
-**--disable-shared-pid-namespace**=""
-  Disable using a shared PID namespace for containers in a pod (default: false)
+**--enable-shared-pid-namespace**=""
+  Enable using a shared PID namespace for containers in a pod (default: false)
 
 **--root**=""
   The crio root dir (default: "/var/lib/containers/storage")

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -87,8 +87,8 @@ Example:
 **pids_limit**=""
   Maximum number of processes allowed in a container (default: 1024)
 
-**disable_shared_pid_namespace**=""
-  Disable using a shared PID namespace for containers in a pod (default: false)
+**enable_shared_pid_namespace**=""
+  Enable using a shared PID namespace for containers in a pod (default: false)
 
 **runtime**=""
   OCI runtime path (default: "/usr/bin/runc")

--- a/libkpod/config.go
+++ b/libkpod/config.go
@@ -121,8 +121,8 @@ type RuntimeConfig struct {
 	// NoPivot instructs the runtime to not use `pivot_root`, but instead use `MS_MOVE`
 	NoPivot bool `toml:"no_pivot"`
 
-	// DisableSharePidNamespace instructs the runtime to disable share pid namespace
-	DisableSharedPIDNamespace bool `toml:"disable_shared_pid_namespace"`
+	// EnableSharePidNamespace instructs the runtime to enable share pid namespace
+	EnableSharedPIDNamespace bool `toml:"enable_shared_pid_namespace"`
 
 	// Conmon is the path to conmon binary, used for managing the runtime.
 	Conmon string `toml:"conmon"`

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -924,7 +924,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	if containerConfig.GetLinux().GetSecurityContext().GetNamespaceOptions().GetHostPid() {
 		// kubernetes PodSpec specify to use Host PID namespace
 		specgen.RemoveLinuxNamespace(string(rspec.PIDNamespace))
-	} else if !s.config.DisableSharedPIDNamespace {
+	} else if s.config.EnableSharedPIDNamespace {
 		// share Pod PID namespace
 		pidNsPath := fmt.Sprintf("/proc/%d/ns/pid", podInfraState.Pid)
 		if err := specgen.AddOrReplaceLinuxNamespace(string(rspec.PIDNamespace), pidNsPath); err != nil {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -57,7 +57,7 @@ PIDS_LIMIT=${PIDS_LIMIT:-1024}
 # Log size max limit
 LOG_SIZE_MAX_LIMIT=${LOG_SIZE_MAX_LIMIT:--1}
 # enable share container pid namespace
-DISABLE_SHARED_PID_NAMESPACE=${DISABLE_SHARED_PID_NAMESPACE:-false}
+ENABLE_SHARED_PID_NAMESPACE=${ENABLE_SHARED_PID_NAMESPACE:-false}
 
 TESTDIR=$(mktemp -d)
 
@@ -242,7 +242,7 @@ function start_crio() {
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=mrunalp/image-volume-test --import-from=dir:"$ARTIFACTS_PATH"/image-volume-test-image --add-name=docker.io/library/mrunalp/image-volume-test --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=busybox:latest --import-from=dir:"$ARTIFACTS_PATH"/busybox-image --add-name=docker.io/library/busybox:latest --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=runcom/stderr-test:latest --import-from=dir:"$ARTIFACTS_PATH"/stderr-test --add-name=docker.io/runcom/stderr-test:latest --signature-policy="$INTEGRATION_ROOT"/policy.json
-	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --cgroup-manager "$CGROUP_MANAGER" --registry "docker.io" --runtime "$RUNTIME_BINARY" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --disable-shared-pid-namespace=${DISABLE_SHARED_PID_NAMESPACE} --log-size-max "$LOG_SIZE_MAX_LIMIT" --config /dev/null config >$CRIO_CONFIG
+	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --cgroup-manager "$CGROUP_MANAGER" --registry "docker.io" --runtime "$RUNTIME_BINARY" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --enable-shared-pid-namespace=${ENABLE_SHARED_PID_NAMESPACE} --log-size-max "$LOG_SIZE_MAX_LIMIT" --config /dev/null config >$CRIO_CONFIG
 
 	# Prepare the CNI configuration files, we're running with non host networking by default
 	if [[ -n "$4" ]]; then

--- a/test/namespaces.bats
+++ b/test/namespaces.bats
@@ -7,7 +7,7 @@ function teardown() {
 }
 
 @test "pod disable shared pid namespace" {
-	DISABLE_SHARED_PID_NAMESPACE="true" start_crio
+	ENABLE_SHARED_PID_NAMESPACE="false" start_crio
 
 	run crictl runs "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -37,7 +37,7 @@ function teardown() {
 }
 
 @test "pod enable shared pid namespace" {
-	DISABLE_SHARED_PID_NAMESPACE="false" start_crio
+	ENABLE_SHARED_PID_NAMESPACE="true" start_crio
 
 	run crictl runs "$TESTDATA"/sandbox_config.json
 	echo "$output"


### PR DESCRIPTION
We reverse the logic so that pid ns sharing is disabled by default.
@weiwei04 @rhatdan @runcom PTAL

I think we should do this because this is the direction upstream will be headed and we want to 
make this enabled explicitly. Till now all pods have run w/o this feature so enabling it should be 
left to the user to turn on by default rather than the default behavior.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>



**- What I did**
Made pid ns sharing opt-in.

**- How I did it**
Reversing the logic we merged by changing disable -> enable

**- How to verify it**
Tests pass

**- Description for the changelog**
```changelog
Disable pid namespace sharing by default and allow enabling it.
```
