### PR TITLE
Add bsdmainutils tool to Dockerfile to enable integration test on arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y \
     netcat \
     socat \
     --no-install-recommends \
+    bsdmainutils \
     && apt-get clean
 
 # install bats


### PR DESCRIPTION
Build image for integration test on arm64 will fail for lack of
hexdump. Add bsdmainutils tool to eliminate that failure and let
build image succussfully
help me check it  @redbaron @mumoshu  @runcom @mrunalp  
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
