### PR TITLE
Set verion info using -ldflags -X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ PACKAGES ?= $(shell go list -tags "${BUILDTAGS}" ./... | grep -v github.com/kube
 COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
 BUILD_INFO := $(shell date +%s)
+VERSION := $(shell git describe --tags --always --dirty)
 
 # If GOPATH not specified, use one in the local directory
 ifeq ($(GOPATH),)
@@ -31,11 +32,12 @@ unexport GOBIN
 endif
 GOPKGDIR := $(GOPATH)/src/$(PROJECT)
 GOPKGBASEDIR := $(shell dirname "$(GOPKGDIR)")
+VERSION_PATH := $(PROJECT)/version.Version
 
 # Update VPATH so make finds .gopathok
 VPATH := $(VPATH):$(GOPATH)
 SHRINKFLAGS := -s -w
-BASE_LDFLAGS := ${SHRINKFLAGS} -X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${BUILD_INFO}
+BASE_LDFLAGS := ${SHRINKFLAGS} -X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${BUILD_INFO} -X ${VERSION_PATH}=${VERSION}
 LDFLAGS := -ldflags '${BASE_LDFLAGS}'
 
 all: binaries crio.conf docs

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-// Version is the version of the build.
-const Version = "1.9.0-dev"
+// Version is the app-global version string, which should be substituted with a real value during build.
+var Version = "UNKNOWN"


### PR DESCRIPTION

#### What I did
Set verion info using `-ldflags -X`
#### How I did it
modify `Makefile` and `version/version.go`,  set verion info using `-ldflags -X`.
#### How to verify it
**First**,  build this project
```
make
```
**Second**, run
```
root@vv-node2:/home/k8s/cri-o# ./bin/crio --version
crio version v1.8.0-37-g8404366
commit: "8404366d9ac08b576b884f27d3d7e325ec7a8ed7"
```
#### Description for the changelog
Set verion info using -ldflags -X