### PR TITLE
Fix a few minor errors in the tutorial document

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -300,15 +300,15 @@ cd $GOPATH/src/github.com/kubernetes-incubator/cri-o
 Next create the Pod and capture the Pod ID for later use:
 
 ```
-POD_ID=$(sudo crictl runs test/testdata/sandbox_config.json)
+POD_ID=$(sudo crictl runp test/testdata/sandbox_config.json)
 ```
 
-> sudo crictl runs test/testdata/sandbox_config.json
+> sudo crictl runp test/testdata/sandbox_config.json
 
 Use the `crictl` command to get the status of the Pod:
 
 ```
-sudo crictl inspects --output table $POD_ID
+sudo crictl inspectp --output table $POD_ID
 ```
 
 Output:


### PR DESCRIPTION
**- What I did**
Fixed a few minor errors in the tutorial document.

**- How I did it**
What I did was just s/runs/runp/ and s/inspects/inspectp/. More specifically:
```
# [Before]
$ POD_ID=$(sudo crictl runs test/testdata/sandbox_config.json)
$ sudo crictl inspects --output table $POD_ID
# [After]
$ POD_ID=$(sudo crictl runp test/testdata/sandbox_config.json)
$ sudo crictl inspectp --output table $POD_ID
```

**- How to verify it**
I used a crictl version `1.0.0-alpha.0` for testing. With this version, hitting `crictl runs ...` or `crictl inspects ...` commands simply returns error `No help topic for 'runs|inspects'`. 

**- Description for the changelog**
Fixed a few minor errors in the tutorial document