### PR TITLE
Permanently disable swap prior to testing

### DIFF
--- a/contrib/test/integration/disable_swap.yml
+++ b/contrib/test/integration/disable_swap.yml
@@ -1,0 +1,26 @@
+---
+
+- name: All active swap devices are known
+  command: 'swapon --show --ifexists --noheadings'
+  changed_when: False  # only looking
+  register: result
+
+- name: All active swap is disabled
+  command: 'swapoff --all'
+  when: result.stdout_lines | default([], True) | length
+
+- name: All persistent swap devices from fstab are known
+  command: findmnt --fstab --type swap --output SOURCE --noheadings
+  # findmnt exit(1) if no swap devices found, expect real errors to appear on stderr
+  failed_when: result | failed and
+               result.stderr | trim | length
+  changed_when: False  # only looking
+  register: result
+
+- name: Swap configuration does not persist across future reboots
+  mount:
+    path: none
+    src: "{{ item }}"
+    fstype: swap
+    state: absent
+  with_items: '{{ result.stdout_lines | default([], True) }}'

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -47,6 +47,9 @@
   tasks:
     - name: clone build and install cri-o
       include: "build/cri-o.yml"
+  post_tasks:
+    - name: Swap is disused and disabled as required for kubernetes
+      include: "disable_swap.yml"
 
 - hosts: all
   remote_user: root

--- a/contrib/test/integration/system.yml
+++ b/contrib/test/integration/system.yml
@@ -89,14 +89,6 @@
   async: 600
   poll: 10
 
-- name: Setup swap to prevent kernel firing off the OOM killer
-  shell: |
-    truncate -s 8G /root/swap && \
-    export SWAPDEV=$(losetup --show -f /root/swap | head -1) && \
-    mkswap $SWAPDEV && \
-    swapon $SWAPDEV && \
-    swapon --show
-
 - name: ensure directories exist as needed
   file:
     path: "{{ item }}"


### PR DESCRIPTION
fixes #1063

**- What I did**
Removed old/disused swap setup which never persisted after creating AMIs.  Add a few late-stage tasks to disable both active and persistent swap.

**- How I did it**
Tasks added under ``post_tasks`` to suggest they should always happen at the last possible moment.  In case swap ever needs to be enabled prior to this point, for compiling purposes.

**- How to verify it**
CI tests will catch any problems and/or reveal gaps in testing.