### PR TITLE
.tool/lint: Use 'command -v' to detect LINTER presence

### DIFF
--- a/.tool/lint
+++ b/.tool/lint
@@ -5,10 +5,10 @@ set -o nounset
 set -o pipefail
 
 # Create the linter path for use later
-LINTER=${GOPATH}/bin/gometalinter
+LINTER="${LINTER:-${GOPATH}/bin/gometalinter}"
 
 # Make sure gometalinter is installed
-if [ ! -f ${LINTER} ]; then
+if ! command -v ${LINTER} >/dev/null 2>/dev/null; then
 	echo >&2 "gometalinter must be installed. Please run 'make install.tools' and try again"
 	exit 1
 fi


### PR DESCRIPTION
There was a `command -v` check back when this script landed in aa748b62 (#30), but it was removed in 741873ad (#70).  The default changed from `gometalinter` to `${GOPATH}/bin/gometalinter` in 6c9628cd (#320) and the `-f` guard landed in 9c240aed (#850).  This commit brings us back to our original `command -v` check ([in POSIX][1]), which allows support for both filesystem and `$PATH` based commands (and shell aliases, etc.).

I've also made the default `LINTER` more flexible, using the `${parameter:-word}` syntax [from POSIX][2].  That keeps the default linter unchanged, but allows callers to set the `LINTER` environent variable to override.  For example:

```console
$ LINTER=gometalinter .tool/lint
```

will use the linter from your $PATH.

[1]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html
[2]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02