### PR TITLE
Add methods for listing and fetching container stats

### DIFF
--- a/lib/stats.go
+++ b/lib/stats.go
@@ -15,8 +15,8 @@ import (
 type ContainerStats struct {
 	Container   string
 	CPU         float64
-	cpuNano     uint64
-	systemNano  uint64
+	CPUNano     uint64
+	SystemNano  int64
 	MemUsage    uint64
 	MemLimit    uint64
 	MemPerc     float64
@@ -29,8 +29,8 @@ type ContainerStats struct {
 
 // GetContainerStats gets the running stats for a given container
 func (c *ContainerServer) GetContainerStats(ctr *oci.Container, previousStats *ContainerStats) (*ContainerStats, error) {
-	previousCPU := previousStats.cpuNano
-	previousSystem := previousStats.systemNano
+	previousCPU := previousStats.CPUNano
+	previousSystem := previousStats.SystemNano
 	libcontainerStats, err := c.LibcontainerStats(ctr)
 	if err != nil {
 		return nil, err
@@ -38,6 +38,8 @@ func (c *ContainerServer) GetContainerStats(ctr *oci.Container, previousStats *C
 	cgroupStats := libcontainerStats.CgroupStats
 	stats := new(ContainerStats)
 	stats.Container = ctr.ID()
+	stats.CPUNano = cgroupStats.CpuStats.CpuUsage.TotalUsage
+	stats.SystemNano = time.Now().UnixNano()
 	stats.CPU = calculateCPUPercent(libcontainerStats, previousCPU, previousSystem)
 	stats.MemUsage = cgroupStats.MemoryStats.Usage.Usage
 	stats.MemLimit = getMemLimit(cgroupStats.MemoryStats.Usage.Limit)
@@ -84,11 +86,11 @@ func getContainerNetIO(stats *libcontainer.Stats) (received uint64, transmitted 
 	return
 }
 
-func calculateCPUPercent(stats *libcontainer.Stats, previousCPU, previousSystem uint64) float64 {
+func calculateCPUPercent(stats *libcontainer.Stats, previousCPU uint64, previousSystem int64) float64 {
 	var (
 		cpuPercent  = 0.0
 		cpuDelta    = float64(stats.CgroupStats.CpuStats.CpuUsage.TotalUsage - previousCPU)
-		systemDelta = float64(uint64(time.Now().UnixNano()) - previousSystem)
+		systemDelta = float64(uint64(time.Now().UnixNano()) - uint64(previousSystem))
 	)
 	if systemDelta > 0.0 && cpuDelta > 0.0 {
 		// gets a ratio of container cpu usage total, multiplies it by the number of cores (4 cores running

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -30,9 +30,7 @@ func filterContainer(c *pb.Container, filter *pb.ContainerFilter) bool {
 
 // filterContainerList applies a protobuf-defined filter to retrieve only intended containers. Not matching
 // the filter is not considered an error but will return an empty response.
-func (s *Server) filterContainerList(filter *pb.ContainerFilter, origCtrList []*oci.Container) (ctrList []*oci.Container, err error) {
-	ctrList = origCtrList
-
+func (s *Server) filterContainerList(filter *pb.ContainerFilter, origCtrList []*oci.Container) []*oci.Container {
 	// Filter using container id and pod id first.
 	if filter.Id != "" {
 		id, err := s.CtrIDIndex().Get(filter.Id)
@@ -40,32 +38,26 @@ func (s *Server) filterContainerList(filter *pb.ContainerFilter, origCtrList []*
 			// If we don't find a container ID with a filter, it should not
 			// be considered an error.  Log a warning and return an empty struct
 			logrus.Warn("unable to find container ID %s", filter.Id)
-			return []*oci.Container{}, nil
+			return []*oci.Container{}
 		}
 		c := s.ContainerServer.GetContainer(id)
 		if c != nil {
-			if filter.PodSandboxId != "" {
-				if c.Sandbox() == filter.PodSandboxId {
-					ctrList = []*oci.Container{c}
-				} else {
-					ctrList = []*oci.Container{}
-				}
-
-			} else {
-				ctrList = []*oci.Container{c}
+			if filter.PodSandboxId == "" || c.Sandbox() == filter.PodSandboxId {
+				return []*oci.Container{}
 			}
+			return []*oci.Container{c}
 		}
 	} else {
 		if filter.PodSandboxId != "" {
 			pod := s.ContainerServer.GetSandbox(filter.PodSandboxId)
 			if pod == nil {
-				ctrList = []*oci.Container{}
+				return []*oci.Container{}
 			} else {
-				ctrList = pod.Containers().List()
+				return pod.Containers().List()
 			}
 		}
 	}
-	return
+	return origCtrList
 }
 
 // ListContainers lists all containers by filters.
@@ -85,10 +77,7 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 	}
 
 	if filter != nil {
-		ctrList, err = s.filterContainerList(filter, ctrList)
-		if err != nil {
-			return nil, err
-		}
+		ctrList = s.filterContainerList(filter, ctrList)
 	}
 
 	for _, ctr := range ctrList {

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -42,21 +42,25 @@ func (s *Server) filterContainerList(filter *pb.ContainerFilter, origCtrList []*
 		}
 		c := s.ContainerServer.GetContainer(id)
 		if c != nil {
-			if filter.PodSandboxId == "" || c.Sandbox() == filter.PodSandboxId {
+			switch {
+			case filter.PodSandboxId == "":
+				return []*oci.Container{c}
+			case c.Sandbox() == filter.PodSandboxId:
+				return []*oci.Container{c}
+			default:
 				return []*oci.Container{}
 			}
-			return []*oci.Container{c}
 		}
 	} else {
 		if filter.PodSandboxId != "" {
 			pod := s.ContainerServer.GetSandbox(filter.PodSandboxId)
 			if pod == nil {
 				return []*oci.Container{}
-			} else {
-				return pod.Containers().List()
 			}
+			return pod.Containers().List()
 		}
 	}
+	logrus.Debug("no filters were applied, returning full container list")
 	return origCtrList
 }
 

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -30,7 +30,9 @@ func filterContainer(c *pb.Container, filter *pb.ContainerFilter) bool {
 
 // filterContainerList applies a protobuf-defined filter to retrieve only intended containers. Not matching
 // the filter is not considered an error but will return an empty response.
-func (s *Server) filterContainerList(filter *pb.ContainerFilter) (ctrList []*oci.Container, err error) {
+func (s *Server) filterContainerList(filter *pb.ContainerFilter, origCtrList []*oci.Container) (ctrList []*oci.Container, err error) {
+	ctrList = origCtrList
+
 	// Filter using container id and pod id first.
 	if filter.Id != "" {
 		id, err := s.CtrIDIndex().Get(filter.Id)
@@ -83,7 +85,7 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 	}
 
 	if filter != nil {
-		ctrList, err = s.filterContainerList(filter)
+		ctrList, err = s.filterContainerList(filter, ctrList)
 		if err != nil {
 			return nil, err
 		}

--- a/server/container_stats.go
+++ b/server/container_stats.go
@@ -4,9 +4,31 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/kubernetes-incubator/cri-o/lib"
+	"github.com/kubernetes-incubator/cri-o/oci"
 	"golang.org/x/net/context"
 	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
+
+func buildContainerStats(stats *lib.ContainerStats, container *oci.Container) *pb.ContainerStats {
+	return &pb.ContainerStats{
+		Attributes: &pb.ContainerAttributes{
+			Id:          container.ID(),
+			Metadata:    container.Metadata(),
+			Labels:      container.Labels(),
+			Annotations: container.Annotations(),
+		},
+		Cpu: &pb.CpuUsage{
+			Timestamp:            stats.SystemNano,
+			UsageCoreNanoSeconds: &pb.UInt64Value{Value: stats.CPUNano},
+		},
+		Memory: &pb.MemoryUsage{
+			Timestamp:       stats.SystemNano,
+			WorkingSetBytes: &pb.UInt64Value{Value: stats.MemUsage},
+		},
+		WritableLayer: nil,
+	}
+}
 
 // ContainerStats returns stats of the container. If the container does not
 // exist, the call returns an error.
@@ -16,5 +38,16 @@ func (s *Server) ContainerStats(ctx context.Context, req *pb.ContainerStatsReque
 		recordOperation(operation, time.Now())
 		recordError(operation, err)
 	}()
-	return nil, fmt.Errorf("not implemented")
+
+	container := s.GetContainer(req.ContainerId)
+	if container == nil {
+		return nil, fmt.Errorf("invalid container")
+	}
+
+	stats, err := s.GetContainerStats(container, &lib.ContainerStats{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.ContainerStatsResponse{Stats: buildContainerStats(stats, container)}, nil
 }

--- a/server/container_stats_list.go
+++ b/server/container_stats_list.go
@@ -28,10 +28,7 @@ func (s *Server) ListContainerStats(ctx context.Context, req *pb.ListContainerSt
 			PodSandboxId:  req.Filter.PodSandboxId,
 			LabelSelector: req.Filter.LabelSelector,
 		}
-		ctrList, err = s.filterContainerList(cFilter, ctrList)
-		if err != nil {
-			return nil, err
-		}
+		ctrList = s.filterContainerList(cFilter, ctrList)
 	}
 
 	var allStats []*pb.ContainerStats

--- a/server/container_stats_list.go
+++ b/server/container_stats_list.go
@@ -28,7 +28,7 @@ func (s *Server) ListContainerStats(ctx context.Context, req *pb.ListContainerSt
 			PodSandboxId:  req.Filter.PodSandboxId,
 			LabelSelector: req.Filter.LabelSelector,
 		}
-		ctrList, err = s.filterContainerList(cFilter)
+		ctrList, err = s.filterContainerList(cFilter, ctrList)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This uses the previously unusued lib/stats.go code to return data
about container stats to the CRI API.

No data on filesystem layer usage is returned at this time.

Fixes one-half of #1248

Signed-off-by: Yann Ramin <atrus@stackworks.net>


**- Description for the changelog**

Add CRI API support for container statistics
