### PR TITLE
Bump up go version to 1.8.5

### DIFF
--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -11,7 +11,7 @@
     - name: install Golang tools
       include: golang.yml
       vars:
-        version: "1.8.4"
+        version: "1.8.5"
 
     - name: clone build and install bats
       include: "build/bats.yml"


### PR DESCRIPTION
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>



**- What I did**
Updated golang to 1.8.5

**- How I did it**
Modifying the version in ansible.

**- How to verify it**
Tests pass.

**- Description for the changelog**
```
Bump up go to 1.8.5 in tests.
```
