### PR TITLE
server: use grpc getters to avoid panics

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -562,7 +562,11 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 		return nil, fmt.Errorf("CreateContainerRequest.ContainerConfig is nil")
 	}
 
-	name := containerConfig.GetMetadata().Name
+	if containerConfig.GetMetadata() == nil {
+		return nil, fmt.Errorf("CreateContainerRequest.ContainerConfig.Metadata is nil")
+	}
+
+	name := containerConfig.GetMetadata().GetName()
 	if name == "" {
 		return nil, fmt.Errorf("CreateContainerRequest.ContainerConfig.Name is empty")
 	}

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -101,16 +101,20 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	s.updateLock.RLock()
 	defer s.updateLock.RUnlock()
 
+	if req.GetConfig().GetMetadata() == nil {
+		return nil, fmt.Errorf("CreateContainerRequest.ContainerConfig.Metadata is nil")
+	}
+
 	logrus.Debugf("RunPodSandboxRequest %+v", req)
 	var processLabel, mountLabel, resolvPath string
 	// process req.Name
-	kubeName := req.GetConfig().GetMetadata().Name
+	kubeName := req.GetConfig().GetMetadata().GetName()
 	if kubeName == "" {
 		return nil, fmt.Errorf("PodSandboxConfig.Name should not be empty")
 	}
 
-	namespace := req.GetConfig().GetMetadata().Namespace
-	attempt := req.GetConfig().GetMetadata().Attempt
+	namespace := req.GetConfig().GetMetadata().GetNamespace()
+	attempt := req.GetConfig().GetMetadata().GetAttempt()
 
 	id, name, err := s.generatePodIDandName(req.GetConfig())
 	if err != nil {
@@ -156,8 +160,8 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		name, id,
 		s.config.PauseImage, "",
 		containerName,
-		req.GetConfig().GetMetadata().Name,
-		req.GetConfig().GetMetadata().Uid,
+		req.GetConfig().GetMetadata().GetName(),
+		req.GetConfig().GetMetadata().GetUid(),
 		namespace,
 		attempt,
 		nil)


### PR DESCRIPTION
Fix https://github.com/kubernetes-incubator/cri-o/issues/1254

/cc @vbatts 

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

use grpc getters that handle nil cases instead of accessing fields directly

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
