### PR TITLE
imageService: cache information about images

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -449,7 +449,7 @@ func setupContainerUser(specgen *generate.Generator, rootfs string, sc *pb.Linux
 		containerUser := ""
 		// Case 1: run as user is set by kubelet
 		if sc.GetRunAsUser() != nil {
-			containerUser = strconv.FormatInt(sc.GetRunAsUser().Value, 10)
+			containerUser = strconv.FormatInt(sc.GetRunAsUser().GetValue(), 10)
 		} else {
 			// Case 2: run as username is set by kubelet
 			userName := sc.GetRunAsUsername()

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -31,20 +31,20 @@ func (s *Server) ListImages(ctx context.Context, req *pb.ListImagesRequest) (res
 	}
 	resp = &pb.ListImagesResponse{}
 	for _, result := range results {
-		if result.Size != nil {
-			resp.Images = append(resp.Images, &pb.Image{
-				Id:          result.ID,
-				RepoTags:    result.RepoTags,
-				RepoDigests: result.RepoDigests,
-				Size_:       *result.Size,
-			})
-		} else {
-			resp.Images = append(resp.Images, &pb.Image{
-				Id:          result.ID,
-				RepoTags:    result.RepoTags,
-				RepoDigests: result.RepoDigests,
-			})
+		resImg := &pb.Image{
+			Id:          result.ID,
+			RepoTags:    result.RepoTags,
+			RepoDigests: result.RepoDigests,
 		}
+		uid, username := getUserFromImage(result.User)
+		if uid != nil {
+			resImg.Uid = &pb.Int64Value{Value: *uid}
+		}
+		resImg.Username = username
+		if result.Size != nil {
+			resImg.Size_ = *result.Size
+		}
+		resp.Images = append(resp.Images, resImg)
 	}
 	logrus.Debugf("ListImagesResponse: %+v", resp)
 	return resp, nil


### PR DESCRIPTION
This is #1332 with some caching added, to cache information about images that isn't trivially read from them, so that `ImageStatus` and particularly `ListImages` don't have to do potentially-expensive things for every image that they report.

The cache is an in-memory map, and we prune it after `ListImages` has assembled its result set.

This is an attempt at adding a cache as described at https://github.com/kubernetes-incubator/cri-o/pull/1333#issuecomment-365677747.  I went back and forth on whether or not to just cache the entire image config structure, but that's pretty easy to add if we find that we need to later.