### PR TITLE
Bump v1.0.7

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.0.7"
+const Version = "1.0.8-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.0.7-dev"
+const Version = "1.0.7"


### PR DESCRIPTION
Welcome to the release of CRI-O v1.0.7!


This new CRI-O patch release fixes a bug in how we were setting container
environment variables when exec'ing into it.

Please try out the release binaries and report any issues at
https://github.com/kubernetes-incubator/cri-o/issues.



### Contributors

* Antonio Murdaca
* Daniel J Walsh
* Mrunal Patel

### Changes

* 7a3e37e25 version: bump to v1.0.7
* eb8df9518 Merge pull request #1187 from runcom/fixups-env-1.7
* 762cb4cca test: add exec/execsync env conflict test
* cc0f78dfc container_create: correctly set image and kube envs
* e4470612a oci: do not append conmon env to container process
* 3a36f553a container_exec: use process file with runc exec
* c30571b43 Merge pull request #1182 from runcom/fix-image-pull-v1
* 327c67318 version: bump to v1.0.7-dev

### Dependency Changes

Previous release can be found at [v1.0.6](https://github.com/kubernetes-incubator/cri-o/releases/tag/v1.0.6)