### PR TITLE
sandbox: record whether sb is using host network

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -340,6 +340,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 
 	privileged := isTrue(m.Annotations[annotations.PrivilegedRuntime])
 	trusted := isTrue(m.Annotations[annotations.TrustedSandbox])
+	hostNetwork := isTrue(m.Annotations[annotations.HostNetwork])
 
 	sb, err := sandbox.New(id, m.Annotations[annotations.Namespace], name, m.Annotations[annotations.KubeName], filepath.Dir(m.Annotations[annotations.LogPath]), labels, kubeAnnotations, processLabel, mountLabel, &metadata, m.Annotations[annotations.ShmPath], m.Annotations[annotations.CgroupParent], privileged, trusted, m.Annotations[annotations.ResolvPath], m.Annotations[annotations.HostName], portMappings)
 	if err != nil {
@@ -348,6 +349,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	sb.AddHostnamePath(m.Annotations[annotations.HostnamePath])
 	sb.AddIP(ip)
 	sb.SetSeccompProfilePath(spp)
+	sb.SetHostNetwork(hostNetwork)
 
 	// We add a netNS only if we can load a permanent one.
 	// Otherwise, the sandbox will live in the host namespace.

--- a/lib/sandbox/sandbox.go
+++ b/lib/sandbox/sandbox.go
@@ -160,6 +160,7 @@ type Sandbox struct {
 	ip                 string
 	seccompProfilePath string
 	created            time.Time
+	hostNetwork        bool
 }
 
 const (
@@ -222,6 +223,16 @@ func (s *Sandbox) SeccompProfilePath() string {
 // AddIP stores the ip in the sandbox
 func (s *Sandbox) AddIP(ip string) {
 	s.ip = ip
+}
+
+// SetHostNetwork sets whether the pod is running using host network
+func (s *Sandbox) SetHostNetwork(hn bool) {
+	s.hostNetwork = hn
+}
+
+// HostNetwork returns whether the pod is using host network
+func (s *Sandbox) HostNetwork() bool {
+	return s.hostNetwork
 }
 
 // IP returns the ip of the sandbox

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -25,6 +25,9 @@ const (
 	// IP is the container ipv4 or ipv6 address
 	IP = "io.kubernetes.cri-o.IP"
 
+	// HostNetwork tells whether the sandbox is using hostnetwork
+	HostNetwork = "io.kubernetes.cri-o.HostNetwork"
+
 	// SeccompProfilePath is the node seccomp profile path
 	SeccompProfilePath = "io.kubernetes.cri-o.SeccompProfilePath"
 

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -353,6 +353,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	g.AddAnnotation(annotations.TrustedSandbox, fmt.Sprintf("%v", trusted))
 	g.AddAnnotation(annotations.ResolvPath, resolvPath)
 	g.AddAnnotation(annotations.HostName, hostname)
+	g.AddAnnotation(annotations.HostNetwork, fmt.Sprintf("%v", hostNetwork))
 	g.AddAnnotation(annotations.KubeName, kubeName)
 	if podContainer.Config.Config.StopSignal != "" {
 		// this key is defined in image-spec conversion document at https://github.com/opencontainers/image-spec/pull/492/files#diff-8aafbe2c3690162540381b8cdb157112R57
@@ -528,6 +529,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 
 	g.AddAnnotation(annotations.IP, ip)
 	sb.AddIP(ip)
+	sb.SetHostNetwork(hostNetwork)
 
 	spp := req.GetConfig().GetLinux().GetSecurityContext().GetSeccompProfilePath()
 	g.AddAnnotation(annotations.SeccompProfilePath, spp)

--- a/server/sandbox_status.go
+++ b/server/sandbox_status.go
@@ -31,6 +31,14 @@ func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusR
 		rStatus = pb.PodSandboxState_SANDBOX_READY
 	}
 
+	linux := &pb.LinuxPodSandboxStatus{
+		Namespaces: &pb.Namespace{
+			Options: &pb.NamespaceOption{
+				HostNetwork: sb.HostNetwork(),
+			},
+		},
+	}
+
 	sandboxID := sb.ID()
 	resp = &pb.PodSandboxStatusResponse{
 		Status: &pb.PodSandboxStatus{
@@ -41,6 +49,7 @@ func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusR
 			Labels:      sb.Labels(),
 			Annotations: sb.Annotations(),
 			Metadata:    sb.Metadata(),
+			Linux:       linux,
 		},
 	}
 


### PR DESCRIPTION
We need to record whether the sandbox is using hostnetwok because the
kubelet needs that information when computing pod changes. Without this
patch it could happen that a pod that's using host network is restarted
just because the sandbox's status isn't reporting that it's running
using host network.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
