### PR TITLE
crio: Ensure container state is stopped when calling StopContainer()

### DIFF
--- a/lib/stop.go
+++ b/lib/stop.go
@@ -24,6 +24,9 @@ func (c *ContainerServer) ContainerStop(ctx context.Context, container string, t
 			if err := c.runtime.StopContainer(ctx, ctr, timeout); err != nil {
 				return "", errors.Wrapf(err, "failed to stop container %s", ctrID)
 			}
+			if err := c.runtime.WaitContainerStateStopped(ctx, ctr, timeout); err != nil {
+				return "", errors.Wrapf(err, "failed to get container 'stopped' status %s", ctrID)
+			}
 			if err := c.storageRuntimeServer.StopContainer(ctrID); err != nil {
 				return "", errors.Wrapf(err, "failed to unmount container %s", ctrID)
 			}


### PR DESCRIPTION
CRI-O works well with runc when stopping a container because as soon
as the container process returns, it can consider every container
resources such as its rootfs as being freed, and it can proceed
further by unmounting it.

But in case of virtualized runtime such as Clear Containers or Kata
Containers, the same rootfs is being mounted into the VM, usually as
a device being hotplugged. This means the runtime will need to be
triggered after the container process has returned. Particularly,
such runtimes should expect a call into "state" in order to realize
the container process is not running anymore, and it would trigger
the container to be officially stopped, proceeding to the necessary
unmounts.

The way this can be done from CRI-O, without impacting the case of
runc, is to explicitly wait for the container status to be updated
into "stopped" after the container process has returned. This way
CRI-O will call into "state" as long as it cannot see the container
status being updated properly, generating an error after a timeout.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>