### PR TITLE
Add default registry

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -509,7 +509,7 @@ func main() {
 				if graceful && strings.Contains(strings.ToLower(err.Error()), "use of closed network connection") {
 					err = nil
 				} else {
-					logrus.Errorf("Failed to serve grpc grpc request: %v", err)
+					logrus.Errorf("Failed to serve grpc request: %v", err)
 				}
 			}
 		}()

--- a/lib/config.go
+++ b/lib/config.go
@@ -24,6 +24,7 @@ const (
 	cgroupManager       = oci.CgroupfsCgroupsManager
 	lockPath            = "/run/crio.lock"
 	containerExitsDir   = oci.ContainerExitsDir
+	defaultRegistry     = "docker.io"
 )
 
 // Config represents the entire set of configuration values that can be set for
@@ -302,6 +303,7 @@ func DefaultConfig() *Config {
 			PauseCommand:        pauseCommand,
 			SignaturePolicyPath: "",
 			ImageVolumes:        ImageVolumesMkdir,
+			Registries:          []string{defaultRegistry},
 		},
 		NetworkConfig: NetworkConfig{
 			NetworkDir: cniConfigDir,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
When I follow the guide[0] to create a container in a sandbox, I get the error:
sudo crictl  --runtime-endpoint /var/run/crio.sock pull redis:alpine              
FATA[0000] pulling image failed: rpc error: code = Unknown desc = no registries configured while trying to pull an unqualified image

and I see the default config for the registry is a empty list, I'd like at list to add the "docker.io" to the list as  a default value.


[0]https://github.com/kubernetes-incubator/cri-o/blob/master/tutorial.md#create-a-redis-container-inside-the-pod
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
