### PR TITLE
Bump up go versions in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
     - stage: Integration Test
       script:
         - make integration
-      go: 1.8.x
+      go: 1.9.x
 
 notifications:
   irc: "chat.freenode.net#cri-o"


### PR DESCRIPTION
k8s master builds off go 1.9.x so we run
all tests for 1.9.x and build on 1.9.x, 1.10.x and tip.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

