### PR TITLE
share pid namespace for Pod container

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -115,6 +115,9 @@ default_mounts = [
 # pids_limit is the number of processes allowed in a container
 pids_limit = {{ .PidsLimit }}
 
+# enable using a shared PID namespace for containers in a pod
+enable_shared_pid_namespace = {{ .EnableSharedPIDNamespace }}
+
 # log_size_max is the max limit for the container log size in bytes.
 # Negative values indicate that no limit is imposed.
 log_size_max = {{ .LogSizeMax }}

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -131,6 +131,9 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("pids-limit") {
 		config.PidsLimit = ctx.GlobalInt64("pids-limit")
 	}
+	if ctx.GlobalIsSet("enable-shared-pid-namespace") {
+		config.EnableSharedPIDNamespace = ctx.GlobalBool("enable-shared-pid-namespace")
+	}
 	if ctx.GlobalIsSet("log-size-max") {
 		config.LogSizeMax = ctx.GlobalInt64("log-size-max")
 	}
@@ -295,6 +298,10 @@ func main() {
 			Name:  "pids-limit",
 			Value: libkpod.DefaultPidsLimit,
 			Usage: "maximum number of processes allowed in a container",
+		},
+		cli.BoolFlag{
+			Name:  "enable-shared-pid-namespace",
+			Usage: "enable using a shared PID namespace for containers in a pod",
 		},
 		cli.Int64Flag{
 			Name:  "log-size-max",

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -118,6 +118,9 @@ set the CPU profile file path
 **--pids-limit**=""
   Maximum number of processes allowed in a container (default: 1024)
 
+**--enable-shared-pid-namespace**=""
+  Enable using a shared PID namespace for containers in a pod (default: false)
+
 **--root**=""
   The crio root dir (default: "/var/lib/containers/storage")
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -87,6 +87,9 @@ Example:
 **pids_limit**=""
   Maximum number of processes allowed in a container (default: 1024)
 
+**enable_shared_pid_namespace**=""
+  Enable using a shared PID namespace for containers in a pod (default: false)
+
 **runtime**=""
   OCI runtime path (default: "/usr/bin/runc")
 

--- a/libkpod/config.go
+++ b/libkpod/config.go
@@ -121,6 +121,9 @@ type RuntimeConfig struct {
 	// NoPivot instructs the runtime to not use `pivot_root`, but instead use `MS_MOVE`
 	NoPivot bool `toml:"no_pivot"`
 
+	// EnableSharePidNamespace instructs the runtime to enable share pid namespace
+	EnableSharedPIDNamespace bool `toml:"enable_shared_pid_namespace"`
+
 	// Conmon is the path to conmon binary, used for managing the runtime.
 	Conmon string `toml:"conmon"`
 

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -921,9 +921,15 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		return nil, err
 	}
 
-	// Do not share pid ns for now
 	if containerConfig.GetLinux().GetSecurityContext().GetNamespaceOptions().GetHostPid() {
+		// kubernetes PodSpec specify to use Host PID namespace
 		specgen.RemoveLinuxNamespace(string(rspec.PIDNamespace))
+	} else if s.config.EnableSharedPIDNamespace {
+		// share Pod PID namespace
+		pidNsPath := fmt.Sprintf("/proc/%d/ns/pid", podInfraState.Pid)
+		if err := specgen.AddOrReplaceLinuxNamespace(string(rspec.PIDNamespace), pidNsPath); err != nil {
+			return nil, err
+		}
 	}
 
 	netNsPath := sb.NetNsPath()

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -56,6 +56,8 @@ IMAGE_VOLUMES=${IMAGE_VOLUMES:-mkdir}
 PIDS_LIMIT=${PIDS_LIMIT:-1024}
 # Log size max limit
 LOG_SIZE_MAX_LIMIT=${LOG_SIZE_MAX_LIMIT:--1}
+# enable share container pid namespace
+ENABLE_SHARED_PID_NAMESPACE=${ENABLE_SHARED_PID_NAMESPACE:-false}
 
 TESTDIR=$(mktemp -d)
 
@@ -240,7 +242,7 @@ function start_crio() {
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=mrunalp/image-volume-test --import-from=dir:"$ARTIFACTS_PATH"/image-volume-test-image --add-name=docker.io/library/mrunalp/image-volume-test --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=busybox:latest --import-from=dir:"$ARTIFACTS_PATH"/busybox-image --add-name=docker.io/library/busybox:latest --signature-policy="$INTEGRATION_ROOT"/policy.json
 	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=runcom/stderr-test:latest --import-from=dir:"$ARTIFACTS_PATH"/stderr-test --add-name=docker.io/runcom/stderr-test:latest --signature-policy="$INTEGRATION_ROOT"/policy.json
-	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --cgroup-manager "$CGROUP_MANAGER" --registry "docker.io" --runtime "$RUNTIME_BINARY" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --log-size-max "$LOG_SIZE_MAX_LIMIT" --config /dev/null config >$CRIO_CONFIG
+	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --cgroup-manager "$CGROUP_MANAGER" --registry "docker.io" --runtime "$RUNTIME_BINARY" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --enable-shared-pid-namespace=${ENABLE_SHARED_PID_NAMESPACE} --log-size-max "$LOG_SIZE_MAX_LIMIT" --config /dev/null config >$CRIO_CONFIG
 
 	# Prepare the CNI configuration files, we're running with non host networking by default
 	if [[ -n "$4" ]]; then

--- a/test/namespaces.bats
+++ b/test/namespaces.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function teardown() {
+	cleanup_test
+}
+
+@test "pod disable shared pid namespace" {
+	ENABLE_SHARED_PID_NAMESPACE="false" start_crio
+
+	run crictl runs "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+	run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run crictl start "$ctr_id"
+	[ "$status" -eq 0 ]
+
+	run crictl exec --sync "$ctr_id" cat /proc/1/cmdline
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "redis" ]]
+
+	run crictl stops "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crictl rms "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}
+
+@test "pod enable shared pid namespace" {
+	ENABLE_SHARED_PID_NAMESPACE="true" start_crio
+
+	run crictl runs "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+	run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run crictl start "$ctr_id"
+	[ "$status" -eq 0 ]
+
+	run crictl exec --sync "$ctr_id" cat /proc/1/cmdline
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "pause" ]]
+
+	run crictl stops "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crictl rms "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}


### PR DESCRIPTION
Signed-off-by: Wei Wei <weiwei.inf@gmail.com>

Make pid namespace sharing optional and disabled by default

We reverse the logic so that pid ns sharing is disabled by default.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>


**- What I did**
Ported pid ns sharing support to release-1.8

**- How I did it**
Squashing the 2 commits in master.

**- How to verify it**
All tests pass.

**- Description for the changelog**
```changlog
Add support for pid ns sharing.
```
