### PR TITLE
Shared constants between conmon and crio

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -1,5 +1,8 @@
 package main
 
+// #include "../../conmon/config.h"
+import "C"
+
 import (
 	"context"
 	"fmt"
@@ -40,9 +43,9 @@ func validateConfig(config *server.Config) error {
 
 	}
 
-	// This needs to match the read buffer size in conmon
-	if config.LogSizeMax >= 0 && config.LogSizeMax < 8192 {
-		return fmt.Errorf("log size max should be negative or >= 8192")
+	bufSize := int64(C.BUF_SIZE)
+	if config.LogSizeMax >= 0 && config.LogSizeMax < bufSize {
+		return fmt.Errorf("log size max should be negative or >= %d", bufSize)
 	}
 	return nil
 }

--- a/conmon/config.h
+++ b/conmon/config.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#if !defined(CONFIG_H)
+#define CONFIG_H
+
+#define BUF_SIZE 8192
+#define STDIO_BUF_SIZE 8192
+
+/* stdpipe_t represents one of the std pipes (or NONE). */
+typedef enum {
+	NO_PIPE,
+	STDIN_PIPE, /* unused */
+	STDOUT_PIPE,
+	STDERR_PIPE,
+} stdpipe_t;
+
+
+#endif // CONFIG_H

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -27,6 +27,7 @@
 #include <glib-unix.h>
 
 #include "cmsg.h"
+#include "config.h"
 
 #define pexit(fmt, ...)                                                          \
 	do {                                                                     \
@@ -92,7 +93,6 @@ static inline void strv_cleanup(char ***strv)
 #define _cleanup_gstring_ _cleanup_(gstring_free_cleanup)
 #define _cleanup_strv_ _cleanup_(strv_cleanup)
 
-#define BUF_SIZE 8192
 #define CMD_SIZE 1024
 #define MAX_EVENTS 10
 
@@ -263,15 +263,6 @@ int set_k8s_timestamp(char *buf, ssize_t buflen, const char *pipename)
 		err = 0;
 	return err;
 }
-
-/* stdpipe_t represents one of the std pipes (or NONE).
- * Sync with const in container_attach.go */
-typedef enum {
-	NO_PIPE,
-	STDIN_PIPE, /* unused */
-	STDOUT_PIPE,
-	STDERR_PIPE,
-} stdpipe_t;
 
 const char *stdpipe_name(stdpipe_t pipe)
 {
@@ -581,11 +572,10 @@ static gboolean tty_hup_timeout_cb (G_GNUC_UNUSED gpointer user_data)
 
 static bool read_stdio(int fd, stdpipe_t pipe, bool *eof)
 {
-	#define STDIO_BUF_SIZE 8192 /* Sync with redirectResponseToOutputStreams() */
 	/* We use one extra byte at the start, which we don't read into, instead
 	   we use that for marking the pipe when we write to the attached socket */
 	char real_buf[STDIO_BUF_SIZE + 1];
-        char *buf = real_buf + 1;
+	char *buf = real_buf + 1;
 	ssize_t num_read = 0;
 
 	if (eof)


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>

closes #1060

**- What I did**
Shared some common constants between crio and conmon.

**- How I did it**
Grep for the common patterns I identified and then wrote a `config.h` file that has been imported where needed.

**- How to verify it**


**- Description for the changelog**
Shared constants between conmon and crio
