### PR TITLE
Support leaving stdin open

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -99,6 +99,7 @@ static inline void strv_cleanup(char ***strv)
 
 static bool opt_terminal = false;
 static bool opt_stdin = false;
+static bool opt_leave_stdin_open = false;
 static char *opt_cid = NULL;
 static char *opt_cuuid = NULL;
 static char *opt_runtime_path = NULL;
@@ -117,6 +118,7 @@ static GOptionEntry opt_entries[] =
 {
   { "terminal", 't', 0, G_OPTION_ARG_NONE, &opt_terminal, "Terminal", NULL },
   { "stdin", 'i', 0, G_OPTION_ARG_NONE, &opt_stdin, "Stdin", NULL },
+  { "leave-stdin-open", 0, 0, G_OPTION_ARG_NONE, &opt_leave_stdin_open, "Leave stdin open when attached client disconnects", NULL },
   { "cid", 'c', 0, G_OPTION_ARG_STRING, &opt_cid, "Container ID", NULL },
   { "cuuid", 'u', 0, G_OPTION_ARG_STRING, &opt_cuuid, "Container UUID", NULL },
   { "runtime", 'r', 0, G_OPTION_ARG_STRING, &opt_runtime_path, "Runtime path", NULL },
@@ -755,8 +757,12 @@ static gboolean conn_sock_cb(int fd, GIOCondition condition, G_GNUC_UNUSED gpoin
 	/* End of input */
 	conn_sock_shutdown(SHUT_RD);
 	if (masterfd_stdin >= 0 && opt_stdin) {
-		close(masterfd_stdin);
-		masterfd_stdin = -1;
+		if (!opt_leave_stdin_open) {
+			close(masterfd_stdin);
+			masterfd_stdin = -1;
+		} else {
+			ninfo("Not closing input");
+		}
 	}
 	return G_SOURCE_REMOVE;
 }

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -189,6 +189,9 @@ func (r *Runtime) CreateContainer(c *Container, cgroupParent string) (err error)
 	if c.terminal {
 		args = append(args, "-t")
 	} else if c.stdin {
+		if !c.stdinOnce {
+			args = append(args, "--leave-stdin-open")
+		}
 		args = append(args, "-i")
 	}
 	logrus.WithFields(logrus.Fields{


### PR DESCRIPTION
This is triggered by StdinOnce set to false by the kubelet.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>



**- What I did**
Added support for leaving container stdin open after attach client disconnects.

**- How I did it**
Added an option to conmon to leave stdin open and hooked it up with StdinOnce setting
passed over the CRI.

**- How to verify it**
The kubectl tests pass. 

**- Description for the changelog**
```
Support leaving the stdin open.
```
