### PR TITLE
container_create: only bind mount /etc/hosts if not provided by k8s

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1079,8 +1079,17 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		specgen.AddMount(mnt)
 	}
 
-	// Bind mount /etc/hosts for host networking containers
-	if hostNetwork(containerConfig) {
+	isInCRIMounts := func(dst string, mounts []*pb.Mount) bool {
+		for _, m := range mounts {
+			if m.ContainerPath == dst {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !isInCRIMounts("/etc/hosts", containerConfig.GetMounts()) && hostNetwork(containerConfig) {
+		// Only bind mount for host netns and when CRI does not give us any hosts file
 		mnt = rspec.Mount{
 			Type:        "bind",
 			Source:      "/etc/hosts",


### PR DESCRIPTION
k8s already mounts /etc/hosts from /var/lib/kubelet/pods/<ID>/etc-hosts
even for host network. We shouldn't play with it unless we're running
from crictl for instance.
Relevant k8s code: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet_pods.go#L259-L266

Signed-off-by: Antonio Murdaca <runcom@redhat.com>