### PR TITLE
Bump v1.8.3

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.8.3"
+const Version = "1.8.4-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.8.3-dev"
+const Version = "1.8.3"


### PR DESCRIPTION
Welcome to the release of CRI-O v1.8.3!


This new CRI-O patch release fixes a bug in how we were setting container
environment variables when exec'ing into it.

Please try out the release binaries and report any issues at
https://github.com/kubernetes-incubator/cri-o/issues.



### Contributors

* Antonio Murdaca
* Mrunal Patel

### Changes

* d9922a9db version: bump to v1.8.3
* 187876571 Merge pull request #1191 from runcom/fix-apparmor-1.8
* 6a9c6b182 Merge pull request #1188 from runcom/fixups-env-1.8
* b2ea67f50 container_create: fix apparmor from container config
* 17ec00c5d test: add exec/execsync env conflict test
* bb327bc3a container_create: correctly set image and kube envs
* 4cde51526 oci: do not append conmon env to container process
* 99b3e82fa container_exec: use process file with runc exec
* 171e31287 Merge pull request #1180 from runcom/fix-image-pull
* 2438f4825 version: bump to v1.8.3-dev

### Dependency Changes

Previous release can be found at [v1.8.2](https://github.com/kubernetes-incubator/cri-o/releases/tag/v1.8.2)

