### PR TITLE
[release-1.9] container_create: only bind mount /etc/hosts if not provided by k8s

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1025,8 +1025,17 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		specgen.AddBindMount(sb.HostnamePath(), "/etc/hostname", options)
 	}
 
-	// Bind mount /etc/hosts for host networking containers
-	if hostNetwork(containerConfig) {
+	isInCRIMounts := func(dst string, mounts []*pb.Mount) bool {
+		for _, m := range mounts {
+			if m.ContainerPath == dst {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !isInCRIMounts("/etc/hosts", containerConfig.GetMounts()) && hostNetwork(containerConfig) {
+		// Only bind mount for host netns and when CRI does not give us any hosts file
 		specgen.AddBindMount("/etc/hosts", "/etc/hosts", options)
 	}
 


### PR DESCRIPTION
k8s already mounts /etc/hosts from /var/lib/kubelet/pods/<ID>/etc-hosts
even for host network. We shouldn't play with it unless we're running
from crictl for instance.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

Backport of https://github.com/kubernetes-incubator/cri-o/pull/1282

@mrunalp PTAL