### PR TITLE
.mailmap: Add entries for inconsistent users

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,10 @@
+Aleksa Sarai <asarai@suse.de> <asarai@suse.com>
+Antonio Murdaca <runcom@redhat.com> <runcom@users.noreply.github.com>
+CuiHaozhi <cuihaozhi@chinacloud.com.cn> <cuihz@wise2c.com>
+Daniel J Walsh <dwalsh@redhat.com>
+Haiyan Meng <hmeng@redhat.com> <haiyanalady@gmail.com>
+Lorenzo Fontana <lo@linux.com> <fontanalorenz@gmail.com>
+Mrunal Patel <mrunalp@gmail.com> <mpatel@redhat.com>
+Mrunal Patel <mrunalp@gmail.com> <mrunal@me.com>
+Pengfei Ni <feiskyer@gmail.com> <feiskyer@users.noreply.github.com>
+Tobias Klauser <tklauser@distanz.ch> <tobias.klauser@gmail.com>


### PR DESCRIPTION
Where the same user had multiple entries, I mostly went with whichever entry had the most-recent non-merge commits.

The order is alphabetical according to Emacs' sort-lines.