### PR TITLE
test/README: Update the CNI plugins instructions for /cni → /plugins

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -41,11 +41,12 @@ You will also need to install the [CNI](https://github.com/containernetworking/c
 the the default pod test template runs without host networking:
 
 ```
-$ go get github.com/containernetworking/cni
-$ cd "$GOPATH/src/github.com/containernetworking/cni"
-$ git checkout -q d4bbce1865270cd2d2be558d6a23e63d314fe769
-$ ./build.sh \
-$ mkdir -p /opt/cni/bin \
+$ cd "$GOPATH/src/github.com/containernetworking"
+$ git clone https://github.com/containernetworking/plugins.git
+$ cd plugins
+$ git checkout -q dcf7368eeab15e2affc6256f0bb1e84dd46a34de
+$ ./build.sh
+$ mkdir -p /opt/cni/bin
 $ cp bin/* /opt/cni/bin/
 ```
 


### PR DESCRIPTION
Catching up with the `Dockerfile` change from f51b0a10 (#536).  The new plugins commit from f51b0a10 is still the current `Dockerfile` entry.

This pull-request also replaces the previous `go get` call with a `git clone` to match the `Dockerfile`'s approach.  I've added an additional `cd` call so I don't have to repeat `$GOPATH/…` more than once, but other than that, the example matches [the current Dockerfile entry][1].

[1]: https://github.com/kubernetes-incubator/cri-o/blob/1bb5846d7d0d6b6d755728053a11690d053c6362/Dockerfile#L71-L80