### PR TITLE
Only parse stdout from "state" command.  Ignore stderr.

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -669,7 +669,7 @@ func (r *Runtime) SetStartFailed(c *Container, err error) {
 func (r *Runtime) UpdateStatus(c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
-	out, err := exec.Command(r.Path(c), "state", c.id).CombinedOutput()
+	out, err := exec.Command(r.Path(c), "state", c.id).Output()
 	if err != nil {
 		// there are many code paths that could lead to have a bad state in the
 		// underlying runtime.


### PR DESCRIPTION
Some oci runtimes may used stderr for logging.  Cri-o should not try to parse this output as json when calling the "state" command.

**- What I did**
Use `cmd.Output` (which only includes stdout) instead of `cmd.CombinedOutput` (which combines stdout and stderr).

**- Description**
Only parse stdout from "state" command.  Ignore stderr.
