### PR TITLE
Report an warning when no stages are defined for a hook

### DIFF
--- a/lib/hooks.go
+++ b/lib/hooks.go
@@ -53,9 +53,13 @@ func readHook(hookPath string) (HookParams, error) {
 			return hook, errors.Wrapf(err, "invalid cmd regular expression %q defined in hook config %q", cmd, hookPath)
 		}
 	}
-	for _, stage := range hook.Stage {
-		if !validStage[stage] {
-			return hook, errors.Wrapf(err, "unknown stage %q defined in hook config %q", stage, hookPath)
+	if len(hook.Stage) == 0 {
+		logrus.Warnf("No stage defined in hook config %q, hook will never run", hookPath)
+	} else {
+		for _, stage := range hook.Stage {
+			if !validStage[stage] {
+				return hook, errors.Wrapf(err, "unknown stage %q defined in hook config %q", stage, hookPath)
+			}
 		}
 	}
 	return hook, nil


### PR DESCRIPTION
We accidently defined hooks using stages rather then stage,
which causes all of the hooks not to work, but we saw no
complaints in the log files about this.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
