### PR TITLE
[DO NOT MERGE] sys containers: run with metrics enabled

### DIFF
--- a/contrib/system_containers/centos/run.sh
+++ b/contrib/system_containers/centos/run.sh
@@ -8,4 +8,4 @@ printf %s $LABEL > /proc/self/attr/exec
 test -e /etc/sysconfig/crio-storage && source /etc/sysconfig/crio-storage
 test -e /etc/sysconfig/crio-network && source /etc/sysconfig/crio-network
 
-exec /usr/bin/crio --log-level=$LOG_LEVEL
+exec /usr/bin/crio --log-level=$LOG_LEVEL --enable-metrics --metrics-port 4242

--- a/contrib/system_containers/fedora/run.sh
+++ b/contrib/system_containers/fedora/run.sh
@@ -8,4 +8,4 @@ printf %s $LABEL > /proc/self/attr/exec
 test -e /etc/sysconfig/crio-storage && source /etc/sysconfig/crio-storage
 test -e /etc/sysconfig/crio-network && source /etc/sysconfig/crio-network
 
-exec /usr/bin/crio --log-level=$LOG_LEVEL
+exec /usr/bin/crio --log-level=$LOG_LEVEL --enable-metrics --metrics-port 4242

--- a/contrib/system_containers/rhel/run.sh
+++ b/contrib/system_containers/rhel/run.sh
@@ -8,4 +8,4 @@ printf %s $LABEL > /proc/self/attr/exec
 test -e /etc/sysconfig/crio-storage && source /etc/sysconfig/crio-storage
 test -e /etc/sysconfig/crio-network && source /etc/sysconfig/crio-network
 
-exec /usr/bin/crio --log-level=$LOG_LEVEL
+exec /usr/bin/crio --log-level=$LOG_LEVEL --enable-metrics --metrics-port 4242


### PR DESCRIPTION
We need to expose metrics by default, this is going to rebuild CRI-O for openshift 3.9 also /cc @jupierce

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
