### PR TITLE
Add extra info to verbose requests to PodSandboxStatus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,15 +35,15 @@ jobs:
       go: tip
     - stage: Build and Verify
       script:
-        - make testunit
+        - sudo "PATH=$PATH" make testunit
         - make
       go: 1.8.x
     - script:
-        - make testunit
+        - sudo "PATH=$PATH" make testunit
         - make
       go: 1.9.x
     - script:
-        - make testunit
+        - sudo "PATH=$PATH" make testunit
         - make
       go: tip
     - stage: Integration Test

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -10,12 +10,6 @@ import (
 
 const fixturePath = "fixtures/crio.conf"
 
-func must(t *testing.T, err error) {
-	if err != nil {
-		t.Error(err)
-	}
-}
-
 func assertAllFieldsEquality(t *testing.T, c Config) {
 	testCases := []struct {
 		fieldValue, expected interface{}

--- a/server/sandbox_status_test.go
+++ b/server/sandbox_status_test.go
@@ -1,0 +1,119 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/kubernetes-incubator/cri-o/lib"
+	"github.com/kubernetes-incubator/cri-o/lib/sandbox"
+	"github.com/kubernetes-incubator/cri-o/oci"
+	"github.com/kubernetes-incubator/cri-o/version"
+	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+)
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
+
+func newTestContainerServerOrFailNow(t *testing.T) (cs *lib.ContainerServer, dirsToCleanUp []string) {
+	tmpdir := os.Getenv("TMPDIR")
+
+	config := lib.DefaultConfig()
+	runRoot, err := ioutil.TempDir(tmpdir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.RootConfig.RunRoot = runRoot
+	root, err := ioutil.TempDir(tmpdir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.RootConfig.Root = root
+	config.RootConfig.Storage = "vfs"
+	cs, err = lib.New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cs, []string{runRoot, root}
+}
+
+func newTestSandboxOrFailNow(t *testing.T) (string, *sandbox.Sandbox) {
+	id := fmt.Sprintf("id-for-sandbox-%d", rand.Int())
+
+	sb, err := sandbox.New(id, "", "", "", "", nil, nil, "", "", nil, "", "", false, false, "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id, sb
+}
+
+func newTestContainerOrFailNow(t *testing.T) *oci.Container {
+	id := fmt.Sprintf("id-for-container-%d", rand.Int())
+
+	c, err := oci.NewContainer(id, "", "", "", nil, nil, nil, nil, "", "", "", nil, "", false, false, false, false, false, "", time.Now(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func setupServer(t *testing.T) (*Server, string, func()) {
+	containerServer, fs := newTestContainerServerOrFailNow(t)
+	teardown := func() {
+		for _, f := range fs {
+			defer os.RemoveAll(f)
+		}
+	}
+
+	server := &Server{ContainerServer: containerServer}
+	sandboxID, sb := newTestSandboxOrFailNow(t)
+	sb.SetInfraContainer(newTestContainerOrFailNow(t))
+	server.PodIDIndex().Add(sandboxID)
+	server.ContainerServer.AddSandbox(sb)
+
+	return server, sandboxID, teardown
+}
+
+func TestPodSandboxStatus(t *testing.T) {
+	server, sandboxID, teardown := setupServer(t)
+	defer teardown()
+
+	t.Run("Without verbose information", func(t *testing.T) {
+		resp, err := server.PodSandboxStatus(nil, &pb.PodSandboxStatusRequest{
+			PodSandboxId: sandboxID,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp.Status == nil {
+			t.Error("expected non nil resp.Status")
+		}
+		if resp.Info != nil {
+			t.Error("expected nil resp.Info")
+		}
+	})
+
+	t.Run("With verbose information", func(t *testing.T) {
+		resp, err := server.PodSandboxStatus(nil, &pb.PodSandboxStatusRequest{
+			PodSandboxId: sandboxID,
+			Verbose:      true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		marshaledVersion := resp.Info["version"]
+		var versionPayload VersionPayload
+		must(t, json.Unmarshal([]byte(marshaledVersion), &versionPayload))
+
+		if version.Version != versionPayload.Version {
+			t.Errorf("expected: %s\ngot: %s", version.Version, versionPayload.Version)
+		}
+	})
+}

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -15,6 +15,12 @@ const (
 	dnsPath        = "fixtures/resolv.conf"
 )
 
+func must(t *testing.T, err error) {
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestParseDNSOptions(t *testing.T) {
 	testCases := []struct {
 		Servers, Searches, Options []string


### PR DESCRIPTION
**What I did**
- I added version info in a JSON object to [this response](https://github.com/kubernetes/kubernetes/blob/c6ddc749e85f4281628f366d65cf924c22d6cd99/pkg/kubelet/apis/cri/v1alpha1/runtime/api.proto#L391) when [verbose is set to true here](https://github.com/kubernetes/kubernetes/blob/c6ddc749e85f4281628f366d65cf924c22d6cd99/pkg/kubelet/apis/cri/v1alpha1/runtime/api.proto#L335).

**How I did it**
- I added some tests to cover the functionality before changing it, these tests include some fixture that maybe could be good to move to some other place.

**How to verify it**
- The tests should be enough, but if that grpc endpoing can be easilly called it should return the version info in a JSON object.
If PodSandboxStatusRequest.Verbose is true now we are returning the cri-o
version in a JSON object for debug purposes. In the future extra information
(to be defined) should be added to the response

**Description for the changelog**
- Add extra info to verbose requests to PodSandboxStatus

**Extra notes**
- We should probably add more info to that endpoint, but I don't know what should be shown there.
- I know that adding an extra vendored dependency could be painful in a big project, but I strongly recommend this: https://github.com/stretchr/testify to don't duplicate asserts logic.
- As I previously mentioned, some of the fixtures I added could be helpful in some other place (or maybe there are already there and I didn't know it).