### PR TITLE
contrib: parametrize the crio socket for kube

### DIFF
--- a/contrib/test/integration/build/kubernetes.yml
+++ b/contrib/test/integration/build/kubernetes.yml
@@ -40,7 +40,7 @@
       export PATH=/usr/local/go/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/root/bin:{{ ansible_env.GOPATH }}/bin:{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes/third_party/etcd:{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes/_output/local/bin/linux/amd64/
       export CONTAINER_RUNTIME=remote
       export CGROUP_DRIVER=systemd
-      export CONTAINER_RUNTIME_ENDPOINT='/var/run/crio/crio.sock --runtime-request-timeout=5m'
+      export CONTAINER_RUNTIME_ENDPOINT='{{ crio_socket }} --runtime-request-timeout=5m'
       export ALLOW_SECURITY_CONTEXT=","
       export ALLOW_PRIVILEGED=1
       export DNS_SERVER_IP={{ ansible_eth0.ipv4.address }}

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -25,6 +25,7 @@
       include: "build/kubernetes.yml"
       vars:
         k8s_git_version: "cri-o-node-e2e-patched-logs"
+        crio_socket: "/var/run/crio.sock"
 
     - name: clone build and install runc
       include: "build/runc.yml"
@@ -81,5 +82,6 @@
       vars:
           force_clone: True
           k8s_git_version: "cri-o-patched-1.9"
+          crio_socket: "/var/run/crio/crio.sock"
     - name: run k8s e2e tests
       include: e2e.yml


### PR DESCRIPTION
This is needed for the 1.0 branch where we're still using `/var/run/crio.sock`. It happened that w/o this, the ami nightly builds built with the wrong socket, we need this so we have 1.0 back to normal.

@mrunalp PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>