### PR TITLE
[release-1.9] lib,oci: drop stateLock when possible

### DIFF
--- a/lib/sandbox/memory_store.go
+++ b/lib/sandbox/memory_store.go
@@ -25,8 +25,9 @@ func (c *memoryStore) Add(id string, cont *Sandbox) {
 
 // Get returns a sandbox from the store by id.
 func (c *memoryStore) Get(id string) *Sandbox {
+	var res *Sandbox
 	c.RLock()
-	res := c.s[id]
+	res = c.s[id]
 	c.RUnlock()
 	return res
 }

--- a/oci/memory_store.go
+++ b/oci/memory_store.go
@@ -25,8 +25,9 @@ func (c *memoryStore) Add(id string, cont *Container) {
 
 // Get returns a container from the store by id.
 func (c *memoryStore) Get(id string) *Container {
+	var res *Container
 	c.RLock()
-	res := c.s[id]
+	res = c.s[id]
 	c.RUnlock()
 	return res
 }


### PR DESCRIPTION
Should fix a possible deadlock in, at least, ListPodSandbox.
There seems to be no reason to hold stateLock when doing operations on
the memory_store for containers and sandboxes.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
