### PR TITLE
conmon needs to support --detach and non --detach mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,15 @@ language: go
 
 sudo: required
 
+matrix:
+  # If the latest unstable development version of go fails, that's OK.
+  allow_failures:
+    - go: tip
+
+  # Don't hold on the tip tests to finish.  Mark tests green if the
+  # stable versions pass.
+  fast_finish: true
+
 services:
   - docker
 

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -109,6 +109,7 @@ static bool opt_systemd_cgroup = false;
 static bool opt_no_pivot = false;
 static char *opt_exec_process_spec = NULL;
 static bool opt_exec = false;
+static bool opt_detach = false;
 static char *opt_log_path = NULL;
 static char *opt_exit_dir = NULL;
 static int opt_timeout = 0;
@@ -126,6 +127,7 @@ static GOptionEntry opt_entries[] =
   { "pidfile", 'p', 0, G_OPTION_ARG_STRING, &opt_pid_file, "PID file", NULL },
   { "systemd-cgroup", 's', 0, G_OPTION_ARG_NONE, &opt_systemd_cgroup, "Enable systemd cgroup manager", NULL },
   { "exec", 'e', 0, G_OPTION_ARG_NONE, &opt_exec, "Exec a command in a running container", NULL },
+  { "detach", 'd', 0, G_OPTION_ARG_NONE, &opt_detach, "When execing into the container do so in detached mode", NULL },
   { "exec-process-spec", 0, 0, G_OPTION_ARG_STRING, &opt_exec_process_spec, "Path to the process spec for exec", NULL },
   { "exit-dir", 0, 0, G_OPTION_ARG_STRING, &opt_exit_dir, "Path to the directory where exit files are written", NULL },
   { "log-path", 'l', 0, G_OPTION_ARG_STRING, &opt_log_path, "Log file path", NULL },
@@ -1250,10 +1252,17 @@ int main(int argc, char *argv[])
 			 NULL);
 
 	if (opt_exec) {
-		add_argv(runtime_argv,
-			 "exec", "-d",
+		if (opt_detach) {
+			add_argv(runtime_argv,
+			 "exec", "-d"
 			 "--pid-file", opt_pid_file,
 			 NULL);
+		} else {
+			add_argv(runtime_argv,
+			 "exec",
+			 "--pid-file", opt_pid_file,
+			 NULL);
+		}
         } else {
 		add_argv(runtime_argv,
 			 "create",

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -172,6 +172,7 @@ func (r *Runtime) CreateContainer(c *Container, cgroupParent string) (err error)
 	if r.cgroupManager == SystemdCgroupsManager {
 		args = append(args, "-s")
 	}
+	args = append(args, "-d")
 	args = append(args, "-c", c.id)
 	args = append(args, "-u", c.id)
 	args = append(args, "-r", r.Path(c))
@@ -427,7 +428,7 @@ func (r *Runtime) ExecSync(c *Container, command []string, timeout int64) (resp 
 	args = append(args, "-c", c.id)
 	args = append(args, "-r", r.Path(c))
 	args = append(args, "-p", pidFile.Name())
-	args = append(args, "-e")
+	args = append(args, "-e", "-d")
 	if c.terminal {
 		args = append(args, "-t")
 	}


### PR DESCRIPTION
In kpod exec we want to maintain the tty with the container.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
