### PR TITLE
contrib: system containers read env from /etc/sysconfig/crio-(network|storage)

### DIFF
--- a/contrib/system_containers/centos/run.sh
+++ b/contrib/system_containers/centos/run.sh
@@ -5,4 +5,7 @@ PID=$$
 LABEL=`tr -d '\000' < /proc/$PID/attr/current`
 printf %s $LABEL > /proc/self/attr/exec
 
+test -e /etc/sysconfig/crio-storage && source /etc/sysconfig/crio-storage
+test -e /etc/sysconfig/crio-network && source /etc/sysconfig/crio-network
+
 exec /usr/bin/crio --log-level=$LOG_LEVEL

--- a/contrib/system_containers/fedora/run.sh
+++ b/contrib/system_containers/fedora/run.sh
@@ -5,4 +5,7 @@ PID=$$
 LABEL=`tr -d '\000' < /proc/$PID/attr/current`
 printf %s $LABEL > /proc/self/attr/exec
 
+test -e /etc/sysconfig/crio-storage && source /etc/sysconfig/crio-storage
+test -e /etc/sysconfig/crio-network && source /etc/sysconfig/crio-network
+
 exec /usr/bin/crio --log-level=$LOG_LEVEL

--- a/contrib/system_containers/rhel/run.sh
+++ b/contrib/system_containers/rhel/run.sh
@@ -5,4 +5,7 @@ PID=$$
 LABEL=`tr -d '\000' < /proc/$PID/attr/current`
 printf %s $LABEL > /proc/self/attr/exec
 
+test -e /etc/sysconfig/crio-storage && source /etc/sysconfig/crio-storage
+test -e /etc/sysconfig/crio-network && source /etc/sysconfig/crio-network
+
 exec /usr/bin/crio --log-level=$LOG_LEVEL


### PR DESCRIPTION
System containers read environment variables from the `/etc/sysconfig/crio-storage` and
`/etc/sysconfig/crio-network` files in the same way as the systemd service file does on the host.

**- Description for the changelog**

- system containers honor `/etc/sysconfig/crio-storage` and `/etc/sysconfig/crio-network` configuration files.
