### PR TITLE
CI: drop git-validation as it's never used

### DIFF
--- a/contrib/test/integration/golang.yml
+++ b/contrib/test/integration/golang.yml
@@ -52,5 +52,4 @@
     - onsi/gomega
     - cloudflare/cfssl/cmd/...
     - jteeuwen/go-bindata/go-bindata
-    - vbatts/git-validation
     - cpuguy83/go-md2man


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
