### PR TITLE
[release-1.0] Add /proc/scsi to masked paths

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -788,6 +788,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 				"/proc/timer_list",
 				"/proc/timer_stats",
 				"/proc/sched_debug",
+				"/proc/scsi",
 				"/sys/firmware",
 			} {
 				specgen.AddLinuxMaskedPaths(mp)

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.0.5-dev"
+const Version = "1.0.5"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.0.5"
+const Version = "1.0.6-dev"


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
