### PR TITLE
CI: wire in critest

### DIFF
--- a/contrib/test/integration/build/cri-tools.yml
+++ b/contrib/test/integration/build/cri-tools.yml
@@ -5,12 +5,23 @@
     repo: "https://github.com/kubernetes-incubator/cri-tools.git"
     dest: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-tools"
     version: "b42fc3f364dd48f649d55926c34492beeb9b2e99"
+    version: "{{ cri_tools_git_version }}"
+    force: "{{ force_clone | default(False) | bool}}"
 
 - name: install crictl
   command: "/usr/bin/go install github.com/kubernetes-incubator/cri-tools/cmd/crictl"
+
+- name: install critest
+  command: "/usr/bin/go install github.com/kubernetes-incubator/cri-tools/cmd/critest"
 
 - name: link crictl
   file:
     src: "{{ ansible_env.GOPATH }}/bin/crictl"
     dest: /usr/bin/crictl
+    state: link
+
+- name: link critest
+  file:
+    src: "{{ ansible_env.GOPATH }}/bin/critest"
+    dest: /usr/bin/critest
     state: link

--- a/contrib/test/integration/critest.yml
+++ b/contrib/test/integration/critest.yml
@@ -1,0 +1,48 @@
+---
+
+- name: enable and start CRI-O
+  systemd:
+    name: crio
+    state: started
+    enabled: yes
+    daemon_reload: yes
+
+- name: Flush the iptables
+  command: iptables -F
+
+- name: Enable localnet routing
+  command: sysctl -w net.ipv4.conf.all.route_localnet=1
+
+- name: Add masquerade for localhost
+  command: iptables -t nat -I POSTROUTING -s 127.0.0.1 ! -d 127.0.0.1 -j MASQUERADE
+
+  # TODO(runcom): enable skipped tests once we fix them (image list related)
+  # https://github.com/kubernetes-incubator/cri-o/issues/1048
+- name: run critest validation
+  shell: "critest -c --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock -s 'listImage should get exactly 2 repoTags in the result image' v"
+  args:
+    chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o"
+  async: 5400
+  poll: 30
+  when: ansible_distribution not in ['RedHat', 'CentOS']
+
+  # XXX: RHEL has an additional test which fails beacuse of selinux but disabling
+  # it doesn't solve the issue.
+  # TODO(runcom): enable skipped tests once we fix them (image list related and selinux)
+  # https://github.com/kubernetes-incubator/cri-o/issues/1048
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1414236
+  # https://access.redhat.com/solutions/2897781
+- name: run critest validation
+  shell: "critest -c --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock -s 'listImage should get exactly 2 repoTags in the result image|should not allow privilege escalation when true' v"
+  args:
+    chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o"
+  async: 5400
+  poll: 30
+  when: ansible_distribution in ['RedHat', 'CentOS']
+
+- name: run critest benchmarks
+  shell: "critest -c --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock b"
+  args:
+    chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o"
+  async: 5400
+  poll: 30

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -18,6 +18,8 @@
 
     - name: clone build and install cri-tools
       include: "build/cri-tools.yml"
+      vars:
+        cri_tools_git_version: "b42fc3f364dd48f649d55926c34492beeb9b2e99"
 
     - name: clone build and install kubernetes
       include: "build/kubernetes.yml"
@@ -48,6 +50,11 @@
   tags:
     - integration
   tasks:
+    - name: clone build and install cri-tools
+      include: "build/cri-tools.yml"
+      vars:
+        force_clone: True
+        cri_tools_git_version: "d9476a4d8632da6c28bf272018a0b9e059c3542f"
     - name: run cri-o integration tests
       include: test.yml
 
@@ -62,11 +69,17 @@
       include: golang.yml
       vars:
           version: "1.9.2"
+    - name: setup critest
+      include: "build/cri-tools.yml"
+      vars:
+          force_clone: True
+          cri_tools_git_version: "d9476a4d8632da6c28bf272018a0b9e059c3542f"
+    - name: run critest validation and benchmarks
+      include: critest.yml
     - name: clone build and install kubernetes
       include: "build/kubernetes.yml"
       vars:
           force_clone: True
           k8s_git_version: "cri-o-patched-1.9"
-
     - name: run k8s e2e tests
       include: e2e.yml

--- a/contrib/test/integration/test.yml
+++ b/contrib/test/integration/test.yml
@@ -1,8 +1,5 @@
 ---
 
-- name: clone build and install cri-tools
-  include: "build/cri-tools.yml"
-
 - name: Make testing output verbose so it can be converted to xunit
   lineinfile:
     dest: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes/hack/make-rules/test.sh"


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

run `critest` validation _before_ the e2e kube tests. If `critest` fails, there would be no need to trigger the whole e2e.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
