### PR TITLE
crio: Ensure container state is stopped when calling StopContainer()

### DIFF
--- a/server/container_stop.go
+++ b/server/container_stop.go
@@ -17,6 +17,11 @@ func (s *Server) StopContainer(ctx context.Context, req *pb.StopContainerRequest
 	}()
 	logrus.Debugf("StopContainerRequest %+v", req)
 
+	if err := s.addContainerToWatcherIgnoreList(req.ContainerId); err != nil {
+		return nil, err
+	}
+	defer s.removeContainerFromWatcherIgnoreList(req.ContainerId)
+
 	_, err = s.ContainerServer.ContainerStop(ctx, req.ContainerId, req.Timeout)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
CRI-O works well with runc when stopping a container because as soon
as the container process returns, it can consider every container
resources such as its rootfs as being freed, and it can proceed
further by unmounting it.

But in case of virtualized runtime such as Clear Containers or Kata
Containers, the same rootfs is being mounted into the VM, usually as
a device being hotplugged. This means the runtime will need to be
triggered after the container process has returned. Particularly,
such runtimes should expect a call into "state" in order to realize
the container process is not running anymore, and it would trigger
the container to be officially stopped, proceeding to the necessary
unmounts.

The way this can be done from CRI-O, without impacting the case of
runc, is to explicitly wait for the container status to be updated
into "stopped" after the container process has returned. This way
CRI-O will call into "state" as long as it cannot see the container
status being updated properly, generating an error after a timeout.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>