### PR TITLE
Add /proc/scsi to masked paths

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -889,6 +889,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 				"/proc/timer_list",
 				"/proc/timer_stats",
 				"/proc/sched_debug",
+				"/proc/scsi",
 				"/sys/firmware",
 			} {
 				specgen.AddLinuxMaskedPaths(mp)


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
