### PR TITLE
Bump v1.0.8

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.0.8"
+const Version = "1.0.9-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.0.8-dev"
+const Version = "1.0.8"


### PR DESCRIPTION
@mrunalp PTAL, we need to tag `v1.0.8` afterwards (I've already tagged `v1.8.4`)