### PR TITLE
Makefile: installing a config, requires a config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ install.man:
 	install ${SELINUXOPT} -m 644 $(filter %.5,$(MANPAGES)) -t $(MANDIR)/man5
 	install ${SELINUXOPT} -m 644 $(filter %.8,$(MANPAGES)) -t $(MANDIR)/man8
 
-install.config:
+install.config: crio.conf
 	install ${SELINUXOPT} -D -m 644 crio.conf $(ETCDIR_CRIO)/crio.conf
 	install ${SELINUXOPT} -D -m 644 seccomp.json $(ETCDIR_CRIO)/seccomp.json
 	install ${SELINUXOPT} -D -m 644 crio-umount.conf $(OCIUMOUNTINSTALLDIR)/crio-umount.conf


### PR DESCRIPTION
Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
found that from a clean checkout of source, that `make install.config` failed to install crio.conf, as it didn't exists.

**- How I did it**
Made the install.config target depend on the crio.conf file existing.

**- How to verify it**
```shell
[vbatts@chacha] (master) ~/src/github.com/kubernetes-incubator/cri-o$ sudo make install.config
install -Z -D -m 644 crio.conf /etc/crio/crio.conf
install: cannot stat 'crio.conf': No such file or directory
make: *** [Makefile:149: install.config] Error 1
[vbatts@chacha] (master) ~/src/github.com/kubernetes-incubator/cri-o$ make crio.conf
go build -i -ldflags '-s -w -X main.gitCommit="41aaf4e3d812d1dfa9e18b7aad39b0e2be4f1960" -X main.buildInfo=1515619273' -tags "seccomp     selinux containers_image_ostree_stub" -o bin/crio github.com/kubernetes-incubator/cri-o/cmd/crio
./bin/crio --config="" config --default > crio.conf
[vbatts@chacha] (master) ~/src/github.com/kubernetes-incubator/cri-o$ sudo make install.config
install -Z -D -m 644 crio.conf /etc/crio/crio.conf
install -Z -D -m 644 seccomp.json /etc/crio/seccomp.json
install -Z -D -m 644 crio-umount.conf /usr/local/share/oci-umount/oci-umount.d/crio-umount.conf
install -Z -D -m 644 crictl.yaml /etc
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
