### PR TITLE
contrib: test: fix runc build on AMIs

### DIFF
--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -30,7 +30,7 @@
 
     - name: clone build and install runc
       include: "build/runc.yml"
-      when: "{{ not use_system_runc | default(True) | bool}}"
+      when: "{{ build_runc | default(True) | bool}}"
 
     - name: clone build and install networking plugins
       include: "build/plugins.yml"


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

https://github.com/kubernetes-incubator/cri-o/pull/1298 changed the setup of the AMI to actually skip runc build by default and that's causing the whole CI to fail with the ami built from that PR. (i.e. https://github.com/kubernetes-incubator/cri-o/pull/1297)

Fix it by reverting the logic so that we *always* build runc except when asked otherwise

@giuseppe @mrunalp @nalind PTAL

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
