### PR TITLE
test/namespaces: Factor out pid_namespace_test helper

### DIFF
--- a/test/namespaces.bats
+++ b/test/namespaces.bats
@@ -6,8 +6,8 @@ function teardown() {
 	cleanup_test
 }
 
-@test "pod disable shared pid namespace" {
-	ENABLE_SHARED_PID_NAMESPACE="false" start_crio
+function pid_namespace_test() {
+	start_crio
 
 	run crictl runs "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -23,7 +23,7 @@ function teardown() {
 	run crictl exec --sync "$ctr_id" cat /proc/1/cmdline
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "redis" ]]
+	[[ "$output" =~ "${EXPECTED_INIT:-redis}" ]]
 
 	run crictl stops "$pod_id"
 	echo "$output"
@@ -36,32 +36,10 @@ function teardown() {
 	stop_crio
 }
 
+@test "pod disable shared pid namespace" {
+	ENABLE_SHARED_PID_NAMESPACE=false pid_namespace_test
+}
+
 @test "pod enable shared pid namespace" {
-	ENABLE_SHARED_PID_NAMESPACE="true" start_crio
-
-	run crictl runs "$TESTDATA"/sandbox_config.json
-	echo "$output"
-	[ "$status" -eq 0 ]
-	pod_id="$output"
-	run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
-	echo "$output"
-	[ "$status" -eq 0 ]
-	ctr_id="$output"
-	run crictl start "$ctr_id"
-	[ "$status" -eq 0 ]
-
-	run crictl exec --sync "$ctr_id" cat /proc/1/cmdline
-	echo "$output"
-	[ "$status" -eq 0 ]
-	[[ "$output" =~ "pause" ]]
-
-	run crictl stops "$pod_id"
-	echo "$output"
-	[ "$status" -eq 0 ]
-	run crictl rms "$pod_id"
-	echo "$output"
-	[ "$status" -eq 0 ]
-	cleanup_ctrs
-	cleanup_pods
-	stop_crio
+	ENABLE_SHARED_PID_NAMESPACE=true EXPECTED_INIT=pause pid_namespace_test
 }


### PR DESCRIPTION
DRY up this code.  The `${parameter:-word}` syntax is [in POSIX][1].

This is setting the stage for some PID-namespace work I have in progress locally to allow for container PID namespaces that are children of the pod's infra PID namespace (see my comment [here][2]).  I'm filing this as a separate PR, since this seems like an easy improvement regardless of whether you want to pick up my broader PID adjustment.

[1]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02
[2]: https://github.com/kubernetes-incubator/cri-o/issues/1242#issuecomment-359076499