### PR TITLE
container_exec: fix terminal true process json

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -423,15 +423,6 @@ func (r *Runtime) ExecSync(c *Container, command []string, timeout int64) (resp 
 		os.RemoveAll(logPath)
 	}()
 
-	f, err := ioutil.TempFile("", "exec-sync-process")
-	if err != nil {
-		return nil, ExecSyncError{
-			ExitCode: -1,
-			Err:      err,
-		}
-	}
-	defer os.RemoveAll(f.Name())
-
 	var args []string
 	args = append(args, "-c", c.id)
 	args = append(args, "-r", r.Path(c))
@@ -447,24 +438,16 @@ func (r *Runtime) ExecSync(c *Container, command []string, timeout int64) (resp 
 	args = append(args, "-l", logPath)
 	args = append(args, "--socket-dir-path", ContainerAttachSocketDir)
 
-	pspec := c.Spec().Process
-	pspec.Args = command
-	processJSON, err := json.Marshal(pspec)
+	processFile, err := PrepareProcessExec(c, command, false)
 	if err != nil {
 		return nil, ExecSyncError{
 			ExitCode: -1,
 			Err:      err,
 		}
 	}
+	defer os.RemoveAll(processFile.Name())
 
-	if err := ioutil.WriteFile(f.Name(), processJSON, 0644); err != nil {
-		return nil, ExecSyncError{
-			ExitCode: -1,
-			Err:      err,
-		}
-	}
-
-	args = append(args, "--exec-process-spec", f.Name())
+	args = append(args, "--exec-process-spec", processFile.Name())
 
 	cmd := exec.Command(r.conmonPath, args...)
 
@@ -771,4 +754,28 @@ func (r *Runtime) UnpauseContainer(c *Container) error {
 	defer c.opLock.Unlock()
 	_, err := utils.ExecCmd(r.Path(c), "resume", c.id)
 	return err
+}
+
+// PrepareProcessExec returns the path of the process.json used in runc exec -p
+// caller is responsible to close the returned *os.File if needed.
+func PrepareProcessExec(c *Container, cmd []string, tty bool) (*os.File, error) {
+	f, err := ioutil.TempFile("", "exec-process-")
+	if err != nil {
+		return nil, err
+	}
+
+	pspec := c.Spec().Process
+	pspec.Args = cmd
+	if tty {
+		pspec.Terminal = true
+	}
+	processJSON, err := json.Marshal(pspec)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ioutil.WriteFile(f.Name(), processJSON, 0644); err != nil {
+		return nil, err
+	}
+	return f, nil
 }


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed and refactored the way we're calling runc exec in container_exec. This patch is fixing a bug where kube requests the terminal for exec but we're not honoring it.

**- How I did it**

set terminal in runc exec's process json

**- How to verify it**

run `kubectl exec -ti POD -- sh` and see it works, Before this patch, it would just hang.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
