### PR TITLE
(1.9) bump containers/image to cri-o's release-1.9 branch

### DIFF
--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -184,7 +184,7 @@ func (svc *imageService) CanPull(imageName string, options *copy.Options) (bool,
 	if err != nil {
 		return false, err
 	}
-	src, err := image.FromSource(rawSource)
+	src, err := image.FromSource(options.SourceCtx, rawSource)
 	if err != nil {
 		rawSource.Close()
 		return false, err

--- a/vendor.conf
+++ b/vendor.conf
@@ -12,7 +12,8 @@ github.com/gregjones/httpcache 787624de3eb7bd915c329cba748687a3b22666a6
 github.com/json-iterator/go 1.0.0
 github.com/peterbourgon/diskv v2.0.1
 github.com/sirupsen/logrus v1.0.0
-github.com/containers/image 57b257d128d6075ea3287991ee408d24c7bd2758
+# tip of the cri-o release-1.9 branch
+github.com/containers/image eb86fe24b91d5290ce2a9e974db49ca8e0dcd968 https://github.com/cri-o/image
 github.com/docker/docker-credential-helpers d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1
 github.com/ostreedev/ostree-go master
 github.com/containers/storage d7921c6facc516358070a1306689eda18adaa20a

--- a/vendor/github.com/containers/image/copy/copy.go
+++ b/vendor/github.com/containers/image/copy/copy.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"time"
 
-	pb "gopkg.in/cheggaaa/pb.v1"
-
 	"github.com/containers/image/image"
 	"github.com/containers/image/pkg/compression"
 	"github.com/containers/image/signature"
@@ -22,6 +20,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	pb "gopkg.in/cheggaaa/pb.v1"
 )
 
 type digestingReader struct {
@@ -29,23 +28,6 @@ type digestingReader struct {
 	digester         digest.Digester
 	expectedDigest   digest.Digest
 	validationFailed bool
-}
-
-// imageCopier allows us to keep track of diffID values for blobs, and other
-// data, that we're copying between images, and cache other information that
-// might allow us to take some shortcuts
-type imageCopier struct {
-	copiedBlobs       map[digest.Digest]digest.Digest
-	cachedDiffIDs     map[digest.Digest]digest.Digest
-	manifestUpdates   *types.ManifestUpdateOptions
-	dest              types.ImageDestination
-	src               types.Image
-	rawSource         types.ImageSource
-	diffIDsAreNeeded  bool
-	canModifyManifest bool
-	reportWriter      io.Writer
-	progressInterval  time.Duration
-	progress          chan types.ProgressProperties
 }
 
 // newDigestingReader returns an io.Reader implementation with contents of source, which will eventually return a non-EOF error
@@ -86,6 +68,27 @@ func (d *digestingReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
+// copier allows us to keep track of diffID values for blobs, and other
+// data shared across one or more images in a possible manifest list.
+type copier struct {
+	copiedBlobs      map[digest.Digest]digest.Digest
+	cachedDiffIDs    map[digest.Digest]digest.Digest
+	dest             types.ImageDestination
+	rawSource        types.ImageSource
+	reportWriter     io.Writer
+	progressInterval time.Duration
+	progress         chan types.ProgressProperties
+}
+
+// imageCopier tracks state specific to a single image (possibly an item of a manifest list)
+type imageCopier struct {
+	c                 *copier
+	manifestUpdates   *types.ManifestUpdateOptions
+	src               types.Image
+	diffIDsAreNeeded  bool
+	canModifyManifest bool
+}
+
 // Options allows supplying non-default configuration modifying the behavior of CopyImage.
 type Options struct {
 	RemoveSignatures bool   // Remove any pre-existing signatures. SignBy will still add a new signature.
@@ -95,6 +98,8 @@ type Options struct {
 	DestinationCtx   *types.SystemContext
 	ProgressInterval time.Duration                 // time to wait between reports to signal the progress channel
 	Progress         chan types.ProgressProperties // Reported to when ProgressInterval has arrived for a single artifact+offset.
+	// manifest MIME type of image set by user. "" is default and means use the autodetection to the the manifest MIME type
+	ForceManifestMIMEType string
 }
 
 // Image copies image from srcRef to destRef, using policyContext to validate
@@ -115,10 +120,6 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 		reportWriter = options.ReportWriter
 	}
 
-	writeReport := func(f string, a ...interface{}) {
-		fmt.Fprintf(reportWriter, f, a...)
-	}
-
 	dest, err := destRef.NewImageDestination(options.DestinationCtx)
 	if err != nil {
 		return errors.Wrapf(err, "Error initializing destination %s", transports.ImageName(destRef))
@@ -133,43 +134,89 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 	if err != nil {
 		return errors.Wrapf(err, "Error initializing source %s", transports.ImageName(srcRef))
 	}
-	unparsedImage := image.UnparsedFromSource(rawSource)
 	defer func() {
-		if unparsedImage != nil {
-			if err := unparsedImage.Close(); err != nil {
-				retErr = errors.Wrapf(retErr, " (unparsed: %v)", err)
-			}
+		if err := rawSource.Close(); err != nil {
+			retErr = errors.Wrapf(retErr, " (src: %v)", err)
 		}
 	}()
 
+	c := &copier{
+		copiedBlobs:      make(map[digest.Digest]digest.Digest),
+		cachedDiffIDs:    make(map[digest.Digest]digest.Digest),
+		dest:             dest,
+		rawSource:        rawSource,
+		reportWriter:     reportWriter,
+		progressInterval: options.ProgressInterval,
+		progress:         options.Progress,
+	}
+
+	unparsedToplevel := image.UnparsedInstance(rawSource, nil)
+	multiImage, err := isMultiImage(unparsedToplevel)
+	if err != nil {
+		return errors.Wrapf(err, "Error determining manifest MIME type for %s", transports.ImageName(srcRef))
+	}
+
+	if !multiImage {
+		// The simple case: Just copy a single image.
+		if err := c.copyOneImage(policyContext, options, unparsedToplevel); err != nil {
+			return err
+		}
+	} else {
+		// This is a manifest list. Choose a single image and copy it.
+		// FIXME: Copy to destinations which support manifest lists, one image at a time.
+		instanceDigest, err := image.ChooseManifestInstanceFromManifestList(options.SourceCtx, unparsedToplevel)
+		if err != nil {
+			return errors.Wrapf(err, "Error choosing an image from manifest list %s", transports.ImageName(srcRef))
+		}
+		logrus.Debugf("Source is a manifest list; copying (only) instance %s", instanceDigest)
+		unparsedInstance := image.UnparsedInstance(rawSource, &instanceDigest)
+
+		if err := c.copyOneImage(policyContext, options, unparsedInstance); err != nil {
+			return err
+		}
+	}
+
+	if err := c.dest.Commit(); err != nil {
+		return errors.Wrap(err, "Error committing the finished image")
+	}
+
+	return nil
+}
+
+// Image copies a single (on-manifest-list) image unparsedImage, using policyContext to validate
+// source image admissibility.
+func (c *copier) copyOneImage(policyContext *signature.PolicyContext, options *Options, unparsedImage *image.UnparsedImage) (retErr error) {
+	// The caller is handling manifest lists; this could happen only if a manifest list contains a manifest list.
+	// Make sure we fail cleanly in such cases.
+	multiImage, err := isMultiImage(unparsedImage)
+	if err != nil {
+		// FIXME FIXME: How to name a reference for the sub-image?
+		return errors.Wrapf(err, "Error determining manifest MIME type for %s", transports.ImageName(unparsedImage.Reference()))
+	}
+	if multiImage {
+		return fmt.Errorf("Unexpectedly received a manifest list instead of a manifest for a single image")
+	}
+
 	// Please keep this policy check BEFORE reading any other information about the image.
+	// (the multiImage check above only matches the MIME type, which we have received anyway.
+	// Actual parsing of anything should be deferred.)
 	if allowed, err := policyContext.IsRunningImageAllowed(unparsedImage); !allowed || err != nil { // Be paranoid and fail if either return value indicates so.
 		return errors.Wrap(err, "Source image rejected")
 	}
-	src, err := image.FromUnparsedImage(unparsedImage)
+	src, err := image.FromUnparsedImage(options.SourceCtx, unparsedImage)
 	if err != nil {
-		return errors.Wrapf(err, "Error initializing image from source %s", transports.ImageName(srcRef))
+		return errors.Wrapf(err, "Error initializing image from source %s", transports.ImageName(c.rawSource.Reference()))
 	}
-	unparsedImage = nil
-	defer func() {
-		if err := src.Close(); err != nil {
-			retErr = errors.Wrapf(retErr, " (source: %v)", err)
-		}
-	}()
 
-	if err := checkImageDestinationForCurrentRuntimeOS(src, dest); err != nil {
+	if err := checkImageDestinationForCurrentRuntimeOS(options.DestinationCtx, src, c.dest); err != nil {
 		return err
-	}
-
-	if src.IsMultiImage() {
-		return errors.Errorf("can not copy %s: manifest contains multiple images", transports.ImageName(srcRef))
 	}
 
 	var sigs [][]byte
 	if options.RemoveSignatures {
 		sigs = [][]byte{}
 	} else {
-		writeReport("Getting image source signatures\n")
+		c.Printf("Getting image source signatures\n")
 		s, err := src.Signatures(context.TODO())
 		if err != nil {
 			return errors.Wrap(err, "Error reading signatures")
@@ -177,41 +224,33 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 		sigs = s
 	}
 	if len(sigs) != 0 {
-		writeReport("Checking if image destination supports signatures\n")
-		if err := dest.SupportsSignatures(); err != nil {
+		c.Printf("Checking if image destination supports signatures\n")
+		if err := c.dest.SupportsSignatures(); err != nil {
 			return errors.Wrap(err, "Can not copy signatures")
 		}
 	}
 
-	canModifyManifest := len(sigs) == 0
-	manifestUpdates := types.ManifestUpdateOptions{}
-	manifestUpdates.InformationOnly.Destination = dest
+	ic := imageCopier{
+		c:               c,
+		manifestUpdates: &types.ManifestUpdateOptions{InformationOnly: types.ManifestUpdateInformation{Destination: c.dest}},
+		src:             src,
+		// diffIDsAreNeeded is computed later
+		canModifyManifest: len(sigs) == 0,
+	}
 
-	if err := updateEmbeddedDockerReference(&manifestUpdates, dest, src, canModifyManifest); err != nil {
+	if err := ic.updateEmbeddedDockerReference(); err != nil {
 		return err
 	}
 
 	// We compute preferredManifestMIMEType only to show it in error messages.
 	// Without having to add this context in an error message, we would be happy enough to know only that no conversion is needed.
-	preferredManifestMIMEType, otherManifestMIMETypeCandidates, err := determineManifestConversion(&manifestUpdates, src, dest.SupportedManifestMIMETypes(), canModifyManifest)
+	preferredManifestMIMEType, otherManifestMIMETypeCandidates, err := ic.determineManifestConversion(c.dest.SupportedManifestMIMETypes(), options.ForceManifestMIMEType)
 	if err != nil {
 		return err
 	}
 
-	// If src.UpdatedImageNeedsLayerDiffIDs(manifestUpdates) will be true, it needs to be true by the time we get here.
-	ic := imageCopier{
-		copiedBlobs:       make(map[digest.Digest]digest.Digest),
-		cachedDiffIDs:     make(map[digest.Digest]digest.Digest),
-		manifestUpdates:   &manifestUpdates,
-		dest:              dest,
-		src:               src,
-		rawSource:         rawSource,
-		diffIDsAreNeeded:  src.UpdatedImageNeedsLayerDiffIDs(manifestUpdates),
-		canModifyManifest: canModifyManifest,
-		reportWriter:      reportWriter,
-		progressInterval:  options.ProgressInterval,
-		progress:          options.Progress,
-	}
+	// If src.UpdatedImageNeedsLayerDiffIDs(ic.manifestUpdates) will be true, it needs to be true by the time we get here.
+	ic.diffIDsAreNeeded = src.UpdatedImageNeedsLayerDiffIDs(*ic.manifestUpdates)
 
 	if err := ic.copyLayers(); err != nil {
 		return err
@@ -233,9 +272,9 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 		}
 		// If the original MIME type is acceptable, determineManifestConversion always uses it as preferredManifestMIMEType.
 		// So if we are here, we will definitely be trying to convert the manifest.
-		// With !canModifyManifest, that would just be a string of repeated failures for the same reason,
+		// With !ic.canModifyManifest, that would just be a string of repeated failures for the same reason,
 		// so let’s bail out early and with a better error message.
-		if !canModifyManifest {
+		if !ic.canModifyManifest {
 			return errors.Wrap(err, "Writing manifest failed (and converting it is not possible)")
 		}
 
@@ -243,7 +282,7 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 		errs := []string{fmt.Sprintf("%s(%v)", preferredManifestMIMEType, err)}
 		for _, manifestMIMEType := range otherManifestMIMETypeCandidates {
 			logrus.Debugf("Trying to use manifest type %s…", manifestMIMEType)
-			manifestUpdates.ManifestMIMEType = manifestMIMEType
+			ic.manifestUpdates.ManifestMIMEType = manifestMIMEType
 			attemptedManifest, err := ic.copyUpdatedConfigAndManifest()
 			if err != nil {
 				logrus.Debugf("Upload of manifest type %s failed: %v", manifestMIMEType, err)
@@ -262,35 +301,44 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 	}
 
 	if options.SignBy != "" {
-		newSig, err := createSignature(dest, manifest, options.SignBy, reportWriter)
+		newSig, err := c.createSignature(manifest, options.SignBy)
 		if err != nil {
 			return err
 		}
 		sigs = append(sigs, newSig)
 	}
 
-	writeReport("Storing signatures\n")
-	if err := dest.PutSignatures(sigs); err != nil {
+	c.Printf("Storing signatures\n")
+	if err := c.dest.PutSignatures(sigs); err != nil {
 		return errors.Wrap(err, "Error writing signatures")
-	}
-
-	if err := dest.Commit(); err != nil {
-		return errors.Wrap(err, "Error committing the finished image")
 	}
 
 	return nil
 }
 
-func checkImageDestinationForCurrentRuntimeOS(src types.Image, dest types.ImageDestination) error {
+// Printf writes a formatted string to c.reportWriter.
+// Note that the method name Printf is not entirely arbitrary: (go tool vet)
+// has a built-in list of functions/methods (whatever object they are for)
+// which have their format strings checked; for other names we would have
+// to pass a parameter to every (go tool vet) invocation.
+func (c *copier) Printf(format string, a ...interface{}) {
+	fmt.Fprintf(c.reportWriter, format, a...)
+}
+
+func checkImageDestinationForCurrentRuntimeOS(ctx *types.SystemContext, src types.Image, dest types.ImageDestination) error {
 	if dest.MustMatchRuntimeOS() {
+		wantedOS := runtime.GOOS
+		if ctx != nil && ctx.OSChoice != "" {
+			wantedOS = ctx.OSChoice
+		}
 		c, err := src.OCIConfig()
 		if err != nil {
 			return errors.Wrapf(err, "Error parsing image configuration")
 		}
-		osErr := fmt.Errorf("image operating system %q cannot be used on %q", c.OS, runtime.GOOS)
-		if runtime.GOOS == "windows" && c.OS == "linux" {
+		osErr := fmt.Errorf("image operating system %q cannot be used on %q", c.OS, wantedOS)
+		if wantedOS == "windows" && c.OS == "linux" {
 			return osErr
-		} else if runtime.GOOS != "windows" && c.OS == "windows" {
+		} else if wantedOS != "windows" && c.OS == "windows" {
 			return osErr
 		}
 	}
@@ -298,24 +346,24 @@ func checkImageDestinationForCurrentRuntimeOS(src types.Image, dest types.ImageD
 }
 
 // updateEmbeddedDockerReference handles the Docker reference embedded in Docker schema1 manifests.
-func updateEmbeddedDockerReference(manifestUpdates *types.ManifestUpdateOptions, dest types.ImageDestination, src types.Image, canModifyManifest bool) error {
-	destRef := dest.Reference().DockerReference()
+func (ic *imageCopier) updateEmbeddedDockerReference() error {
+	destRef := ic.c.dest.Reference().DockerReference()
 	if destRef == nil {
 		return nil // Destination does not care about Docker references
 	}
-	if !src.EmbeddedDockerReferenceConflicts(destRef) {
+	if !ic.src.EmbeddedDockerReferenceConflicts(destRef) {
 		return nil // No reference embedded in the manifest, or it matches destRef already.
 	}
 
-	if !canModifyManifest {
+	if !ic.canModifyManifest {
 		return errors.Errorf("Copying a schema1 image with an embedded Docker reference to %s (Docker reference %s) would invalidate existing signatures. Explicitly enable signature removal to proceed anyway",
-			transports.ImageName(dest.Reference()), destRef.String())
+			transports.ImageName(ic.c.dest.Reference()), destRef.String())
 	}
-	manifestUpdates.EmbeddedDockerReference = destRef
+	ic.manifestUpdates.EmbeddedDockerReference = destRef
 	return nil
 }
 
-// copyLayers copies layers from src/rawSource to dest, using and updating ic.manifestUpdates if necessary and ic.canModifyManifest.
+// copyLayers copies layers from ic.src/ic.c.rawSource to dest, using and updating ic.manifestUpdates if necessary and ic.canModifyManifest.
 func (ic *imageCopier) copyLayers() error {
 	srcInfos := ic.src.LayerInfos()
 	destInfos := []types.BlobInfo{}
@@ -326,7 +374,7 @@ func (ic *imageCopier) copyLayers() error {
 			diffID   digest.Digest
 			err      error
 		)
-		if ic.dest.AcceptsForeignLayerURLs() && len(srcLayer.URLs) != 0 {
+		if ic.c.dest.AcceptsForeignLayerURLs() && len(srcLayer.URLs) != 0 {
 			// DiffIDs are, currently, needed only when converting from schema1.
 			// In which case src.LayerInfos will not have URLs because schema1
 			// does not support them.
@@ -334,7 +382,7 @@ func (ic *imageCopier) copyLayers() error {
 				return errors.New("getting DiffID for foreign layers is unimplemented")
 			}
 			destInfo = srcLayer
-			fmt.Fprintf(ic.reportWriter, "Skipping foreign layer %q copy to %s\n", destInfo.Digest, ic.dest.Reference().Transport().Name())
+			ic.c.Printf("Skipping foreign layer %q copy to %s\n", destInfo.Digest, ic.c.dest.Reference().Transport().Name())
 		} else {
 			destInfo, diffID, err = ic.copyLayer(srcLayer)
 			if err != nil {
@@ -379,7 +427,7 @@ func (ic *imageCopier) copyUpdatedConfigAndManifest() ([]byte, error) {
 			// We have set ic.diffIDsAreNeeded based on the preferred MIME type returned by determineManifestConversion.
 			// So, this can only happen if we are trying to upload using one of the other MIME type candidates.
 			// Because UpdatedImageNeedsLayerDiffIDs is true only when converting from s1 to s2, this case should only arise
-			// when ic.dest.SupportedManifestMIMETypes() includes both s1 and s2, the upload using s1 failed, and we are now trying s2.
+			// when ic.c.dest.SupportedManifestMIMETypes() includes both s1 and s2, the upload using s1 failed, and we are now trying s2.
 			// Supposedly s2-only registries do not exist or are extremely rare, so failing with this error message is good enough for now.
 			// If handling such registries turns out to be necessary, we could compute ic.diffIDsAreNeeded based on the full list of manifest MIME type candidates.
 			return nil, errors.Errorf("Can not convert image to %s, preparing DiffIDs for this case is not supported", ic.manifestUpdates.ManifestMIMEType)
@@ -395,27 +443,27 @@ func (ic *imageCopier) copyUpdatedConfigAndManifest() ([]byte, error) {
 		return nil, errors.Wrap(err, "Error reading manifest")
 	}
 
-	if err := ic.copyConfig(pendingImage); err != nil {
+	if err := ic.c.copyConfig(pendingImage); err != nil {
 		return nil, err
 	}
 
-	fmt.Fprintf(ic.reportWriter, "Writing manifest to image destination\n")
-	if err := ic.dest.PutManifest(manifest); err != nil {
+	ic.c.Printf("Writing manifest to image destination\n")
+	if err := ic.c.dest.PutManifest(manifest); err != nil {
 		return nil, errors.Wrap(err, "Error writing manifest")
 	}
 	return manifest, nil
 }
 
 // copyConfig copies config.json, if any, from src to dest.
-func (ic *imageCopier) copyConfig(src types.Image) error {
+func (c *copier) copyConfig(src types.Image) error {
 	srcInfo := src.ConfigInfo()
 	if srcInfo.Digest != "" {
-		fmt.Fprintf(ic.reportWriter, "Copying config %s\n", srcInfo.Digest)
+		c.Printf("Copying config %s\n", srcInfo.Digest)
 		configBlob, err := src.ConfigBlob()
 		if err != nil {
 			return errors.Wrapf(err, "Error reading config blob %s", srcInfo.Digest)
 		}
-		destInfo, err := ic.copyBlobFromStream(bytes.NewReader(configBlob), srcInfo, nil, false)
+		destInfo, err := c.copyBlobFromStream(bytes.NewReader(configBlob), srcInfo, nil, false)
 		if err != nil {
 			return err
 		}
@@ -437,12 +485,12 @@ type diffIDResult struct {
 // and returns a complete blobInfo of the copied layer, and a value for LayerDiffIDs if diffIDIsNeeded
 func (ic *imageCopier) copyLayer(srcInfo types.BlobInfo) (types.BlobInfo, digest.Digest, error) {
 	// Check if we already have a blob with this digest
-	haveBlob, extantBlobSize, err := ic.dest.HasBlob(srcInfo)
+	haveBlob, extantBlobSize, err := ic.c.dest.HasBlob(srcInfo)
 	if err != nil {
 		return types.BlobInfo{}, "", errors.Wrapf(err, "Error checking for blob %s at destination", srcInfo.Digest)
 	}
 	// If we already have a cached diffID for this blob, we don't need to compute it
-	diffIDIsNeeded := ic.diffIDsAreNeeded && (ic.cachedDiffIDs[srcInfo.Digest] == "")
+	diffIDIsNeeded := ic.diffIDsAreNeeded && (ic.c.cachedDiffIDs[srcInfo.Digest] == "")
 	// If we already have the blob, and we don't need to recompute the diffID, then we might be able to avoid reading it again
 	if haveBlob && !diffIDIsNeeded {
 		// Check the blob sizes match, if we were given a size this time
@@ -451,17 +499,17 @@ func (ic *imageCopier) copyLayer(srcInfo types.BlobInfo) (types.BlobInfo, digest
 		}
 		srcInfo.Size = extantBlobSize
 		// Tell the image destination that this blob's delta is being applied again.  For some image destinations, this can be faster than using GetBlob/PutBlob
-		blobinfo, err := ic.dest.ReapplyBlob(srcInfo)
+		blobinfo, err := ic.c.dest.ReapplyBlob(srcInfo)
 		if err != nil {
 			return types.BlobInfo{}, "", errors.Wrapf(err, "Error reapplying blob %s at destination", srcInfo.Digest)
 		}
-		fmt.Fprintf(ic.reportWriter, "Skipping fetch of repeat blob %s\n", srcInfo.Digest)
-		return blobinfo, ic.cachedDiffIDs[srcInfo.Digest], err
+		ic.c.Printf("Skipping fetch of repeat blob %s\n", srcInfo.Digest)
+		return blobinfo, ic.c.cachedDiffIDs[srcInfo.Digest], err
 	}
 
 	// Fallback: copy the layer, computing the diffID if we need to do so
-	fmt.Fprintf(ic.reportWriter, "Copying blob %s\n", srcInfo.Digest)
-	srcStream, srcBlobSize, err := ic.rawSource.GetBlob(srcInfo)
+	ic.c.Printf("Copying blob %s\n", srcInfo.Digest)
+	srcStream, srcBlobSize, err := ic.c.rawSource.GetBlob(srcInfo)
 	if err != nil {
 		return types.BlobInfo{}, "", errors.Wrapf(err, "Error reading blob %s", srcInfo.Digest)
 	}
@@ -479,7 +527,7 @@ func (ic *imageCopier) copyLayer(srcInfo types.BlobInfo) (types.BlobInfo, digest
 			return types.BlobInfo{}, "", errors.Wrap(diffIDResult.err, "Error computing layer DiffID")
 		}
 		logrus.Debugf("Computed DiffID %s for layer %s", diffIDResult.digest, srcInfo.Digest)
-		ic.cachedDiffIDs[srcInfo.Digest] = diffIDResult.digest
+		ic.c.cachedDiffIDs[srcInfo.Digest] = diffIDResult.digest
 	}
 	return blobInfo, diffIDResult.digest, nil
 }
@@ -513,7 +561,7 @@ func (ic *imageCopier) copyLayerFromStream(srcStream io.Reader, srcInfo types.Bl
 			return pipeWriter
 		}
 	}
-	blobInfo, err := ic.copyBlobFromStream(srcStream, srcInfo, getDiffIDRecorder, ic.canModifyManifest) // Sets err to nil on success
+	blobInfo, err := ic.c.copyBlobFromStream(srcStream, srcInfo, getDiffIDRecorder, ic.canModifyManifest) // Sets err to nil on success
 	return blobInfo, diffIDChan, err
 	// We need the defer … pipeWriter.CloseWithError() to happen HERE so that the caller can block on reading from diffIDChan
 }
@@ -547,7 +595,7 @@ func computeDiffID(stream io.Reader, decompressor compression.DecompressorFunc) 
 // perhaps sending a copy to an io.Writer if getOriginalLayerCopyWriter != nil,
 // perhaps compressing it if canCompress,
 // and returns a complete blobInfo of the copied blob.
-func (ic *imageCopier) copyBlobFromStream(srcStream io.Reader, srcInfo types.BlobInfo,
+func (c *copier) copyBlobFromStream(srcStream io.Reader, srcInfo types.BlobInfo,
 	getOriginalLayerCopyWriter func(decompressor compression.DecompressorFunc) io.Writer,
 	canCompress bool) (types.BlobInfo, error) {
 	// The copying happens through a pipeline of connected io.Readers.
@@ -575,7 +623,7 @@ func (ic *imageCopier) copyBlobFromStream(srcStream io.Reader, srcInfo types.Blo
 
 	// === Report progress using a pb.Reader.
 	bar := pb.New(int(srcInfo.Size)).SetUnits(pb.U_BYTES)
-	bar.Output = ic.reportWriter
+	bar.Output = c.reportWriter
 	bar.SetMaxWidth(80)
 	bar.ShowTimeLeft = false
 	bar.ShowPercent = false
@@ -592,7 +640,7 @@ func (ic *imageCopier) copyBlobFromStream(srcStream io.Reader, srcInfo types.Blo
 
 	// === Compress the layer if it is uncompressed and compression is desired
 	var inputInfo types.BlobInfo
-	if !canCompress || isCompressed || !ic.dest.ShouldCompressLayers() {
+	if !canCompress || isCompressed || !c.dest.ShouldCompressLayers() {
 		logrus.Debugf("Using original blob without modification")
 		inputInfo = srcInfo
 	} else {
@@ -609,19 +657,19 @@ func (ic *imageCopier) copyBlobFromStream(srcStream io.Reader, srcInfo types.Blo
 		inputInfo.Size = -1
 	}
 
-	// === Report progress using the ic.progress channel, if required.
-	if ic.progress != nil && ic.progressInterval > 0 {
+	// === Report progress using the c.progress channel, if required.
+	if c.progress != nil && c.progressInterval > 0 {
 		destStream = &progressReader{
 			source:   destStream,
-			channel:  ic.progress,
-			interval: ic.progressInterval,
+			channel:  c.progress,
+			interval: c.progressInterval,
 			artifact: srcInfo,
 			lastTime: time.Now(),
 		}
 	}
 
 	// === Finally, send the layer stream to dest.
-	uploadedInfo, err := ic.dest.PutBlob(destStream, inputInfo)
+	uploadedInfo, err := c.dest.PutBlob(destStream, inputInfo)
 	if err != nil {
 		return types.BlobInfo{}, errors.Wrap(err, "Error writing blob")
 	}

--- a/vendor/github.com/containers/image/copy/sign.go
+++ b/vendor/github.com/containers/image/copy/sign.go
@@ -1,17 +1,13 @@
 package copy
 
 import (
-	"fmt"
-	"io"
-
 	"github.com/containers/image/signature"
 	"github.com/containers/image/transports"
-	"github.com/containers/image/types"
 	"github.com/pkg/errors"
 )
 
-// createSignature creates a new signature of manifest at (identified by) dest using keyIdentity.
-func createSignature(dest types.ImageDestination, manifest []byte, keyIdentity string, reportWriter io.Writer) ([]byte, error) {
+// createSignature creates a new signature of manifest using keyIdentity.
+func (c *copier) createSignature(manifest []byte, keyIdentity string) ([]byte, error) {
 	mech, err := signature.NewGPGSigningMechanism()
 	if err != nil {
 		return nil, errors.Wrap(err, "Error initializing GPG")
@@ -21,12 +17,12 @@ func createSignature(dest types.ImageDestination, manifest []byte, keyIdentity s
 		return nil, errors.Wrap(err, "Signing not supported")
 	}
 
-	dockerReference := dest.Reference().DockerReference()
+	dockerReference := c.dest.Reference().DockerReference()
 	if dockerReference == nil {
-		return nil, errors.Errorf("Cannot determine canonical Docker reference for destination %s", transports.ImageName(dest.Reference()))
+		return nil, errors.Errorf("Cannot determine canonical Docker reference for destination %s", transports.ImageName(c.dest.Reference()))
 	}
 
-	fmt.Fprintf(reportWriter, "Signing manifest\n")
+	c.Printf("Signing manifest\n")
 	newSig, err := signature.SignDockerManifest(manifest, dockerReference.String(), mech, keyIdentity)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error creating signature")

--- a/vendor/github.com/containers/image/directory/directory_src.go
+++ b/vendor/github.com/containers/image/directory/directory_src.go
@@ -35,16 +35,17 @@ func (s *dirImageSource) Close() error {
 
 // GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
 // It may use a remote (= slow) service.
-func (s *dirImageSource) GetManifest() ([]byte, string, error) {
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+func (s *dirImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+	if instanceDigest != nil {
+		return nil, "", errors.Errorf(`Getting target manifest not supported by "dir:"`)
+	}
 	m, err := ioutil.ReadFile(s.ref.manifestPath())
 	if err != nil {
 		return nil, "", err
 	}
 	return m, manifest.GuessMIMEType(m), err
-}
-
-func (s *dirImageSource) GetTargetManifest(digest digest.Digest) ([]byte, string, error) {
-	return nil, "", errors.Errorf(`Getting target manifest not supported by "dir:"`)
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
@@ -60,7 +61,14 @@ func (s *dirImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, err
 	return r, fi.Size(), nil
 }
 
-func (s *dirImageSource) GetSignatures(ctx context.Context) ([][]byte, error) {
+// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+func (s *dirImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	if instanceDigest != nil {
+		return nil, errors.Errorf(`Manifests lists are not supported by "dir:"`)
+	}
 	signatures := [][]byte{}
 	for i := 0; ; i++ {
 		signature, err := ioutil.ReadFile(s.ref.signaturePath(i))

--- a/vendor/github.com/containers/image/docker/archive/transport.go
+++ b/vendor/github.com/containers/image/docker/archive/transport.go
@@ -125,13 +125,14 @@ func (ref archiveReference) PolicyConfigurationNamespaces() []string {
 	return []string{}
 }
 
-// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
-// The caller must call .Close() on the returned Image.
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
-func (ref archiveReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (ref archiveReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	src := newImageSource(ctx, ref)
-	return ctrImage.FromSource(src)
+	return ctrImage.FromSource(ctx, src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.

--- a/vendor/github.com/containers/image/docker/daemon/client.go
+++ b/vendor/github.com/containers/image/docker/daemon/client.go
@@ -1,0 +1,69 @@
+package daemon
+
+import (
+	"net/http"
+	"path/filepath"
+
+	"github.com/containers/image/types"
+	dockerclient "github.com/docker/docker/client"
+	"github.com/docker/go-connections/tlsconfig"
+)
+
+const (
+	// The default API version to be used in case none is explicitly specified
+	defaultAPIVersion = "1.22"
+)
+
+// NewDockerClient initializes a new API client based on the passed SystemContext.
+func newDockerClient(ctx *types.SystemContext) (*dockerclient.Client, error) {
+	host := dockerclient.DefaultDockerHost
+	if ctx != nil && ctx.DockerDaemonHost != "" {
+		host = ctx.DockerDaemonHost
+	}
+
+	// Sadly, unix:// sockets don't work transparently with dockerclient.NewClient.
+	// They work fine with a nil httpClient; with a non-nil httpClient, the transport’s
+	// TLSClientConfig must be nil (or the client will try using HTTPS over the PF_UNIX socket
+	// regardless of the values in the *tls.Config), and we would have to call sockets.ConfigureTransport.
+	//
+	// We don't really want to configure anything for unix:// sockets, so just pass a nil *http.Client.
+	proto, _, _, err := dockerclient.ParseHost(host)
+	if err != nil {
+		return nil, err
+	}
+	var httpClient *http.Client
+	if proto != "unix" {
+		hc, err := tlsConfig(ctx)
+		if err != nil {
+			return nil, err
+		}
+		httpClient = hc
+	}
+
+	return dockerclient.NewClient(host, defaultAPIVersion, httpClient, nil)
+}
+
+func tlsConfig(ctx *types.SystemContext) (*http.Client, error) {
+	options := tlsconfig.Options{}
+	if ctx != nil && ctx.DockerDaemonInsecureSkipTLSVerify {
+		options.InsecureSkipVerify = true
+	}
+
+	if ctx != nil && ctx.DockerDaemonCertPath != "" {
+		options.CAFile = filepath.Join(ctx.DockerDaemonCertPath, "ca.pem")
+		options.CertFile = filepath.Join(ctx.DockerDaemonCertPath, "cert.pem")
+		options.KeyFile = filepath.Join(ctx.DockerDaemonCertPath, "key.pem")
+	}
+
+	tlsc, err := tlsconfig.Client(options)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsc,
+		},
+		CheckRedirect: dockerclient.CheckRedirect,
+	}, nil
+}

--- a/vendor/github.com/containers/image/docker/daemon/daemon_dest.go
+++ b/vendor/github.com/containers/image/docker/daemon/daemon_dest.go
@@ -14,6 +14,7 @@ import (
 
 type daemonImageDestination struct {
 	ref                  daemonReference
+	mustMatchRuntimeOS   bool
 	*tarfile.Destination // Implements most of types.ImageDestination
 	// For talking to imageLoadGoroutine
 	goroutineCancel context.CancelFunc
@@ -24,7 +25,7 @@ type daemonImageDestination struct {
 }
 
 // newImageDestination returns a types.ImageDestination for the specified image reference.
-func newImageDestination(systemCtx *types.SystemContext, ref daemonReference) (types.ImageDestination, error) {
+func newImageDestination(ctx *types.SystemContext, ref daemonReference) (types.ImageDestination, error) {
 	if ref.ref == nil {
 		return nil, errors.Errorf("Invalid destination docker-daemon:%s: a destination must be a name:tag", ref.StringWithinTransport())
 	}
@@ -33,7 +34,12 @@ func newImageDestination(systemCtx *types.SystemContext, ref daemonReference) (t
 		return nil, errors.Errorf("Invalid destination docker-daemon:%s: a destination must be a name:tag", ref.StringWithinTransport())
 	}
 
-	c, err := client.NewClient(client.DefaultDockerHost, "1.22", nil, nil) // FIXME: overridable host
+	var mustMatchRuntimeOS = true
+	if ctx != nil && ctx.DockerDaemonHost != client.DefaultDockerHost {
+		mustMatchRuntimeOS = false
+	}
+
+	c, err := newDockerClient(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error initializing docker engine client")
 	}
@@ -42,16 +48,17 @@ func newImageDestination(systemCtx *types.SystemContext, ref daemonReference) (t
 	// Commit() may never be called, so we may never read from this channel; so, make this buffered to allow imageLoadGoroutine to write status and terminate even if we never read it.
 	statusChannel := make(chan error, 1)
 
-	ctx, goroutineCancel := context.WithCancel(context.Background())
-	go imageLoadGoroutine(ctx, c, reader, statusChannel)
+	goroutineContext, goroutineCancel := context.WithCancel(context.Background())
+	go imageLoadGoroutine(goroutineContext, c, reader, statusChannel)
 
 	return &daemonImageDestination{
-		ref:             ref,
-		Destination:     tarfile.NewDestination(writer, namedTaggedRef),
-		goroutineCancel: goroutineCancel,
-		statusChannel:   statusChannel,
-		writer:          writer,
-		committed:       false,
+		ref:                ref,
+		mustMatchRuntimeOS: mustMatchRuntimeOS,
+		Destination:        tarfile.NewDestination(writer, namedTaggedRef),
+		goroutineCancel:    goroutineCancel,
+		statusChannel:      statusChannel,
+		writer:             writer,
+		committed:          false,
 	}, nil
 }
 
@@ -80,7 +87,7 @@ func imageLoadGoroutine(ctx context.Context, c *client.Client, reader *io.PipeRe
 
 // MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
 func (d *daemonImageDestination) MustMatchRuntimeOS() bool {
-	return true
+	return d.mustMatchRuntimeOS
 }
 
 // Close removes resources associated with an initialized ImageDestination, if any.

--- a/vendor/github.com/containers/image/docker/daemon/daemon_src.go
+++ b/vendor/github.com/containers/image/docker/daemon/daemon_src.go
@@ -6,13 +6,11 @@ import (
 	"os"
 
 	"github.com/containers/image/docker/tarfile"
+	"github.com/containers/image/internal/tmpdir"
 	"github.com/containers/image/types"
-	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
-
-const temporaryDirectoryForBigFiles = "/var/tmp" // Do not use the system default of os.TempDir(), usually /tmp, because with systemd it could be a tmpfs.
 
 type daemonImageSource struct {
 	ref             daemonReference
@@ -35,7 +33,7 @@ type layerInfo struct {
 // is the config, and that the following len(RootFS) files are the layers, but that feels
 // way too brittle.)
 func newImageSource(ctx *types.SystemContext, ref daemonReference) (types.ImageSource, error) {
-	c, err := client.NewClient(client.DefaultDockerHost, "1.22", nil, nil) // FIXME: overridable host
+	c, err := newDockerClient(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error initializing docker engine client")
 	}
@@ -48,7 +46,7 @@ func newImageSource(ctx *types.SystemContext, ref daemonReference) (types.ImageS
 	defer inputStream.Close()
 
 	// FIXME: use SystemContext here.
-	tarCopyFile, err := ioutil.TempFile(temporaryDirectoryForBigFiles, "docker-daemon-tar")
+	tarCopyFile, err := ioutil.TempFile(tmpdir.TemporaryDirectoryForBigFiles(), "docker-daemon-tar")
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containers/image/docker/daemon/daemon_transport.go
+++ b/vendor/github.com/containers/image/docker/daemon/daemon_transport.go
@@ -151,14 +151,17 @@ func (ref daemonReference) PolicyConfigurationNamespaces() []string {
 	return []string{}
 }
 
-// NewImage returns a types.Image for this reference.
-// The caller must call .Close() on the returned Image.
-func (ref daemonReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
+// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
+// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (ref daemonReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	src, err := newImageSource(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
-	return image.FromSource(src)
+	return image.FromSource(ctx, src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.

--- a/vendor/github.com/containers/image/docker/docker_image.go
+++ b/vendor/github.com/containers/image/docker/docker_image.go
@@ -12,26 +12,26 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Image is a Docker-specific implementation of types.Image with a few extra methods
+// Image is a Docker-specific implementation of types.ImageCloser with a few extra methods
 // which are specific to Docker.
 type Image struct {
-	types.Image
+	types.ImageCloser
 	src *dockerImageSource
 }
 
 // newImage returns a new Image interface type after setting up
 // a client to the registry hosting the given image.
 // The caller must call .Close() on the returned Image.
-func newImage(ctx *types.SystemContext, ref dockerReference) (types.Image, error) {
+func newImage(ctx *types.SystemContext, ref dockerReference) (types.ImageCloser, error) {
 	s, err := newImageSource(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
-	img, err := image.FromSource(s)
+	img, err := image.FromSource(ctx, s)
 	if err != nil {
 		return nil, err
 	}
-	return &Image{Image: img, src: s}, nil
+	return &Image{ImageCloser: img, src: s}, nil
 }
 
 // SourceRefFullName returns a fully expanded name for the repository this image is in.

--- a/vendor/github.com/containers/image/docker/docker_image_dest.go
+++ b/vendor/github.com/containers/image/docker/docker_image_dest.go
@@ -236,7 +236,7 @@ func (d *dockerImageDestination) PutManifest(m []byte) error {
 		return err
 	}
 	defer res.Body.Close()
-	if res.StatusCode != http.StatusCreated {
+	if !successStatus(res.StatusCode) {
 		err = errors.Wrapf(client.HandleErrorResponse(res), "Error uploading manifest to %s", path)
 		if isManifestInvalidError(errors.Cause(err)) {
 			err = types.ManifestTypeRejectedError{Err: err}
@@ -244,6 +244,12 @@ func (d *dockerImageDestination) PutManifest(m []byte) error {
 		return err
 	}
 	return nil
+}
+
+// successStatus returns true if the argument is a successful HTTP response
+// code (in the range 200 - 399 inclusive).
+func successStatus(status int) bool {
+	return status >= 200 && status <= 399
 }
 
 // isManifestInvalidError returns true iff err from client.HandleErrorReponse is a “manifest invalid” error.

--- a/vendor/github.com/containers/image/docker/docker_image_src.go
+++ b/vendor/github.com/containers/image/docker/docker_image_src.go
@@ -67,7 +67,12 @@ func simplifyContentType(contentType string) string {
 
 // GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
 // It may use a remote (= slow) service.
-func (s *dockerImageSource) GetManifest() ([]byte, string, error) {
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+func (s *dockerImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+	if instanceDigest != nil {
+		return s.fetchManifest(context.TODO(), instanceDigest.String())
+	}
 	err := s.ensureManifestIsLoaded(context.TODO())
 	if err != nil {
 		return nil, "", err
@@ -94,18 +99,12 @@ func (s *dockerImageSource) fetchManifest(ctx context.Context, tagOrDigest strin
 	return manblob, simplifyContentType(res.Header.Get("Content-Type")), nil
 }
 
-// GetTargetManifest returns an image's manifest given a digest.
-// This is mainly used to retrieve a single image's manifest out of a manifest list.
-func (s *dockerImageSource) GetTargetManifest(digest digest.Digest) ([]byte, string, error) {
-	return s.fetchManifest(context.TODO(), digest.String())
-}
-
 // ensureManifestIsLoaded sets s.cachedManifest and s.cachedManifestMIMEType
 //
 // ImageSource implementations are not required or expected to do any caching,
 // but because our signatures are “attached” to the manifest digest,
-// we need to ensure that the digest of the manifest returned by GetManifest
-// and used by GetSignatures are consistent, otherwise we would get spurious
+// we need to ensure that the digest of the manifest returned by GetManifest(nil)
+// and used by GetSignatures(ctx, nil) are consistent, otherwise we would get spurious
 // signature verification failures when pulling while a tag is being updated.
 func (s *dockerImageSource) ensureManifestIsLoaded(ctx context.Context) error {
 	if s.cachedManifest != nil {
@@ -176,22 +175,30 @@ func (s *dockerImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, 
 	return res.Body, getBlobSize(res), nil
 }
 
-func (s *dockerImageSource) GetSignatures(ctx context.Context) ([][]byte, error) {
+// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+func (s *dockerImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
 	if err := s.c.detectProperties(ctx); err != nil {
 		return nil, err
 	}
 	switch {
 	case s.c.signatureBase != nil:
-		return s.getSignaturesFromLookaside(ctx)
+		return s.getSignaturesFromLookaside(ctx, instanceDigest)
 	case s.c.supportsSignatures:
-		return s.getSignaturesFromAPIExtension(ctx)
+		return s.getSignaturesFromAPIExtension(ctx, instanceDigest)
 	default:
 		return [][]byte{}, nil
 	}
 }
 
-// manifestDigest returns a digest of the manifest, either from the supplied reference or from a fetched manifest.
-func (s *dockerImageSource) manifestDigest(ctx context.Context) (digest.Digest, error) {
+// manifestDigest returns a digest of the manifest, from instanceDigest if non-nil; or from the supplied reference,
+// or finally, from a fetched manifest.
+func (s *dockerImageSource) manifestDigest(ctx context.Context, instanceDigest *digest.Digest) (digest.Digest, error) {
+	if instanceDigest != nil {
+		return *instanceDigest, nil
+	}
 	if digested, ok := s.ref.ref.(reference.Digested); ok {
 		d := digested.Digest()
 		if d.Algorithm() == digest.Canonical {
@@ -206,8 +213,8 @@ func (s *dockerImageSource) manifestDigest(ctx context.Context) (digest.Digest, 
 
 // getSignaturesFromLookaside implements GetSignatures() from the lookaside location configured in s.c.signatureBase,
 // which is not nil.
-func (s *dockerImageSource) getSignaturesFromLookaside(ctx context.Context) ([][]byte, error) {
-	manifestDigest, err := s.manifestDigest(ctx)
+func (s *dockerImageSource) getSignaturesFromLookaside(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	manifestDigest, err := s.manifestDigest(ctx, instanceDigest)
 	if err != nil {
 		return nil, err
 	}
@@ -276,8 +283,8 @@ func (s *dockerImageSource) getOneSignature(ctx context.Context, url *url.URL) (
 }
 
 // getSignaturesFromAPIExtension implements GetSignatures() using the X-Registry-Supports-Signatures API extension.
-func (s *dockerImageSource) getSignaturesFromAPIExtension(ctx context.Context) ([][]byte, error) {
-	manifestDigest, err := s.manifestDigest(ctx)
+func (s *dockerImageSource) getSignaturesFromAPIExtension(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	manifestDigest, err := s.manifestDigest(ctx, instanceDigest)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containers/image/docker/docker_transport.go
+++ b/vendor/github.com/containers/image/docker/docker_transport.go
@@ -122,11 +122,12 @@ func (ref dockerReference) PolicyConfigurationNamespaces() []string {
 	return policyconfiguration.DockerReferenceNamespaces(ref.ref)
 }
 
-// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
-// The caller must call .Close() on the returned Image.
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
-func (ref dockerReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (ref dockerReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	return newImage(ctx, ref)
 }
 

--- a/vendor/github.com/containers/image/docker/tarfile/dest.go
+++ b/vendor/github.com/containers/image/docker/tarfile/dest.go
@@ -11,14 +11,13 @@ import (
 	"time"
 
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/internal/tmpdir"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
-
-const temporaryDirectoryForBigFiles = "/var/tmp" // Do not use the system default of os.TempDir(), usually /tmp, because with systemd it could be a tmpfs.
 
 // Destination is a partial implementation of types.ImageDestination for writing to an io.Writer.
 type Destination struct {
@@ -107,7 +106,7 @@ func (d *Destination) PutBlob(stream io.Reader, inputInfo types.BlobInfo) (types
 
 	if inputInfo.Size == -1 { // Ouch, we need to stream the blob into a temporary file just to determine the size.
 		logrus.Debugf("docker tarfile: input with unknown size, streaming to disk first ...")
-		streamCopy, err := ioutil.TempFile(temporaryDirectoryForBigFiles, "docker-tarfile-blob")
+		streamCopy, err := ioutil.TempFile(tmpdir.TemporaryDirectoryForBigFiles(), "docker-tarfile-blob")
 		if err != nil {
 			return types.BlobInfo{}, err
 		}

--- a/vendor/github.com/containers/image/docker/tarfile/src.go
+++ b/vendor/github.com/containers/image/docker/tarfile/src.go
@@ -249,7 +249,13 @@ func (s *Source) prepareLayerData(tarManifest *ManifestItem, parsedConfig *image
 
 // GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
 // It may use a remote (= slow) service.
-func (s *Source) GetManifest() ([]byte, string, error) {
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+func (s *Source) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+	if instanceDigest != nil {
+		// How did we even get here? GetManifest(nil) has returned a manifest.DockerV2Schema2MediaType.
+		return nil, "", errors.Errorf(`Manifest lists are not supported by "docker-daemon:"`)
+	}
 	if s.generatedManifest == nil {
 		if err := s.ensureCachedDataIsPresent(); err != nil {
 			return nil, "", err
@@ -282,13 +288,6 @@ func (s *Source) GetManifest() ([]byte, string, error) {
 		s.generatedManifest = manifestBytes
 	}
 	return s.generatedManifest, manifest.DockerV2Schema2MediaType, nil
-}
-
-// GetTargetManifest returns an image's manifest given a digest. This is mainly used to retrieve a single image's manifest
-// out of a manifest list.
-func (s *Source) GetTargetManifest(digest digest.Digest) ([]byte, string, error) {
-	// How did we even get here? GetManifest() above has returned a manifest.DockerV2Schema2MediaType.
-	return nil, "", errors.Errorf(`Manifest lists are not supported by "docker-daemon:"`)
 }
 
 type readCloseWrapper struct {
@@ -355,6 +354,13 @@ func (s *Source) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, error) {
 }
 
 // GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
-func (s *Source) GetSignatures(ctx context.Context) ([][]byte, error) {
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+func (s *Source) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	if instanceDigest != nil {
+		// How did we even get here? GetManifest(nil) has returned a manifest.DockerV2Schema2MediaType.
+		return nil, errors.Errorf(`Manifest lists are not supported by "docker-daemon:"`)
+	}
 	return [][]byte{}, nil
 }

--- a/vendor/github.com/containers/image/image/docker_list.go
+++ b/vendor/github.com/containers/image/image/docker_list.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"encoding/json"
+	"fmt"
 	"runtime"
 
 	"github.com/containers/image/manifest"
@@ -31,22 +32,36 @@ type manifestList struct {
 	Manifests     []manifestDescriptor `json:"manifests"`
 }
 
-func manifestSchema2FromManifestList(src types.ImageSource, manblob []byte) (genericManifest, error) {
-	list := manifestList{}
-	if err := json.Unmarshal(manblob, &list); err != nil {
-		return nil, err
+// chooseDigestFromManifestList parses blob as a schema2 manifest list,
+// and returns the digest of the image appropriate for the current environment.
+func chooseDigestFromManifestList(ctx *types.SystemContext, blob []byte) (digest.Digest, error) {
+	wantedArch := runtime.GOARCH
+	if ctx != nil && ctx.ArchitectureChoice != "" {
+		wantedArch = ctx.ArchitectureChoice
 	}
-	var targetManifestDigest digest.Digest
+	wantedOS := runtime.GOOS
+	if ctx != nil && ctx.OSChoice != "" {
+		wantedOS = ctx.OSChoice
+	}
+
+	list := manifestList{}
+	if err := json.Unmarshal(blob, &list); err != nil {
+		return "", err
+	}
 	for _, d := range list.Manifests {
-		if d.Platform.Architecture == runtime.GOARCH && d.Platform.OS == runtime.GOOS {
-			targetManifestDigest = d.Digest
-			break
+		if d.Platform.Architecture == wantedArch && d.Platform.OS == wantedOS {
+			return d.Digest, nil
 		}
 	}
-	if targetManifestDigest == "" {
-		return nil, errors.New("no supported platform found in manifest list")
+	return "", fmt.Errorf("no image found in manifest list for architecture %s, OS %s", wantedArch, wantedOS)
+}
+
+func manifestSchema2FromManifestList(ctx *types.SystemContext, src types.ImageSource, manblob []byte) (genericManifest, error) {
+	targetManifestDigest, err := chooseDigestFromManifestList(ctx, manblob)
+	if err != nil {
+		return nil, err
 	}
-	manblob, mt, err := src.GetTargetManifest(targetManifestDigest)
+	manblob, mt, err := src.GetManifest(&targetManifestDigest)
 	if err != nil {
 		return nil, err
 	}
@@ -59,5 +74,20 @@ func manifestSchema2FromManifestList(src types.ImageSource, manblob []byte) (gen
 		return nil, errors.Errorf("Manifest image does not match selected manifest digest %s", targetManifestDigest)
 	}
 
-	return manifestInstanceFromBlob(src, manblob, mt)
+	return manifestInstanceFromBlob(ctx, src, manblob, mt)
+}
+
+// ChooseManifestInstanceFromManifestList returns a digest of a manifest appropriate
+// for the current system from the manifest available from src.
+func ChooseManifestInstanceFromManifestList(ctx *types.SystemContext, src types.UnparsedImage) (digest.Digest, error) {
+	// For now this only handles manifest.DockerV2ListMediaType; we can generalize it later,
+	// probably along with manifest list editing.
+	blob, mt, err := src.Manifest()
+	if err != nil {
+		return "", err
+	}
+	if mt != manifest.DockerV2ListMediaType {
+		return "", fmt.Errorf("Internal error: Trying to select an image from a non-manifest-list manifest type %s", mt)
+	}
+	return chooseDigestFromManifestList(ctx, blob)
 }

--- a/vendor/github.com/containers/image/image/docker_schema2.go
+++ b/vendor/github.com/containers/image/image/docker_schema2.go
@@ -157,13 +157,16 @@ func (m *manifestSchema2) imageInspectInfo() (*types.ImageInspectInfo, error) {
 	if err := json.Unmarshal(config, v1); err != nil {
 		return nil, err
 	}
-	return &types.ImageInspectInfo{
+	i := &types.ImageInspectInfo{
 		DockerVersion: v1.DockerVersion,
 		Created:       v1.Created,
-		Labels:        v1.Config.Labels,
 		Architecture:  v1.Architecture,
 		Os:            v1.OS,
-	}, nil
+	}
+	if v1.Config != nil {
+		i.Labels = v1.Config.Labels
+	}
+	return i, nil
 }
 
 // UpdatedImageNeedsLayerDiffIDs returns true iff UpdatedImage(options) needs InformationOnly.LayerDiffIDs.

--- a/vendor/github.com/containers/image/image/manifest.go
+++ b/vendor/github.com/containers/image/image/manifest.go
@@ -87,7 +87,9 @@ type genericManifest interface {
 	UpdatedImage(options types.ManifestUpdateOptions) (types.Image, error)
 }
 
-func manifestInstanceFromBlob(src types.ImageSource, manblob []byte, mt string) (genericManifest, error) {
+// manifestInstanceFromBlob returns a genericManifest implementation for (manblob, mt) in src.
+// If manblob is a manifest list, it implicitly chooses an appropriate image from the list.
+func manifestInstanceFromBlob(ctx *types.SystemContext, src types.ImageSource, manblob []byte, mt string) (genericManifest, error) {
 	switch mt {
 	// "application/json" is a valid v2s1 value per https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-1.md .
 	// This works for now, when nothing else seems to return "application/json"; if that were not true, the mapping/detection might
@@ -99,7 +101,7 @@ func manifestInstanceFromBlob(src types.ImageSource, manblob []byte, mt string) 
 	case manifest.DockerV2Schema2MediaType:
 		return manifestSchema2FromManifest(src, manblob)
 	case manifest.DockerV2ListMediaType:
-		return manifestSchema2FromManifestList(src, manblob)
+		return manifestSchema2FromManifestList(ctx, src, manblob)
 	default:
 		// If it's not a recognized manifest media type, or we have failed determining the type, we'll try one last time
 		// to deserialize using v2s1 as per https://github.com/docker/distribution/blob/master/manifests.go#L108

--- a/vendor/github.com/containers/image/image/memory.go
+++ b/vendor/github.com/containers/image/image/memory.go
@@ -33,11 +33,6 @@ func (i *memoryImage) Reference() types.ImageReference {
 	return nil
 }
 
-// Close removes resources associated with an initialized UnparsedImage, if any.
-func (i *memoryImage) Close() error {
-	return nil
-}
-
 // Size returns the size of the image as stored, if known, or -1 if not.
 func (i *memoryImage) Size() (int64, error) {
 	return -1, nil
@@ -65,9 +60,4 @@ func (i *memoryImage) Signatures(ctx context.Context) ([][]byte, error) {
 // Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
 func (i *memoryImage) Inspect() (*types.ImageInspectInfo, error) {
 	return inspectManifest(i.genericManifest)
-}
-
-// IsMultiImage returns true if the image's manifest is a list of images, false otherwise.
-func (i *memoryImage) IsMultiImage() bool {
-	return false
 }

--- a/vendor/github.com/containers/image/image/oci.go
+++ b/vendor/github.com/containers/image/image/oci.go
@@ -109,7 +109,7 @@ func (m *manifestOCI1) OCIConfig() (*imgspecv1.Image, error) {
 func (m *manifestOCI1) LayerInfos() []types.BlobInfo {
 	blobs := []types.BlobInfo{}
 	for _, layer := range m.LayersDescriptors {
-		blobs = append(blobs, types.BlobInfo{Digest: layer.Digest, Size: layer.Size, Annotations: layer.Annotations, URLs: layer.URLs})
+		blobs = append(blobs, types.BlobInfo{Digest: layer.Digest, Size: layer.Size, Annotations: layer.Annotations, URLs: layer.URLs, MediaType: layer.MediaType})
 	}
 	return blobs
 }
@@ -130,13 +130,16 @@ func (m *manifestOCI1) imageInspectInfo() (*types.ImageInspectInfo, error) {
 	if err := json.Unmarshal(config, v1); err != nil {
 		return nil, err
 	}
-	return &types.ImageInspectInfo{
+	i := &types.ImageInspectInfo{
 		DockerVersion: v1.DockerVersion,
 		Created:       v1.Created,
-		Labels:        v1.Config.Labels,
 		Architecture:  v1.Architecture,
 		Os:            v1.OS,
-	}, nil
+	}
+	if v1.Config != nil {
+		i.Labels = v1.Config.Labels
+	}
+	return i, nil
 }
 
 // UpdatedImageNeedsLayerDiffIDs returns true iff UpdatedImage(options) needs InformationOnly.LayerDiffIDs.

--- a/vendor/github.com/containers/image/image/sourced.go
+++ b/vendor/github.com/containers/image/image/sourced.go
@@ -4,12 +4,22 @@
 package image
 
 import (
-	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 )
 
-// FromSource returns a types.Image implementation for source.
-// The caller must call .Close() on the returned Image.
+// imageCloser implements types.ImageCloser, perhaps allowing simple users
+// to use a single object without having keep a reference to a types.ImageSource
+// only to call types.ImageSource.Close().
+type imageCloser struct {
+	types.Image
+	src types.ImageSource
+}
+
+// FromSource returns a types.ImageCloser implementation for the default instance of source.
+// If source is a manifest list, .Manifest() still returns the manifest list,
+// but other methods transparently return data from an appropriate image instance.
+//
+// The caller must call .Close() on the returned ImageCloser.
 //
 // FromSource “takes ownership” of the input ImageSource and will call src.Close()
 // when the image is closed.  (This does not prevent callers from using both the
@@ -18,8 +28,19 @@ import (
 //
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage instead of calling this function.
-func FromSource(src types.ImageSource) (types.Image, error) {
-	return FromUnparsedImage(UnparsedFromSource(src))
+func FromSource(ctx *types.SystemContext, src types.ImageSource) (types.ImageCloser, error) {
+	img, err := FromUnparsedImage(ctx, UnparsedInstance(src, nil))
+	if err != nil {
+		return nil, err
+	}
+	return &imageCloser{
+		Image: img,
+		src:   src,
+	}, nil
+}
+
+func (ic *imageCloser) Close() error {
+	return ic.src.Close()
 }
 
 // sourcedImage is a general set of utilities for working with container images,
@@ -38,19 +59,14 @@ type sourcedImage struct {
 }
 
 // FromUnparsedImage returns a types.Image implementation for unparsed.
-// The caller must call .Close() on the returned Image.
+// If unparsed represents a manifest list, .Manifest() still returns the manifest list,
+// but other methods transparently return data from an appropriate single image.
 //
-// FromSource “takes ownership” of the input UnparsedImage and will call uparsed.Close()
-// when the image is closed.  (This does not prevent callers from using both the
-// UnparsedImage and ImageSource objects simultaneously, but it means that they only need to
-// keep a reference to the Image.)
-func FromUnparsedImage(unparsed *UnparsedImage) (types.Image, error) {
+// The Image must not be used after the underlying ImageSource is Close()d.
+func FromUnparsedImage(ctx *types.SystemContext, unparsed *UnparsedImage) (types.Image, error) {
 	// Note that the input parameter above is specifically *image.UnparsedImage, not types.UnparsedImage:
 	// we want to be able to use unparsed.src.  We could make that an explicit interface, but, well,
 	// this is the only UnparsedImage implementation around, anyway.
-
-	// Also, we do not explicitly implement types.Image.Close; we let the implementation fall through to
-	// unparsed.Close.
 
 	// NOTE: It is essential for signature verification that all parsing done in this object happens on the same manifest which is returned by unparsed.Manifest().
 	manifestBlob, manifestMIMEType, err := unparsed.Manifest()
@@ -58,7 +74,7 @@ func FromUnparsedImage(unparsed *UnparsedImage) (types.Image, error) {
 		return nil, err
 	}
 
-	parsedManifest, err := manifestInstanceFromBlob(unparsed.src, manifestBlob, manifestMIMEType)
+	parsedManifest, err := manifestInstanceFromBlob(ctx, unparsed.src, manifestBlob, manifestMIMEType)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +99,4 @@ func (i *sourcedImage) Manifest() ([]byte, string, error) {
 
 func (i *sourcedImage) Inspect() (*types.ImageInspectInfo, error) {
 	return inspectManifest(i.genericManifest)
-}
-
-func (i *sourcedImage) IsMultiImage() bool {
-	return i.manifestMIMEType == manifest.DockerV2ListMediaType
 }

--- a/vendor/github.com/containers/image/image/unparsed.go
+++ b/vendor/github.com/containers/image/image/unparsed.go
@@ -11,8 +11,10 @@ import (
 )
 
 // UnparsedImage implements types.UnparsedImage .
+// An UnparsedImage is a pair of (ImageSource, instance digest); it can represent either a manifest list or a single image instance.
 type UnparsedImage struct {
 	src            types.ImageSource
+	instanceDigest *digest.Digest
 	cachedManifest []byte // A private cache for Manifest(); nil if not yet known.
 	// A private cache for Manifest(), may be the empty string if guessing failed.
 	// Valid iff cachedManifest is not nil.
@@ -20,49 +22,41 @@ type UnparsedImage struct {
 	cachedSignatures       [][]byte // A private cache for Signatures(); nil if not yet known.
 }
 
-// UnparsedFromSource returns a types.UnparsedImage implementation for source.
-// The caller must call .Close() on the returned UnparsedImage.
+// UnparsedInstance returns a types.UnparsedImage implementation for (source, instanceDigest).
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list).
 //
-// UnparsedFromSource “takes ownership” of the input ImageSource and will call src.Close()
-// when the image is closed.  (This does not prevent callers from using both the
-// UnparsedImage and ImageSource objects simultaneously, but it means that they only need to
-// keep a reference to the UnparsedImage.)
-func UnparsedFromSource(src types.ImageSource) *UnparsedImage {
-	return &UnparsedImage{src: src}
+// The UnparsedImage must not be used after the underlying ImageSource is Close()d.
+func UnparsedInstance(src types.ImageSource, instanceDigest *digest.Digest) *UnparsedImage {
+	return &UnparsedImage{
+		src:            src,
+		instanceDigest: instanceDigest,
+	}
 }
 
 // Reference returns the reference used to set up this source, _as specified by the user_
 // (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 func (i *UnparsedImage) Reference() types.ImageReference {
+	// Note that this does not depend on instanceDigest; e.g. all instances within a manifest list need to be signed with the manifest list identity.
 	return i.src.Reference()
-}
-
-// Close removes resources associated with an initialized UnparsedImage, if any.
-func (i *UnparsedImage) Close() error {
-	return i.src.Close()
 }
 
 // Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
 func (i *UnparsedImage) Manifest() ([]byte, string, error) {
 	if i.cachedManifest == nil {
-		m, mt, err := i.src.GetManifest()
+		m, mt, err := i.src.GetManifest(i.instanceDigest)
 		if err != nil {
 			return nil, "", err
 		}
 
 		// ImageSource.GetManifest does not do digest verification, but we do;
 		// this immediately protects also any user of types.Image.
-		ref := i.Reference().DockerReference()
-		if ref != nil {
-			if canonical, ok := ref.(reference.Canonical); ok {
-				digest := digest.Digest(canonical.Digest())
-				matches, err := manifest.MatchesDigest(m, digest)
-				if err != nil {
-					return nil, "", errors.Wrap(err, "Error computing manifest digest")
-				}
-				if !matches {
-					return nil, "", errors.Errorf("Manifest does not match provided manifest digest %s", digest)
-				}
+		if digest, haveDigest := i.expectedManifestDigest(); haveDigest {
+			matches, err := manifest.MatchesDigest(m, digest)
+			if err != nil {
+				return nil, "", errors.Wrap(err, "Error computing manifest digest")
+			}
+			if !matches {
+				return nil, "", errors.Errorf("Manifest does not match provided manifest digest %s", digest)
 			}
 		}
 
@@ -72,10 +66,26 @@ func (i *UnparsedImage) Manifest() ([]byte, string, error) {
 	return i.cachedManifest, i.cachedManifestMIMEType, nil
 }
 
+// expectedManifestDigest returns a the expected value of the manifest digest, and an indicator whether it is known.
+// The bool return value seems redundant with digest != ""; it is used explicitly
+// to refuse (unexpected) situations when the digest exists but is "".
+func (i *UnparsedImage) expectedManifestDigest() (digest.Digest, bool) {
+	if i.instanceDigest != nil {
+		return *i.instanceDigest, true
+	}
+	ref := i.Reference().DockerReference()
+	if ref != nil {
+		if canonical, ok := ref.(reference.Canonical); ok {
+			return canonical.Digest(), true
+		}
+	}
+	return "", false
+}
+
 // Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
 func (i *UnparsedImage) Signatures(ctx context.Context) ([][]byte, error) {
 	if i.cachedSignatures == nil {
-		sigs, err := i.src.GetSignatures(ctx)
+		sigs, err := i.src.GetSignatures(ctx, i.instanceDigest)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/containers/image/internal/tmpdir/tmpdir.go
+++ b/vendor/github.com/containers/image/internal/tmpdir/tmpdir.go
@@ -1,0 +1,19 @@
+package tmpdir
+
+import (
+	"os"
+	"runtime"
+)
+
+// TemporaryDirectoryForBigFiles returns a directory for temporary (big) files.
+// On non Windows systems it avoids the use of os.TempDir(), because the default temporary directory usually falls under /tmp
+// which on systemd based systems could be the unsuitable tmpfs filesystem.
+func TemporaryDirectoryForBigFiles() string {
+	var temporaryDirectoryForBigFiles string
+	if runtime.GOOS == "windows" {
+		temporaryDirectoryForBigFiles = os.TempDir()
+	} else {
+		temporaryDirectoryForBigFiles = "/var/tmp"
+	}
+	return temporaryDirectoryForBigFiles
+}

--- a/vendor/github.com/containers/image/manifest/manifest.go
+++ b/vendor/github.com/containers/image/manifest/manifest.go
@@ -35,7 +35,7 @@ var DefaultRequestedManifestMIMETypes = []string{
 	DockerV2Schema2MediaType,
 	DockerV2Schema1SignedMediaType,
 	DockerV2Schema1MediaType,
-	// DockerV2ListMediaType, // FIXME: Restore this ASAP
+	DockerV2ListMediaType,
 }
 
 // GuessMIMEType guesses MIME type of a manifest and returns it _if it is recognized_, or "" if unknown or unrecognized.
@@ -141,4 +141,9 @@ func AddDummyV2S1Signature(manifest []byte) ([]byte, error) {
 		return nil, err
 	}
 	return js.PrettySignature("signatures")
+}
+
+// MIMETypeIsMultiImage returns true if mimeType is a list of images
+func MIMETypeIsMultiImage(mimeType string) bool {
+	return mimeType == DockerV2ListMediaType
 }

--- a/vendor/github.com/containers/image/oci/archive/oci_src.go
+++ b/vendor/github.com/containers/image/oci/archive/oci_src.go
@@ -68,14 +68,12 @@ func (s *ociArchiveImageSource) Close() error {
 	return s.unpackedSrc.Close()
 }
 
-// GetManifest returns the image's manifest along with its MIME type
-// (which may be empty when it can't be determined but the manifest is available).
-func (s *ociArchiveImageSource) GetManifest() ([]byte, string, error) {
-	return s.unpackedSrc.GetManifest()
-}
-
-func (s *ociArchiveImageSource) GetTargetManifest(digest digest.Digest) ([]byte, string, error) {
-	return s.unpackedSrc.GetTargetManifest(digest)
+// GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
+// It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+func (s *ociArchiveImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+	return s.unpackedSrc.GetManifest(instanceDigest)
 }
 
 // GetBlob returns a stream for the specified blob, and the blob's size.
@@ -83,6 +81,10 @@ func (s *ociArchiveImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int
 	return s.unpackedSrc.GetBlob(info)
 }
 
-func (s *ociArchiveImageSource) GetSignatures(c context.Context) ([][]byte, error) {
-	return s.unpackedSrc.GetSignatures(c)
+// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+func (s *ociArchiveImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	return s.unpackedSrc.GetSignatures(ctx, instanceDigest)
 }

--- a/vendor/github.com/containers/image/oci/internal/oci_util.go
+++ b/vendor/github.com/containers/image/oci/internal/oci_util.go
@@ -1,0 +1,126 @@
+package internal
+
+import (
+	"github.com/pkg/errors"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+// annotation spex from https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
+const (
+	separator = `(?:[-._:@+]|--)`
+	alphanum  = `(?:[A-Za-z0-9]+)`
+	component = `(?:` + alphanum + `(?:` + separator + alphanum + `)*)`
+)
+
+var refRegexp = regexp.MustCompile(`^` + component + `(?:/` + component + `)*$`)
+var windowsRefRegexp = regexp.MustCompile(`^([a-zA-Z]:\\.+?):(.*)$`)
+
+// ValidateImageName returns nil if the image name is empty or matches the open-containers image name specs.
+// In any other case an error is returned.
+func ValidateImageName(image string) error {
+	if len(image) == 0 {
+		return nil
+	}
+
+	var err error
+	if !refRegexp.MatchString(image) {
+		err = errors.Errorf("Invalid image %s", image)
+	}
+	return err
+}
+
+// SplitPathAndImage tries to split the provided OCI reference into the OCI path and image.
+// Neither path nor image parts are validated at this stage.
+func SplitPathAndImage(reference string) (string, string) {
+	if runtime.GOOS == "windows" {
+		return splitPathAndImageWindows(reference)
+	}
+	return splitPathAndImageNonWindows(reference)
+}
+
+func splitPathAndImageWindows(reference string) (string, string) {
+	groups := windowsRefRegexp.FindStringSubmatch(reference)
+	// nil group means no match
+	if groups == nil {
+		return reference, ""
+	}
+
+	// we expect three elements. First one full match, second the capture group for the path and
+	// the third the capture group for the image
+	if len(groups) != 3 {
+		return reference, ""
+	}
+	return groups[1], groups[2]
+}
+
+func splitPathAndImageNonWindows(reference string) (string, string) {
+	sep := strings.SplitN(reference, ":", 2)
+	path := sep[0]
+
+	var image string
+	if len(sep) == 2 {
+		image = sep[1]
+	}
+	return path, image
+}
+
+// ValidateOCIPath takes the OCI path and validates it.
+func ValidateOCIPath(path string) error {
+	if runtime.GOOS == "windows" {
+		// On Windows we must allow for a ':' as part of the path
+		if strings.Count(path, ":") > 1 {
+			return errors.Errorf("Invalid OCI reference: path %s contains more than one colon", path)
+		}
+	} else {
+		if strings.Contains(path, ":") {
+			return errors.Errorf("Invalid OCI reference: path %s contains a colon", path)
+		}
+	}
+	return nil
+}
+
+// ValidateScope validates a policy configuration scope for an OCI transport.
+func ValidateScope(scope string) error {
+	var err error
+	if runtime.GOOS == "windows" {
+		err = validateScopeWindows(scope)
+	} else {
+		err = validateScopeNonWindows(scope)
+	}
+	if err != nil {
+		return err
+	}
+
+	cleaned := filepath.Clean(scope)
+	if cleaned != scope {
+		return errors.Errorf(`Invalid scope %s: Uses non-canonical path format, perhaps try with path %s`, scope, cleaned)
+	}
+
+	return nil
+}
+
+func validateScopeWindows(scope string) error {
+	matched, _ := regexp.Match(`^[a-zA-Z]:\\`, []byte(scope))
+	if !matched {
+		return errors.Errorf("Invalid scope '%s'. Must be an absolute path", scope)
+	}
+
+	return nil
+}
+
+func validateScopeNonWindows(scope string) error {
+	if !strings.HasPrefix(scope, "/") {
+		return errors.Errorf("Invalid scope %s: must be an absolute path", scope)
+	}
+
+	// Refuse also "/", otherwise "/" and "" would have the same semantics,
+	// and "" could be unexpectedly shadowed by the "/" entry.
+	if scope == "/" {
+		return errors.New(`Invalid scope "/": Use the generic default scope ""`)
+	}
+
+	return nil
+}

--- a/vendor/github.com/containers/image/oci/layout/oci_dest.go
+++ b/vendor/github.com/containers/image/oci/layout/oci_dest.go
@@ -18,21 +18,47 @@ import (
 )
 
 type ociImageDestination struct {
-	ref   ociReference
-	index imgspecv1.Index
+	ref           ociReference
+	index         imgspecv1.Index
+	sharedBlobDir string
 }
 
 // newImageDestination returns an ImageDestination for writing to an existing directory.
-func newImageDestination(ref ociReference) (types.ImageDestination, error) {
+func newImageDestination(ctx *types.SystemContext, ref ociReference) (types.ImageDestination, error) {
 	if ref.image == "" {
 		return nil, errors.Errorf("cannot save image with empty image.ref.name")
 	}
-	index := imgspecv1.Index{
-		Versioned: imgspec.Versioned{
-			SchemaVersion: 2,
-		},
+
+	var index *imgspecv1.Index
+	if indexExists(ref) {
+		var err error
+		index, err = ref.getIndex()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		index = &imgspecv1.Index{
+			Versioned: imgspec.Versioned{
+				SchemaVersion: 2,
+			},
+		}
 	}
-	return &ociImageDestination{ref: ref, index: index}, nil
+
+	d := &ociImageDestination{ref: ref, index: *index}
+	if ctx != nil {
+		d.sharedBlobDir = ctx.OCISharedBlobDirPath
+	}
+
+	if err := ensureDirectoryExists(d.ref.dir); err != nil {
+		return nil, err
+	}
+	// Per the OCI image specification, layouts MUST have a "blobs" subdirectory,
+	// but it MAY be empty (e.g. if we never end up calling PutBlob)
+	// https://github.com/opencontainers/image-spec/blame/7c889fafd04a893f5c5f50b7ab9963d5d64e5242/image-layout.md#L19
+	if err := ensureDirectoryExists(filepath.Join(d.ref.dir, "blobs")); err != nil {
+		return nil, err
+	}
+	return d, nil
 }
 
 // Reference returns the reference used to set up this destination.  Note that this should directly correspond to user's intent,
@@ -81,16 +107,16 @@ func (d *ociImageDestination) MustMatchRuntimeOS() bool {
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 func (d *ociImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo) (types.BlobInfo, error) {
-	if err := ensureDirectoryExists(d.ref.dir); err != nil {
-		return types.BlobInfo{}, err
-	}
 	blobFile, err := ioutil.TempFile(d.ref.dir, "oci-put-blob")
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
 	succeeded := false
+	explicitClosed := false
 	defer func() {
-		blobFile.Close()
+		if !explicitClosed {
+			blobFile.Close()
+		}
 		if !succeeded {
 			os.Remove(blobFile.Name())
 		}
@@ -110,17 +136,28 @@ func (d *ociImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo
 	if err := blobFile.Sync(); err != nil {
 		return types.BlobInfo{}, err
 	}
-	if err := blobFile.Chmod(0644); err != nil {
-		return types.BlobInfo{}, err
+
+	// On POSIX systems, blobFile was created with mode 0600, so we need to make it readable.
+	// On Windows, the “permissions of newly created files” argument to syscall.Open is
+	// ignored and the file is already readable; besides, blobFile.Chmod, i.e. syscall.Fchmod,
+	// always fails on Windows.
+	if runtime.GOOS != "windows" {
+		if err := blobFile.Chmod(0644); err != nil {
+			return types.BlobInfo{}, err
+		}
 	}
 
-	blobPath, err := d.ref.blobPath(computedDigest)
+	blobPath, err := d.ref.blobPath(computedDigest, d.sharedBlobDir)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
 	if err := ensureParentDirectoryExists(blobPath); err != nil {
 		return types.BlobInfo{}, err
 	}
+
+	// need to explicitly close the file, since a rename won't otherwise not work on Windows
+	blobFile.Close()
+	explicitClosed = true
 	if err := os.Rename(blobFile.Name(), blobPath); err != nil {
 		return types.BlobInfo{}, err
 	}
@@ -136,7 +173,7 @@ func (d *ociImageDestination) HasBlob(info types.BlobInfo) (bool, int64, error) 
 	if info.Digest == "" {
 		return false, -1, errors.Errorf(`"Can not check for a blob with unknown digest`)
 	}
-	blobPath, err := d.ref.blobPath(info.Digest)
+	blobPath, err := d.ref.blobPath(info.Digest, d.sharedBlobDir)
 	if err != nil {
 		return false, -1, err
 	}
@@ -169,7 +206,7 @@ func (d *ociImageDestination) PutManifest(m []byte) error {
 	desc.MediaType = imgspecv1.MediaTypeImageManifest
 	desc.Size = int64(len(m))
 
-	blobPath, err := d.ref.blobPath(digest)
+	blobPath, err := d.ref.blobPath(digest, d.sharedBlobDir)
 	if err != nil {
 		return err
 	}
@@ -191,23 +228,20 @@ func (d *ociImageDestination) PutManifest(m []byte) error {
 		Architecture: runtime.GOARCH,
 		OS:           runtime.GOOS,
 	}
-	d.index.Manifests = append(d.index.Manifests, desc)
+	d.addManifest(&desc)
 
 	return nil
 }
 
-func ensureDirectoryExists(path string) error {
-	if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
-		if err := os.MkdirAll(path, 0755); err != nil {
-			return err
+func (d *ociImageDestination) addManifest(desc *imgspecv1.Descriptor) {
+	for i, manifest := range d.index.Manifests {
+		if manifest.Annotations["org.opencontainers.image.ref.name"] == desc.Annotations["org.opencontainers.image.ref.name"] {
+			// TODO Should there first be a cleanup based on the descriptor we are going to replace?
+			d.index.Manifests[i] = *desc
+			return
 		}
 	}
-	return nil
-}
-
-// ensureParentDirectoryExists ensures the parent of the supplied path exists.
-func ensureParentDirectoryExists(path string) error {
-	return ensureDirectoryExists(filepath.Dir(path))
+	d.index.Manifests = append(d.index.Manifests, *desc)
 }
 
 func (d *ociImageDestination) PutSignatures(signatures [][]byte) error {
@@ -230,4 +264,31 @@ func (d *ociImageDestination) Commit() error {
 		return err
 	}
 	return ioutil.WriteFile(d.ref.indexPath(), indexJSON, 0644)
+}
+
+func ensureDirectoryExists(path string) error {
+	if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ensureParentDirectoryExists ensures the parent of the supplied path exists.
+func ensureParentDirectoryExists(path string) error {
+	return ensureDirectoryExists(filepath.Dir(path))
+}
+
+// indexExists checks whether the index location specified in the OCI reference exists.
+// The implementation is opinionated, since in case of unexpected errors false is returned
+func indexExists(ref ociReference) bool {
+	_, err := os.Stat(ref.indexPath())
+	if err == nil {
+		return true
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	return true
 }

--- a/vendor/github.com/containers/image/oci/layout/oci_src.go
+++ b/vendor/github.com/containers/image/oci/layout/oci_src.go
@@ -17,9 +17,10 @@ import (
 )
 
 type ociImageSource struct {
-	ref        ociReference
-	descriptor imgspecv1.Descriptor
-	client     *http.Client
+	ref           ociReference
+	descriptor    imgspecv1.Descriptor
+	client        *http.Client
+	sharedBlobDir string
 }
 
 // newImageSource returns an ImageSource for reading from an existing directory.
@@ -40,7 +41,12 @@ func newImageSource(ctx *types.SystemContext, ref ociReference) (types.ImageSour
 	if err != nil {
 		return nil, err
 	}
-	return &ociImageSource{ref: ref, descriptor: descriptor, client: client}, nil
+	d := &ociImageSource{ref: ref, descriptor: descriptor, client: client}
+	if ctx != nil {
+		// TODO(jonboulle): check dir existence?
+		d.sharedBlobDir = ctx.OCISharedBlobDirPath
+	}
+	return d, nil
 }
 
 // Reference returns the reference used to set up this source.
@@ -55,8 +61,26 @@ func (s *ociImageSource) Close() error {
 
 // GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
 // It may use a remote (= slow) service.
-func (s *ociImageSource) GetManifest() ([]byte, string, error) {
-	manifestPath, err := s.ref.blobPath(digest.Digest(s.descriptor.Digest))
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+func (s *ociImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+	var dig digest.Digest
+	var mimeType string
+	if instanceDigest == nil {
+		dig = digest.Digest(s.descriptor.Digest)
+		mimeType = s.descriptor.MediaType
+	} else {
+		dig = *instanceDigest
+		// XXX: instanceDigest means that we don't immediately have the context of what
+		//      mediaType the manifest has. In OCI this means that we don't know
+		//      what reference it came from, so we just *assume* that its
+		//      MediaTypeImageManifest.
+		// FIXME: We should actually be able to look up the manifest in the index,
+		// and see the MIME type there.
+		mimeType = imgspecv1.MediaTypeImageManifest
+	}
+
+	manifestPath, err := s.ref.blobPath(dig, s.sharedBlobDir)
 	if err != nil {
 		return nil, "", err
 	}
@@ -65,25 +89,7 @@ func (s *ociImageSource) GetManifest() ([]byte, string, error) {
 		return nil, "", err
 	}
 
-	return m, s.descriptor.MediaType, nil
-}
-
-func (s *ociImageSource) GetTargetManifest(digest digest.Digest) ([]byte, string, error) {
-	manifestPath, err := s.ref.blobPath(digest)
-	if err != nil {
-		return nil, "", err
-	}
-
-	m, err := ioutil.ReadFile(manifestPath)
-	if err != nil {
-		return nil, "", err
-	}
-
-	// XXX: GetTargetManifest means that we don't have the context of what
-	//      mediaType the manifest has. In OCI this means that we don't know
-	//      what reference it came from, so we just *assume* that its
-	//      MediaTypeImageManifest.
-	return m, imgspecv1.MediaTypeImageManifest, nil
+	return m, mimeType, nil
 }
 
 // GetBlob returns a stream for the specified blob, and the blob's size.
@@ -92,7 +98,7 @@ func (s *ociImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, err
 		return s.getExternalBlob(info.URLs)
 	}
 
-	path, err := s.ref.blobPath(info.Digest)
+	path, err := s.ref.blobPath(info.Digest, s.sharedBlobDir)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -108,7 +114,11 @@ func (s *ociImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, err
 	return r, fi.Size(), nil
 }
 
-func (s *ociImageSource) GetSignatures(context.Context) ([][]byte, error) {
+// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+func (s *ociImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
 	return [][]byte{}, nil
 }
 

--- a/vendor/github.com/containers/image/oci/layout/oci_transport.go
+++ b/vendor/github.com/containers/image/oci/layout/oci_transport.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/containers/image/directory/explicitfilepath"
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/image"
+	"github.com/containers/image/oci/internal"
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
@@ -36,45 +36,12 @@ func (t ociTransport) ParseReference(reference string) (types.ImageReference, er
 	return ParseReference(reference)
 }
 
-// annotation spex from https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
-const (
-	separator = `(?:[-._:@+]|--)`
-	alphanum  = `(?:[A-Za-z0-9]+)`
-	component = `(?:` + alphanum + `(?:` + separator + alphanum + `)*)`
-)
-
-var refRegexp = regexp.MustCompile(`^` + component + `(?:/` + component + `)*$`)
-
 // ValidatePolicyConfigurationScope checks that scope is a valid name for a signature.PolicyTransportScopes keys
 // (i.e. a valid PolicyConfigurationIdentity() or PolicyConfigurationNamespaces() return value).
 // It is acceptable to allow an invalid value which will never be matched, it can "only" cause user confusion.
 // scope passed to this function will not be "", that value is always allowed.
 func (t ociTransport) ValidatePolicyConfigurationScope(scope string) error {
-	var dir string
-	sep := strings.SplitN(scope, ":", 2)
-	dir = sep[0]
-
-	if len(sep) == 2 {
-		image := sep[1]
-		if !refRegexp.MatchString(image) {
-			return errors.Errorf("Invalid image %s", image)
-		}
-	}
-
-	if !strings.HasPrefix(dir, "/") {
-		return errors.Errorf("Invalid scope %s: must be an absolute path", scope)
-	}
-	// Refuse also "/", otherwise "/" and "" would have the same semantics,
-	// and "" could be unexpectedly shadowed by the "/" entry.
-	// (Note: we do allow "/:someimage", a bit ridiculous but why refuse it?)
-	if scope == "/" {
-		return errors.New(`Invalid scope "/": Use the generic default scope ""`)
-	}
-	cleaned := filepath.Clean(dir)
-	if cleaned != dir {
-		return errors.Errorf(`Invalid scope %s: Uses non-canonical path format, perhaps try with path %s`, scope, cleaned)
-	}
-	return nil
+	return internal.ValidateScope(scope)
 }
 
 // ociReference is an ImageReference for OCI directory paths.
@@ -92,13 +59,7 @@ type ociReference struct {
 
 // ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an OCI ImageReference.
 func ParseReference(reference string) (types.ImageReference, error) {
-	var dir, image string
-	sep := strings.SplitN(reference, ":", 2)
-	dir = sep[0]
-
-	if len(sep) == 2 {
-		image = sep[1]
-	}
+	dir, image := internal.SplitPathAndImage(reference)
 	return NewReference(dir, image)
 }
 
@@ -111,14 +72,15 @@ func NewReference(dir, image string) (types.ImageReference, error) {
 	if err != nil {
 		return nil, err
 	}
-	// This is necessary to prevent directory paths returned by PolicyConfigurationNamespaces
-	// from being ambiguous with values of PolicyConfigurationIdentity.
-	if strings.Contains(resolved, ":") {
-		return nil, errors.Errorf("Invalid OCI reference %s:%s: path %s contains a colon", dir, image, resolved)
+
+	if err := internal.ValidateOCIPath(dir); err != nil {
+		return nil, err
 	}
-	if len(image) > 0 && !refRegexp.MatchString(image) {
-		return nil, errors.Errorf("Invalid image %s", image)
+
+	if err = internal.ValidateImageName(image); err != nil {
+		return nil, err
 	}
+
 	return ociReference{dir: dir, resolvedDir: resolved, image: image}, nil
 }
 
@@ -177,26 +139,38 @@ func (ref ociReference) PolicyConfigurationNamespaces() []string {
 	return res
 }
 
-// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
-// The caller must call .Close() on the returned Image.
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
-func (ref ociReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (ref ociReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	src, err := newImageSource(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
-	return image.FromSource(src)
+	return image.FromSource(ctx, src)
+}
+
+// getIndex returns a pointer to the index references by this ociReference. If an error occurs opening an index nil is returned together
+// with an error.
+func (ref ociReference) getIndex() (*imgspecv1.Index, error) {
+	indexJSON, err := os.Open(ref.indexPath())
+	if err != nil {
+		return nil, err
+	}
+	defer indexJSON.Close()
+
+	index := &imgspecv1.Index{}
+	if err := json.NewDecoder(indexJSON).Decode(index); err != nil {
+		return nil, err
+	}
+	return index, nil
 }
 
 func (ref ociReference) getManifestDescriptor() (imgspecv1.Descriptor, error) {
-	indexJSON, err := os.Open(ref.indexPath())
+	index, err := ref.getIndex()
 	if err != nil {
-		return imgspecv1.Descriptor{}, err
-	}
-	defer indexJSON.Close()
-	index := imgspecv1.Index{}
-	if err := json.NewDecoder(indexJSON).Decode(&index); err != nil {
 		return imgspecv1.Descriptor{}, err
 	}
 
@@ -250,7 +224,7 @@ func (ref ociReference) NewImageSource(ctx *types.SystemContext) (types.ImageSou
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
 func (ref ociReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
-	return newImageDestination(ref)
+	return newImageDestination(ctx, ref)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.
@@ -269,9 +243,13 @@ func (ref ociReference) indexPath() string {
 }
 
 // blobPath returns a path for a blob within a directory using OCI image-layout conventions.
-func (ref ociReference) blobPath(digest digest.Digest) (string, error) {
+func (ref ociReference) blobPath(digest digest.Digest, sharedBlobDir string) (string, error) {
 	if err := digest.Validate(); err != nil {
 		return "", errors.Wrapf(err, "unexpected digest reference %s", digest)
 	}
-	return filepath.Join(ref.dir, "blobs", digest.Algorithm().String(), digest.Hex()), nil
+	blobDir := filepath.Join(ref.dir, "blobs")
+	if sharedBlobDir != "" {
+		blobDir = sharedBlobDir
+	}
+	return filepath.Join(blobDir, digest.Algorithm().String(), digest.Hex()), nil
 }

--- a/vendor/github.com/containers/image/openshift/openshift.go
+++ b/vendor/github.com/containers/image/openshift/openshift.go
@@ -200,20 +200,15 @@ func (s *openshiftImageSource) Close() error {
 	return nil
 }
 
-func (s *openshiftImageSource) GetTargetManifest(digest digest.Digest) ([]byte, string, error) {
-	if err := s.ensureImageIsResolved(context.TODO()); err != nil {
-		return nil, "", err
-	}
-	return s.docker.GetTargetManifest(digest)
-}
-
 // GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
 // It may use a remote (= slow) service.
-func (s *openshiftImageSource) GetManifest() ([]byte, string, error) {
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+func (s *openshiftImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
 	if err := s.ensureImageIsResolved(context.TODO()); err != nil {
 		return nil, "", err
 	}
-	return s.docker.GetManifest()
+	return s.docker.GetManifest(instanceDigest)
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
@@ -224,12 +219,21 @@ func (s *openshiftImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int6
 	return s.docker.GetBlob(info)
 }
 
-func (s *openshiftImageSource) GetSignatures(ctx context.Context) ([][]byte, error) {
-	if err := s.ensureImageIsResolved(ctx); err != nil {
-		return nil, err
+// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+func (s *openshiftImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	var imageName string
+	if instanceDigest == nil {
+		if err := s.ensureImageIsResolved(ctx); err != nil {
+			return nil, err
+		}
+		imageName = s.imageStreamImageName
+	} else {
+		imageName = instanceDigest.String()
 	}
-
-	image, err := s.client.getImage(ctx, s.imageStreamImageName)
+	image, err := s.client.getImage(ctx, imageName)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containers/image/openshift/openshift_transport.go
+++ b/vendor/github.com/containers/image/openshift/openshift_transport.go
@@ -125,16 +125,17 @@ func (ref openshiftReference) PolicyConfigurationNamespaces() []string {
 	return policyconfiguration.DockerReferenceNamespaces(ref.dockerReference)
 }
 
-// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
-// The caller must call .Close() on the returned Image.
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
-func (ref openshiftReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (ref openshiftReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
 	src, err := newImageSource(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
-	return genericImage.FromSource(src)
+	return genericImage.FromSource(ctx, src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference.

--- a/vendor/github.com/containers/image/ostree/ostree_src.go
+++ b/vendor/github.com/containers/image/ostree/ostree_src.go
@@ -1,0 +1,349 @@
+// +build !containers_image_ostree_stub
+
+package ostree
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strconv"
+	"strings"
+	"unsafe"
+
+	"github.com/containers/image/manifest"
+	"github.com/containers/image/types"
+	"github.com/containers/storage/pkg/ioutils"
+	"github.com/opencontainers/go-digest"
+	glib "github.com/ostreedev/ostree-go/pkg/glibobject"
+	"github.com/pkg/errors"
+	"github.com/vbatts/tar-split/tar/asm"
+	"github.com/vbatts/tar-split/tar/storage"
+)
+
+// #cgo pkg-config: glib-2.0 gobject-2.0 ostree-1
+// #include <glib.h>
+// #include <glib-object.h>
+// #include <gio/gio.h>
+// #include <stdlib.h>
+// #include <ostree.h>
+// #include <gio/ginputstream.h>
+import "C"
+
+type ostreeImageSource struct {
+	ref    ostreeReference
+	tmpDir string
+	repo   *C.struct_OstreeRepo
+}
+
+// newImageSource returns an ImageSource for reading from an existing directory.
+func newImageSource(ctx *types.SystemContext, tmpDir string, ref ostreeReference) (types.ImageSource, error) {
+	return &ostreeImageSource{ref: ref, tmpDir: tmpDir}, nil
+}
+
+// Reference returns the reference used to set up this source.
+func (s *ostreeImageSource) Reference() types.ImageReference {
+	return s.ref
+}
+
+// Close removes resources associated with an initialized ImageSource, if any.
+func (s *ostreeImageSource) Close() error {
+	if s.repo != nil {
+		C.g_object_unref(C.gpointer(s.repo))
+	}
+	return nil
+}
+
+func (s *ostreeImageSource) getLayerSize(blob string) (int64, error) {
+	b := fmt.Sprintf("ociimage/%s", blob)
+	found, data, err := readMetadata(s.repo, b, "docker.size")
+	if err != nil || !found {
+		return 0, err
+	}
+	return strconv.ParseInt(data, 10, 64)
+}
+
+func (s *ostreeImageSource) getLenSignatures() (int64, error) {
+	b := fmt.Sprintf("ociimage/%s", s.ref.branchName)
+	found, data, err := readMetadata(s.repo, b, "signatures")
+	if err != nil {
+		return -1, err
+	}
+	if !found {
+		// if 'signatures' is not present, just return 0 signatures.
+		return 0, nil
+	}
+	return strconv.ParseInt(data, 10, 64)
+}
+
+func (s *ostreeImageSource) getTarSplitData(blob string) ([]byte, error) {
+	b := fmt.Sprintf("ociimage/%s", blob)
+	found, out, err := readMetadata(s.repo, b, "tarsplit.output")
+	if err != nil || !found {
+		return nil, err
+	}
+	return base64.StdEncoding.DecodeString(out)
+}
+
+// GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
+// It may use a remote (= slow) service.
+func (s *ostreeImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+	if instanceDigest != nil {
+		return nil, "", errors.Errorf(`Manifest lists are not supported by "ostree:"`)
+	}
+	if s.repo == nil {
+		repo, err := openRepo(s.ref.repo)
+		if err != nil {
+			return nil, "", err
+		}
+		s.repo = repo
+	}
+
+	b := fmt.Sprintf("ociimage/%s", s.ref.branchName)
+	found, out, err := readMetadata(s.repo, b, "docker.manifest")
+	if err != nil {
+		return nil, "", err
+	}
+	if !found {
+		return nil, "", errors.New("manifest not found")
+	}
+	m := []byte(out)
+	return m, manifest.GuessMIMEType(m), nil
+}
+
+func (s *ostreeImageSource) GetTargetManifest(digest digest.Digest) ([]byte, string, error) {
+	return nil, "", errors.New("manifest lists are not supported by this transport")
+}
+
+func openRepo(path string) (*C.struct_OstreeRepo, error) {
+	var cerr *C.GError
+	cpath := C.CString(path)
+	defer C.free(unsafe.Pointer(cpath))
+	pathc := C.g_file_new_for_path(cpath)
+	defer C.g_object_unref(C.gpointer(pathc))
+	repo := C.ostree_repo_new(pathc)
+	r := glib.GoBool(glib.GBoolean(C.ostree_repo_open(repo, nil, &cerr)))
+	if !r {
+		C.g_object_unref(C.gpointer(repo))
+		return nil, glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+	}
+	return repo, nil
+}
+
+type ostreePathFileGetter struct {
+	repo       *C.struct_OstreeRepo
+	parentRoot *C.GFile
+}
+
+type ostreeReader struct {
+	stream *C.GFileInputStream
+}
+
+func (o ostreeReader) Close() error {
+	C.g_object_unref(C.gpointer(o.stream))
+	return nil
+}
+func (o ostreeReader) Read(p []byte) (int, error) {
+	var cerr *C.GError
+	instanceCast := C.g_type_check_instance_cast((*C.GTypeInstance)(unsafe.Pointer(o.stream)), C.g_input_stream_get_type())
+	stream := (*C.GInputStream)(unsafe.Pointer(instanceCast))
+
+	b := C.g_input_stream_read_bytes(stream, (C.gsize)(cap(p)), nil, &cerr)
+	if b == nil {
+		return 0, glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+	}
+	defer C.g_bytes_unref(b)
+
+	count := int(C.g_bytes_get_size(b))
+	if count == 0 {
+		return 0, io.EOF
+	}
+	data := (*[1 << 30]byte)(unsafe.Pointer(C.g_bytes_get_data(b, nil)))[:count:count]
+	copy(p, data)
+	return count, nil
+}
+
+func readMetadata(repo *C.struct_OstreeRepo, commit, key string) (bool, string, error) {
+	var cerr *C.GError
+	var ref *C.char
+	defer C.free(unsafe.Pointer(ref))
+
+	cCommit := C.CString(commit)
+	defer C.free(unsafe.Pointer(cCommit))
+
+	if !glib.GoBool(glib.GBoolean(C.ostree_repo_resolve_rev(repo, cCommit, C.gboolean(1), &ref, &cerr))) {
+		return false, "", glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+	}
+
+	if ref == nil {
+		return false, "", nil
+	}
+
+	var variant *C.GVariant
+	if !glib.GoBool(glib.GBoolean(C.ostree_repo_load_variant(repo, C.OSTREE_OBJECT_TYPE_COMMIT, ref, &variant, &cerr))) {
+		return false, "", glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+	}
+	defer C.g_variant_unref(variant)
+	if variant != nil {
+		cKey := C.CString(key)
+		defer C.free(unsafe.Pointer(cKey))
+
+		metadata := C.g_variant_get_child_value(variant, 0)
+		defer C.g_variant_unref(metadata)
+
+		data := C.g_variant_lookup_value(metadata, (*C.gchar)(cKey), nil)
+		if data != nil {
+			defer C.g_variant_unref(data)
+			ptr := (*C.char)(C.g_variant_get_string(data, nil))
+			val := C.GoString(ptr)
+			return true, val, nil
+		}
+	}
+	return false, "", nil
+}
+
+func newOSTreePathFileGetter(repo *C.struct_OstreeRepo, commit string) (*ostreePathFileGetter, error) {
+	var cerr *C.GError
+	var parentRoot *C.GFile
+	cCommit := C.CString(commit)
+	defer C.free(unsafe.Pointer(cCommit))
+	if !glib.GoBool(glib.GBoolean(C.ostree_repo_read_commit(repo, cCommit, &parentRoot, nil, nil, &cerr))) {
+		return &ostreePathFileGetter{}, glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+	}
+
+	C.g_object_ref(C.gpointer(repo))
+
+	return &ostreePathFileGetter{repo: repo, parentRoot: parentRoot}, nil
+}
+
+func (o ostreePathFileGetter) Get(filename string) (io.ReadCloser, error) {
+	var file *C.GFile
+	if strings.HasPrefix(filename, "./") {
+		filename = filename[2:]
+	}
+	cfilename := C.CString(filename)
+	defer C.free(unsafe.Pointer(cfilename))
+
+	file = (*C.GFile)(C.g_file_resolve_relative_path(o.parentRoot, cfilename))
+
+	var cerr *C.GError
+	stream := C.g_file_read(file, nil, &cerr)
+	if stream == nil {
+		return nil, glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+	}
+
+	return &ostreeReader{stream: stream}, nil
+}
+
+func (o ostreePathFileGetter) Close() {
+	C.g_object_unref(C.gpointer(o.repo))
+	C.g_object_unref(C.gpointer(o.parentRoot))
+}
+
+func (s *ostreeImageSource) readSingleFile(commit, path string) (io.ReadCloser, error) {
+	getter, err := newOSTreePathFileGetter(s.repo, commit)
+	if err != nil {
+		return nil, err
+	}
+	defer getter.Close()
+
+	return getter.Get(path)
+}
+
+// GetBlob returns a stream for the specified blob, and the blob's size.
+func (s *ostreeImageSource) GetBlob(info types.BlobInfo) (io.ReadCloser, int64, error) {
+	blob := info.Digest.Hex()
+	branch := fmt.Sprintf("ociimage/%s", blob)
+
+	if s.repo == nil {
+		repo, err := openRepo(s.ref.repo)
+		if err != nil {
+			return nil, 0, err
+		}
+		s.repo = repo
+	}
+
+	layerSize, err := s.getLayerSize(blob)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	tarsplit, err := s.getTarSplitData(blob)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// if tarsplit is nil we are looking at the manifest.  Return directly the file in /content
+	if tarsplit == nil {
+		file, err := s.readSingleFile(branch, "/content")
+		if err != nil {
+			return nil, 0, err
+		}
+		return file, layerSize, nil
+	}
+
+	mf := bytes.NewReader(tarsplit)
+	mfz, err := gzip.NewReader(mf)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer mfz.Close()
+	metaUnpacker := storage.NewJSONUnpacker(mfz)
+
+	getter, err := newOSTreePathFileGetter(s.repo, branch)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	ots := asm.NewOutputTarStream(getter, metaUnpacker)
+
+	pipeReader, pipeWriter := io.Pipe()
+	go func() {
+		io.Copy(pipeWriter, ots)
+		pipeWriter.Close()
+	}()
+
+	rc := ioutils.NewReadCloserWrapper(pipeReader, func() error {
+		getter.Close()
+		return ots.Close()
+	})
+	return rc, layerSize, nil
+}
+
+func (s *ostreeImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	if instanceDigest != nil {
+		return nil, errors.New("manifest lists are not supported by this transport")
+	}
+	lenSignatures, err := s.getLenSignatures()
+	if err != nil {
+		return nil, err
+	}
+	branch := fmt.Sprintf("ociimage/%s", s.ref.branchName)
+
+	if s.repo == nil {
+		repo, err := openRepo(s.ref.repo)
+		if err != nil {
+			return nil, err
+		}
+		s.repo = repo
+	}
+
+	signatures := [][]byte{}
+	for i := int64(1); i <= lenSignatures; i++ {
+		sigReader, err := s.readSingleFile(branch, fmt.Sprintf("/signature-%d", i))
+		if err != nil {
+			return nil, err
+		}
+		defer sigReader.Close()
+
+		sig, err := ioutil.ReadAll(sigReader)
+		if err != nil {
+			return nil, err
+		}
+		signatures = append(signatures, sig)
+	}
+	return signatures, nil
+}

--- a/vendor/github.com/containers/image/signature/policy_config.go
+++ b/vendor/github.com/containers/image/signature/policy_config.go
@@ -70,7 +70,11 @@ func NewPolicyFromFile(fileName string) (*Policy, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewPolicyFromBytes(contents)
+	policy, err := NewPolicyFromBytes(contents)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid policy in %q", fileName)
+	}
+	return policy, nil
 }
 
 // NewPolicyFromBytes returns a policy parsed from the specified blob.

--- a/vendor/github.com/containers/image/storage/storage_reference.go
+++ b/vendor/github.com/containers/image/storage/storage_reference.go
@@ -1,3 +1,5 @@
+// +build !containers_image_storage_stub
+
 package storage
 
 import (
@@ -135,8 +137,13 @@ func (s storageReference) PolicyConfigurationNamespaces() []string {
 	return namespaces
 }
 
-func (s storageReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
-	return newImage(s)
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
+// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
+// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (s storageReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
+	return newImage(ctx, s)
 }
 
 func (s storageReference) DeleteImage(ctx *types.SystemContext) error {

--- a/vendor/github.com/containers/image/storage/storage_transport.go
+++ b/vendor/github.com/containers/image/storage/storage_transport.go
@@ -1,3 +1,5 @@
+// +build !containers_image_storage_stub
+
 package storage
 
 import (
@@ -157,11 +159,11 @@ func (s storageTransport) ParseStoreReference(store storage.Store, ref string) (
 		refname = verboseName(name)
 	}
 	if refname == "" {
-		logrus.Debugf("parsed reference into %q", storeSpec+"@"+id)
+		logrus.Debugf("parsed reference to id into %q", storeSpec+"@"+id)
 	} else if id == "" {
-		logrus.Debugf("parsed reference into %q", storeSpec+refname)
+		logrus.Debugf("parsed reference to refname into %q", storeSpec+refname)
 	} else {
-		logrus.Debugf("parsed reference into %q", storeSpec+refname+"@"+id)
+		logrus.Debugf("parsed reference to refname@id into %q", storeSpec+refname+"@"+id)
 	}
 	return newReference(storageTransport{store: store, defaultUIDMap: s.defaultUIDMap, defaultGIDMap: s.defaultGIDMap}, refname, id, name), nil
 }

--- a/vendor/github.com/containers/image/tarball/doc.go
+++ b/vendor/github.com/containers/image/tarball/doc.go
@@ -1,0 +1,48 @@
+// Package tarball provides a way to generate images using one or more layer
+// tarballs and an optional template configuration.
+//
+// An example:
+//	package main
+//
+//	import (
+//		"fmt"
+//
+//		cp "github.com/containers/image/copy"
+//		"github.com/containers/image/tarball"
+//		"github.com/containers/image/transports/alltransports"
+//
+//		imgspecv1 "github.com/containers/image/transports/alltransports"
+//	)
+//
+//	func imageFromTarball() {
+//		src, err := alltransports.ParseImageName("tarball:/var/cache/mock/fedora-26-x86_64/root_cache/cache.tar.gz")
+//		// - or -
+//		// src, err := tarball.Transport.ParseReference("/var/cache/mock/fedora-26-x86_64/root_cache/cache.tar.gz")
+//		if err != nil {
+//			panic(err)
+//		}
+//		updater, ok := src.(tarball.ConfigUpdater)
+//		if !ok {
+//			panic("unexpected: a tarball reference should implement tarball.ConfigUpdater")
+//		}
+//		config := imgspecv1.Image{
+//			Config: imgspecv1.ImageConfig{
+//				Cmd: []string{"/bin/bash"},
+//			},
+//		}
+//		annotations := make(map[string]string)
+//		annotations[imgspecv1.AnnotationDescription] = "test image built from a mock root cache"
+//		err = updater.ConfigUpdate(config, annotations)
+//		if err != nil {
+//			panic(err)
+//		}
+//		dest, err := alltransports.ParseImageName("docker-daemon:mock:latest")
+//		if err != nil {
+//			panic(err)
+//		}
+//		err = cp.Image(nil, dest, src, nil)
+//		if err != nil {
+//			panic(err)
+//		}
+//	}
+package tarball

--- a/vendor/github.com/containers/image/tarball/tarball_reference.go
+++ b/vendor/github.com/containers/image/tarball/tarball_reference.go
@@ -1,0 +1,93 @@
+package tarball
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/image"
+	"github.com/containers/image/types"
+
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// ConfigUpdater is an interface that ImageReferences for "tarball" images also
+// implement.  It can be used to set values for a configuration, and to set
+// image annotations which will be present in the images returned by the
+// reference's NewImage() or NewImageSource() methods.
+type ConfigUpdater interface {
+	ConfigUpdate(config imgspecv1.Image, annotations map[string]string) error
+}
+
+type tarballReference struct {
+	transport   types.ImageTransport
+	config      imgspecv1.Image
+	annotations map[string]string
+	filenames   []string
+	stdin       []byte
+}
+
+// ConfigUpdate updates the image's default configuration and adds annotations
+// which will be visible in source images created using this reference.
+func (r *tarballReference) ConfigUpdate(config imgspecv1.Image, annotations map[string]string) error {
+	r.config = config
+	if r.annotations == nil {
+		r.annotations = make(map[string]string)
+	}
+	for k, v := range annotations {
+		r.annotations[k] = v
+	}
+	return nil
+}
+
+func (r *tarballReference) Transport() types.ImageTransport {
+	return r.transport
+}
+
+func (r *tarballReference) StringWithinTransport() string {
+	return strings.Join(r.filenames, ":")
+}
+
+func (r *tarballReference) DockerReference() reference.Named {
+	return nil
+}
+
+func (r *tarballReference) PolicyConfigurationIdentity() string {
+	return ""
+}
+
+func (r *tarballReference) PolicyConfigurationNamespaces() []string {
+	return nil
+}
+
+// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+// The caller must call .Close() on the returned ImageCloser.
+// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
+// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
+// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+func (r *tarballReference) NewImage(ctx *types.SystemContext) (types.ImageCloser, error) {
+	src, err := r.NewImageSource(ctx)
+	if err != nil {
+		return nil, err
+	}
+	img, err := image.FromSource(ctx, src)
+	if err != nil {
+		src.Close()
+		return nil, err
+	}
+	return img, nil
+}
+
+func (r *tarballReference) DeleteImage(ctx *types.SystemContext) error {
+	for _, filename := range r.filenames {
+		if err := os.Remove(filename); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("error removing %q: %v", filename, err)
+		}
+	}
+	return nil
+}
+
+func (r *tarballReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
+	return nil, fmt.Errorf("destination not implemented yet")
+}

--- a/vendor/github.com/containers/image/tarball/tarball_src.go
+++ b/vendor/github.com/containers/image/tarball/tarball_src.go
@@ -1,0 +1,260 @@
+package tarball
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/containers/image/types"
+
+	digest "github.com/opencontainers/go-digest"
+	imgspecs "github.com/opencontainers/image-spec/specs-go"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type tarballImageSource struct {
+	reference  tarballReference
+	filenames  []string
+	diffIDs    []digest.Digest
+	diffSizes  []int64
+	blobIDs    []digest.Digest
+	blobSizes  []int64
+	blobTypes  []string
+	config     []byte
+	configID   digest.Digest
+	configSize int64
+	manifest   []byte
+}
+
+func (r *tarballReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
+	// Gather up the digests, sizes, and date information for all of the files.
+	filenames := []string{}
+	diffIDs := []digest.Digest{}
+	diffSizes := []int64{}
+	blobIDs := []digest.Digest{}
+	blobSizes := []int64{}
+	blobTimes := []time.Time{}
+	blobTypes := []string{}
+	for _, filename := range r.filenames {
+		var file *os.File
+		var err error
+		var blobSize int64
+		var blobTime time.Time
+		var reader io.Reader
+		if filename == "-" {
+			blobSize = int64(len(r.stdin))
+			blobTime = time.Now()
+			reader = bytes.NewReader(r.stdin)
+		} else {
+			file, err = os.Open(filename)
+			if err != nil {
+				return nil, fmt.Errorf("error opening %q for reading: %v", filename, err)
+			}
+			defer file.Close()
+			reader = file
+			fileinfo, err := file.Stat()
+			if err != nil {
+				return nil, fmt.Errorf("error reading size of %q: %v", filename, err)
+			}
+			blobSize = fileinfo.Size()
+			blobTime = fileinfo.ModTime()
+		}
+
+		// Default to assuming the layer is compressed.
+		layerType := imgspecv1.MediaTypeImageLayerGzip
+
+		// Set up to digest the file as it is.
+		blobIDdigester := digest.Canonical.Digester()
+		reader = io.TeeReader(reader, blobIDdigester.Hash())
+
+		// Set up to digest the file after we maybe decompress it.
+		diffIDdigester := digest.Canonical.Digester()
+		uncompressed, err := gzip.NewReader(reader)
+		if err == nil {
+			// It is compressed, so the diffID is the digest of the uncompressed version
+			reader = io.TeeReader(uncompressed, diffIDdigester.Hash())
+		} else {
+			// It is not compressed, so the diffID and the blobID are going to be the same
+			diffIDdigester = blobIDdigester
+			layerType = imgspecv1.MediaTypeImageLayer
+			uncompressed = nil
+		}
+		n, err := io.Copy(ioutil.Discard, reader)
+		if err != nil {
+			return nil, fmt.Errorf("error reading %q: %v", filename, err)
+		}
+		if uncompressed != nil {
+			uncompressed.Close()
+		}
+
+		// Grab our uncompressed and possibly-compressed digests and sizes.
+		filenames = append(filenames, filename)
+		diffIDs = append(diffIDs, diffIDdigester.Digest())
+		diffSizes = append(diffSizes, n)
+		blobIDs = append(blobIDs, blobIDdigester.Digest())
+		blobSizes = append(blobSizes, blobSize)
+		blobTimes = append(blobTimes, blobTime)
+		blobTypes = append(blobTypes, layerType)
+	}
+
+	// Build the rootfs and history for the configuration blob.
+	rootfs := imgspecv1.RootFS{
+		Type:    "layers",
+		DiffIDs: diffIDs,
+	}
+	created := time.Time{}
+	history := []imgspecv1.History{}
+	// Pick up the layer comment from the configuration's history list, if one is set.
+	comment := "imported from tarball"
+	if len(r.config.History) > 0 && r.config.History[0].Comment != "" {
+		comment = r.config.History[0].Comment
+	}
+	for i := range diffIDs {
+		createdBy := fmt.Sprintf("/bin/sh -c #(nop) ADD file:%s in %c", diffIDs[i].Hex(), os.PathSeparator)
+		history = append(history, imgspecv1.History{
+			Created:   &blobTimes[i],
+			CreatedBy: createdBy,
+			Comment:   comment,
+		})
+		// Use the mtime of the most recently modified file as the image's creation time.
+		if created.Before(blobTimes[i]) {
+			created = blobTimes[i]
+		}
+	}
+
+	// Pick up other defaults from the config in the reference.
+	config := r.config
+	if config.Created == nil {
+		config.Created = &created
+	}
+	if config.Architecture == "" {
+		config.Architecture = runtime.GOARCH
+	}
+	if config.OS == "" {
+		config.OS = runtime.GOOS
+	}
+	config.RootFS = rootfs
+	config.History = history
+
+	// Encode and digest the image configuration blob.
+	configBytes, err := json.Marshal(&config)
+	if err != nil {
+		return nil, fmt.Errorf("error generating configuration blob for %q: %v", strings.Join(r.filenames, separator), err)
+	}
+	configID := digest.Canonical.FromBytes(configBytes)
+	configSize := int64(len(configBytes))
+
+	// Populate a manifest with the configuration blob and the file as the single layer.
+	layerDescriptors := []imgspecv1.Descriptor{}
+	for i := range blobIDs {
+		layerDescriptors = append(layerDescriptors, imgspecv1.Descriptor{
+			Digest:    blobIDs[i],
+			Size:      blobSizes[i],
+			MediaType: blobTypes[i],
+		})
+	}
+	annotations := make(map[string]string)
+	for k, v := range r.annotations {
+		annotations[k] = v
+	}
+	manifest := imgspecv1.Manifest{
+		Versioned: imgspecs.Versioned{
+			SchemaVersion: 2,
+		},
+		Config: imgspecv1.Descriptor{
+			Digest:    configID,
+			Size:      configSize,
+			MediaType: imgspecv1.MediaTypeImageConfig,
+		},
+		Layers:      layerDescriptors,
+		Annotations: annotations,
+	}
+
+	// Encode the manifest.
+	manifestBytes, err := json.Marshal(&manifest)
+	if err != nil {
+		return nil, fmt.Errorf("error generating manifest for %q: %v", strings.Join(r.filenames, separator), err)
+	}
+
+	// Return the image.
+	src := &tarballImageSource{
+		reference:  *r,
+		filenames:  filenames,
+		diffIDs:    diffIDs,
+		diffSizes:  diffSizes,
+		blobIDs:    blobIDs,
+		blobSizes:  blobSizes,
+		blobTypes:  blobTypes,
+		config:     configBytes,
+		configID:   configID,
+		configSize: configSize,
+		manifest:   manifestBytes,
+	}
+
+	return src, nil
+}
+
+func (is *tarballImageSource) Close() error {
+	return nil
+}
+
+func (is *tarballImageSource) GetBlob(blobinfo types.BlobInfo) (io.ReadCloser, int64, error) {
+	// We should only be asked about things in the manifest.  Maybe the configuration blob.
+	if blobinfo.Digest == is.configID {
+		return ioutil.NopCloser(bytes.NewBuffer(is.config)), is.configSize, nil
+	}
+	// Maybe one of the layer blobs.
+	for i := range is.blobIDs {
+		if blobinfo.Digest == is.blobIDs[i] {
+			// We want to read that layer: open the file or memory block and hand it back.
+			if is.filenames[i] == "-" {
+				return ioutil.NopCloser(bytes.NewBuffer(is.reference.stdin)), int64(len(is.reference.stdin)), nil
+			}
+			reader, err := os.Open(is.filenames[i])
+			if err != nil {
+				return nil, -1, fmt.Errorf("error opening %q: %v", is.filenames[i], err)
+			}
+			return reader, is.blobSizes[i], nil
+		}
+	}
+	return nil, -1, fmt.Errorf("no blob with digest %q found", blobinfo.Digest.String())
+}
+
+// GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
+// It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+func (is *tarballImageSource) GetManifest(instanceDigest *digest.Digest) ([]byte, string, error) {
+	if instanceDigest != nil {
+		return nil, "", fmt.Errorf("manifest lists are not supported by the %q transport", transportName)
+	}
+	return is.manifest, imgspecv1.MediaTypeImageManifest, nil
+}
+
+// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
+// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+// (e.g. if the source never returns manifest lists).
+func (*tarballImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	if instanceDigest != nil {
+		return nil, fmt.Errorf("manifest lists are not supported by the %q transport", transportName)
+	}
+	return nil, nil
+}
+
+func (is *tarballImageSource) Reference() types.ImageReference {
+	return &is.reference
+}
+
+// UpdatedLayerInfos() returns updated layer info that should be used when reading, in preference to values in the manifest, if specified.
+func (*tarballImageSource) UpdatedLayerInfos() []types.BlobInfo {
+	return nil
+}

--- a/vendor/github.com/containers/image/tarball/tarball_transport.go
+++ b/vendor/github.com/containers/image/tarball/tarball_transport.go
@@ -1,0 +1,66 @@
+package tarball
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/containers/image/transports"
+	"github.com/containers/image/types"
+)
+
+const (
+	transportName = "tarball"
+	separator     = ":"
+)
+
+var (
+	// Transport implements the types.ImageTransport interface for "tarball:" images,
+	// which are makeshift images constructed using one or more possibly-compressed tar
+	// archives.
+	Transport = &tarballTransport{}
+)
+
+type tarballTransport struct {
+}
+
+func (t *tarballTransport) Name() string {
+	return transportName
+}
+
+func (t *tarballTransport) ParseReference(reference string) (types.ImageReference, error) {
+	var stdin []byte
+	var err error
+	filenames := strings.Split(reference, separator)
+	for _, filename := range filenames {
+		if filename == "-" {
+			stdin, err = ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				return nil, fmt.Errorf("error buffering stdin: %v", err)
+			}
+			continue
+		}
+		f, err := os.Open(filename)
+		if err != nil {
+			return nil, fmt.Errorf("error opening %q: %v", filename, err)
+		}
+		f.Close()
+	}
+	ref := &tarballReference{
+		transport: t,
+		filenames: filenames,
+		stdin:     stdin,
+	}
+	return ref, nil
+}
+
+func (t *tarballTransport) ValidatePolicyConfigurationScope(scope string) error {
+	// See the explanation in daemonReference.PolicyConfigurationIdentity.
+	return errors.New(`tarball: does not support any scopes except the default "" one`)
+}
+
+func init() {
+	transports.Register(Transport)
+}

--- a/vendor/github.com/containers/image/transports/alltransports/alltransports.go
+++ b/vendor/github.com/containers/image/transports/alltransports/alltransports.go
@@ -13,8 +13,9 @@ import (
 	_ "github.com/containers/image/oci/archive"
 	_ "github.com/containers/image/oci/layout"
 	_ "github.com/containers/image/openshift"
+	_ "github.com/containers/image/tarball"
 	// The ostree transport is registered by ostree*.go
-	_ "github.com/containers/image/storage"
+	// The storage transport is registered by storage*.go
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/pkg/errors"

--- a/vendor/github.com/containers/image/transports/alltransports/storage.go
+++ b/vendor/github.com/containers/image/transports/alltransports/storage.go
@@ -1,0 +1,8 @@
+// +build !containers_image_storage_stub
+
+package alltransports
+
+import (
+	// Register the storage transport
+	_ "github.com/containers/image/storage"
+)

--- a/vendor/github.com/containers/image/transports/alltransports/storage_stub.go
+++ b/vendor/github.com/containers/image/transports/alltransports/storage_stub.go
@@ -1,0 +1,9 @@
+// +build containers_image_storage_stub
+
+package alltransports
+
+import "github.com/containers/image/transports"
+
+func init() {
+	transports.Register(transports.NewStubTransport("containers-storage"))
+}

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -73,11 +73,12 @@ type ImageReference interface {
 	// and each following element to be a prefix of the element preceding it.
 	PolicyConfigurationNamespaces() []string
 
-	// NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
-	// The caller must call .Close() on the returned Image.
+	// NewImage returns a types.ImageCloser for this reference, possibly specialized for this ImageTransport.
+	// The caller must call .Close() on the returned ImageCloser.
 	// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 	// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
-	NewImage(ctx *SystemContext) (Image, error)
+	// WARNING: This may not do the right thing for a manifest list, see image.FromSource for details.
+	NewImage(ctx *SystemContext) (ImageCloser, error)
 	// NewImageSource returns a types.ImageSource for this reference.
 	// The caller must call .Close() on the returned ImageSource.
 	NewImageSource(ctx *SystemContext) (ImageSource, error)
@@ -96,9 +97,10 @@ type BlobInfo struct {
 	Size        int64         // -1 if unknown
 	URLs        []string
 	Annotations map[string]string
+	MediaType   string
 }
 
-// ImageSource is a service, possibly remote (= slow), to download components of a single image.
+// ImageSource is a service, possibly remote (= slow), to download components of a single image or a named image set (manifest list).
 // This is primarily useful for copying images around; for examining their properties, Image (below)
 // is usually more useful.
 // Each ImageSource should eventually be closed by calling Close().
@@ -113,15 +115,17 @@ type ImageSource interface {
 	Close() error
 	// GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
 	// It may use a remote (= slow) service.
-	GetManifest() ([]byte, string, error)
-	// GetTargetManifest returns an image's manifest given a digest. This is mainly used to retrieve a single image's manifest
-	// out of a manifest list.
-	GetTargetManifest(digest digest.Digest) ([]byte, string, error)
+	// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve (when the primary manifest is a manifest list);
+	// this never happens if the primary manifest is not a manifest list (e.g. if the source never returns manifest lists).
+	GetManifest(instanceDigest *digest.Digest) ([]byte, string, error)
 	// GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
-	// The Digest field in BlobInfo is guaranteed to be provided; Size may be -1.
+	// The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 	GetBlob(BlobInfo) (io.ReadCloser, int64, error)
 	// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
-	GetSignatures(context.Context) ([][]byte, error)
+	// If instanceDigest is not nil, it contains a digest of the specific manifest instance to retrieve signatures for
+	// (when the primary manifest is a manifest list); this never happens if the primary manifest is not a manifest list
+	// (e.g. if the source never returns manifest lists).
+	GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error)
 }
 
 // ImageDestination is a service, possibly remote (= slow), to store components of a single image.
@@ -153,9 +157,10 @@ type ImageDestination interface {
 	AcceptsForeignLayerURLs() bool
 	// MustMatchRuntimeOS returns true iff the destination can store only images targeted for the current runtime OS. False otherwise.
 	MustMatchRuntimeOS() bool
-	// PutBlob writes contents of stream and returns data representing the result (with all data filled in).
+	// PutBlob writes contents of stream and returns data representing the result.
 	// inputInfo.Digest can be optionally provided if known; it is not mandatory for the implementation to verify it.
 	// inputInfo.Size is the expected length of stream, if known.
+	// inputInfo.MediaType describes the blob format, if known.
 	// WARNING: The contents of stream are being verified on the fly.  Until stream.Read() returns io.EOF, the contents of the data SHOULD NOT be available
 	// to any other readers for download using the supplied digest.
 	// If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
@@ -194,13 +199,14 @@ func (e ManifestTypeRejectedError) Error() string {
 // Thus, an UnparsedImage can be created from an ImageSource simply by fetching blobs without interpreting them,
 // allowing cryptographic signature verification to happen first, before even fetching the manifest, or parsing anything else.
 // This also makes the UnparsedImage→Image conversion an explicitly visible step.
-// Each UnparsedImage should eventually be closed by calling Close().
+//
+// An UnparsedImage is a pair of (ImageSource, instance digest); it can represent either a manifest list or a single image instance.
+//
+// The UnparsedImage must not be used after the underlying ImageSource is Close()d.
 type UnparsedImage interface {
 	// Reference returns the reference used to set up this source, _as specified by the user_
 	// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 	Reference() ImageReference
-	// Close removes resources associated with an initialized UnparsedImage, if any.
-	Close() error
 	// Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
 	Manifest() ([]byte, string, error)
 	// Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
@@ -208,14 +214,16 @@ type UnparsedImage interface {
 }
 
 // Image is the primary API for inspecting properties of images.
-// Each Image should eventually be closed by calling Close().
+// An Image is based on a pair of (ImageSource, instance digest); it can represent either a manifest list or a single image instance.
+//
+// The Image must not be used after the underlying ImageSource is Close()d.
 type Image interface {
 	// Note that Reference may return nil in the return value of UpdatedImage!
 	UnparsedImage
 	// ConfigInfo returns a complete BlobInfo for the separate config object, or a BlobInfo{Digest:""} if there isn't a separate object.
 	// Note that the config object may not exist in the underlying storage in the return value of UpdatedImage! Use ConfigBlob() below.
 	ConfigInfo() BlobInfo
-	// ConfigBlob returns the blob described by ConfigInfo, iff ConfigInfo().Digest != ""; nil otherwise.
+	// ConfigBlob returns the blob described by ConfigInfo, if ConfigInfo().Digest != ""; nil otherwise.
 	// The result is cached; it is OK to call this however often you need.
 	ConfigBlob() ([]byte, error)
 	// OCIConfig returns the image configuration as per OCI v1 image-spec. Information about
@@ -223,7 +231,7 @@ type Image interface {
 	// old image manifests work (docker v2s1 especially).
 	OCIConfig() (*v1.Image, error)
 	// LayerInfos returns a list of BlobInfos of layers referenced by this image, in order (the root layer first, and then successive layered layers).
-	// The Digest field is guaranteed to be provided; Size may be -1.
+	// The Digest field is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 	// WARNING: The list may contain duplicates, and they are semantically relevant.
 	LayerInfos() []BlobInfo
 	// EmbeddedDockerReferenceConflicts whether a Docker reference embedded in the manifest, if any, conflicts with destination ref.
@@ -240,16 +248,23 @@ type Image interface {
 	// Everything in options.InformationOnly should be provided, other fields should be set only if a modification is desired.
 	// This does not change the state of the original Image object.
 	UpdatedImage(options ManifestUpdateOptions) (Image, error)
-	// IsMultiImage returns true if the image's manifest is a list of images, false otherwise.
-	IsMultiImage() bool
 	// Size returns an approximation of the amount of disk space which is consumed by the image in its current
 	// location.  If the size is not known, -1 will be returned.
 	Size() (int64, error)
 }
 
+// ImageCloser is an Image with a Close() method which must be called by the user.
+// This is returned by ImageReference.NewImage, which transparently instantiates a types.ImageSource,
+// to ensure that the ImageSource is closed.
+type ImageCloser interface {
+	Image
+	// Close removes resources associated with an initialized ImageCloser.
+	Close() error
+}
+
 // ManifestUpdateOptions is a way to pass named optional arguments to Image.UpdatedManifest
 type ManifestUpdateOptions struct {
-	LayerInfos              []BlobInfo // Complete BlobInfos (size+digest+urls) which should replace the originals, in order (the root layer first, and then successive layered layers)
+	LayerInfos              []BlobInfo // Complete BlobInfos (size+digest+urls+annotations) which should replace the originals, in order (the root layer first, and then successive layered layers). BlobInfos' MediaType fields are ignored.
 	EmbeddedDockerReference reference.Named
 	ManifestMIMEType        string
 	// The values below are NOT requests to modify the image; they provide optional context which may or may not be used.
@@ -283,7 +298,7 @@ type DockerAuthConfig struct {
 	Password string
 }
 
-// SystemContext allows parametrizing access to implicitly-accessed resources,
+// SystemContext allows parameterizing access to implicitly-accessed resources,
 // like configuration files in /etc and users' login state in their home directory.
 // Various components can share the same field only if their semantics is exactly
 // the same; if in doubt, add a new field.
@@ -306,6 +321,10 @@ type SystemContext struct {
 	SystemRegistriesConfPath string
 	// If not "", overrides the default path for the authentication file
 	AuthFilePath string
+	// If not "", overrides the use of platform.GOARCH when choosing an image or verifying architecture match.
+	ArchitectureChoice string
+	// If not "", overrides the use of platform.GOOS when choosing an image or verifying OS match.
+	OSChoice string
 
 	// === OCI.Transport overrides ===
 	// If not "", a directory containing a CA certificate (ending with ".crt"),
@@ -314,6 +333,8 @@ type SystemContext struct {
 	OCICertPath string
 	// Allow downloading OCI image layers over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
 	OCIInsecureSkipTLSVerify bool
+	// If not "", use a shared directory for storing blobs rather than within OCI layouts
+	OCISharedBlobDirPath string
 
 	// === docker.Transport overrides ===
 	// If not "", a directory containing a CA certificate (ending with ".crt"),
@@ -322,8 +343,9 @@ type SystemContext struct {
 	DockerCertPath string
 	// If not "", overrides the system’s default path for a directory containing host[:port] subdirectories with the same structure as DockerCertPath above.
 	// Ignored if DockerCertPath is non-empty.
-	DockerPerHostCertDirPath    string
-	DockerInsecureSkipTLSVerify bool // Allow contacting docker registries over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
+	DockerPerHostCertDirPath string
+	// Allow contacting docker registries over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
+	DockerInsecureSkipTLSVerify bool
 	// if nil, the library tries to parse ~/.docker/config.json to retrieve credentials
 	DockerAuthConfig *DockerAuthConfig
 	// if not "", an User-Agent header is added to each request when contacting a registry.
@@ -334,6 +356,20 @@ type SystemContext struct {
 	DockerDisableV1Ping bool
 	// Directory to use for OSTree temporary files
 	OSTreeTmpDirPath string
+
+	// === docker/daemon.Transport overrides ===
+	// A directory containing a CA certificate (ending with ".crt"),
+	// a client certificate (ending with ".cert") and a client certificate key
+	// (ending with ".key") used when talking to a Docker daemon.
+	DockerDaemonCertPath string
+	// The hostname or IP to the Docker daemon. If not set (aka ""), client.DefaultDockerHost is assumed.
+	DockerDaemonHost string
+	// Used to skip TLS verification, off by default. To take effect DockerDaemonCertPath needs to be specified as well.
+	DockerDaemonInsecureSkipTLSVerify bool
+
+	// === dir.Transport overrides ===
+	// DirForceCompress compresses the image layers if set to true
+	DirForceCompress bool
 }
 
 // ProgressProperties is used to pass information from the copy code to a monitor which

--- a/vendor/github.com/containers/image/vendor.conf
+++ b/vendor/github.com/containers/image/vendor.conf
@@ -22,7 +22,7 @@ github.com/pborman/uuid 1b00554d822231195d1babd97ff4a781231955c9
 github.com/pkg/errors 248dadf4e9068a0b3e79f02ed0a610d935de5302
 github.com/pmezard/go-difflib 792786c7400a136282c1664665ae0a8db921c6c2
 github.com/stretchr/testify 4d4bfba8f1d1027c4fdbe371823030df51419987
-github.com/vbatts/tar-split bd4c5d64c3e9297f410025a3b1bd0c58f659e721
+github.com/vbatts/tar-split v0.10.2
 golang.org/x/crypto 453249f01cfeb54c3d549ddb75ff152ca243f9d8
 golang.org/x/net 6b27048ae5e6ad1ef927e72e437531493de612fe
 golang.org/x/sys 43e60d72a8e2bd92ee98319ba9a384a0e9837c08


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Attempt to fix https://bugzilla.redhat.com/show_bug.cgi?id=1540895

**- How I did it**
When reapplying a blob to a storageImageDestination, if we didn't already create an image entry to hold not-layer blobs as big data items, we won't be able to read them.  In that case we should check the cached set of blobs for a matching blob.

**- How to verify it**
Attempt to pull and use the `docker.io/pweil/hello-nginx-docker` image with cri-o 1.9.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
containers/image storage: when reapplying a blob, also check the cached blobs

Current containers/image does this differently than the version we're using in the 1.9 branch, so we don't need to do this in later branches.