### PR TITLE
cmd/crio: fix listen address dir creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,10 @@ install.tools: .install.gitvalidation .install.gometalinter .install.md2man
 
 .install.md2man: .gopathok
 	if [ ! -x "$(GOPATH)/bin/go-md2man" ]; then \
-		go get -u github.com/cpuguy83/go-md2man; \
+		go get -u -d github.com/cpuguy83/go-md2man; \
+		cd $(GOPATH)/src/github.com/cpuguy83/go-md2man; \
+		git checkout 20f5889cbdc3c73dbd2862796665e7c465ade7d1; \
+		$(GO) install github.com/cpuguy83/go-md2man; \
 	fi
 
 .install.ostree: .gopathok

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -8,6 +8,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -428,6 +429,10 @@ func main() {
 		if _, err := os.Stat(config.Runtime); os.IsNotExist(err) {
 			// path to runtime does not exist
 			return fmt.Errorf("invalid --runtime value %q", err)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(config.Listen), 0755); err != nil {
+			return err
 		}
 
 		// Remove the socket if it already exists

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -34,6 +34,11 @@
     - integration
     - e2e
   tasks:
+    - name: fixup go-md2man
+      shell: |
+              cd {{ ansible_env.GOPATH }}/src/github.com/cpuguy83/go-md2man
+              git checkout 20f5889cbdc3c73dbd2862796665e7c465ade7d1
+              go install github.com/cpuguy83/go-md2man
     - name: clone build and install cri-o
       include: "build/cri-o.yml"
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.0.9-dev"
+const Version = "1.0.9"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.0.9"
+const Version = "1.0.10-dev"


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Allow to create the parent directory for the listen socket. Otherwise, we get failures like https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/18478/test_pull_request_origin_extended_conformance_crio/3888/ in the Origin CI

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

@mrunalp PTAL