### PR TITLE
kubernetes: Simplify and freshen the required-files table

### DIFF
--- a/kubernetes.md
+++ b/kubernetes.md
@@ -13,17 +13,15 @@ Below, you can find an instruction how to switch one or more nodes on running ku
 
 ### Preparing crio
 
-You must prepare and install `crio` on each node you would like to switch. Here's the list of files that must be provided:
+You must prepare and install `crio` on each node you would like to switch.
+Besides the files installed by `make install install.config`, here's the list of files that must be provided:
 
-| File path                                  | Description                | Location                                            |
-|--------------------------------------------|----------------------------|-----------------------------------------------------|
-| `/etc/crio/crio.conf`                      | crio configuration         | Generated on cri-o `make install`                   |
-| `/etc/crio/seccomp.conf`                   | seccomp config             | Example stored in cri-o repository                  |
-| `/etc/containers/policy.json`              | containers policy          | Example stored in cri-o repository                  |
-| `/bin/{crio, runc}`                        | `crio` and `runc` binaries | Built from cri-o repository                         |
-| `/usr/local/libexec/crio/conmon`           | `conmon` binary            | Built from cri-o repository                         |
-| `/opt/cni/bin/{flannel, bridge,...}`       | CNI plugins binaries       | Can be built from sources `containernetworking/cni` |
-| `/etc/cni/net.d/10-mynet.conf`             | Network config             | Example stored in [README file](README.md)          |
+| File path                                  | Description                 | Location                                                |
+|--------------------------------------------|-----------------------------|---------------------------------------------------------|
+| `/etc/containers/policy.json`              | containers policy           | [Example](test/policy.json) stored in cri-o repository  |
+| `/bin/runc`                                | `runc` or other OCI runtime | Can be build from sources `opencontainers/runc`         |
+| `/opt/cni/bin/{flannel, bridge,...}`       | CNI plugins binaries        | Can be built from sources `containernetworking/plugins` |
+| `/etc/cni/net.d/...`                       | CNI network config          | Example [here](contrib/cni)                             |
 
 `crio` binary can be executed directly on host, inside the container or in any way.
 However, recommended way is to set it as a systemd service.

--- a/tutorial.md
+++ b/tutorial.md
@@ -138,19 +138,6 @@ make
 sudo make install
 ```
 
-Output:
-
-```
-install -D -m 755 crio /usr/local/bin/crio
-install -D -m 755 conmon/conmon /usr/local/libexec/crio/conmon
-install -D -m 755 pause/pause /usr/local/libexec/crio/pause
-install -d -m 755 /usr/local/share/man/man{1,5,8}
-install -m 644 docs/crio.conf.5 -t /usr/local/share/man/man5
-install -m 644 docs/crio.8 -t /usr/local/share/man/man8
-install -D -m 644 crio.conf /etc/crio/crio.conf
-install -D -m 644 seccomp.json /etc/crio/seccomp.json
-```
-
 If you are installing for the first time, generate and install configuration files with:
 
 ```

--- a/tutorial.md
+++ b/tutorial.md
@@ -151,17 +151,10 @@ install -D -m 644 crio.conf /etc/crio/crio.conf
 install -D -m 644 seccomp.json /etc/crio/seccomp.json
 ```
 
-If you are installing for the first time, generate config as follows:
+If you are installing for the first time, generate and install configuration files with:
 
 ```
 sudo make install.config
-```
-
-Output:
-
-```
-install -D -m 644 crio.conf /etc/crio/crio.conf
-install -D -m 644 seccomp.json /etc/crio/seccomp.json
 ```
 
 #### Start the crio system daemon


### PR DESCRIPTION
The cri-o entries are stale vs. the content currently installed by the `Makefile`.  This pull-request drops them and just references the make call before starting the table, which lets us stay DRY.

`runc` is not built from the cri-o repository.  The docs have claimed it was since 983aec63 (#353), but it's independent like the CNI plugins.

I've added a link to the in-repo `policy.json` example.  We probably also want to link to [the docs][1] (for the version we vendor?), but I've left that alone for now.

The CNI config examples were removed from the project README in 9088a12c (#295).  I've adjusted the reference to point to the new location, although again, I'd rather replace this with links to upstream docs.

I've also removed some stale `make` output sections from the tutorial.  Notes in the commit messages about when the individual blocks went stale, but make output isn't very interesting and we're DRYer without them.

[1]: https://github.com/containers/image/blob/3d0304a02154dddc8f97cc833aa0861cea5e9ade/docs/policy.json.md