### PR TITLE
Get the terminal size of stdout and set it inside of container

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -27,6 +27,8 @@
 
 #include "cmsg.h"
 
+struct winsize term_ws;
+
 #define pexit(fmt, ...)                                                          \
 	do {                                                                     \
 		fprintf(stderr, "[conmon:e]: " fmt " %m\n", ##__VA_ARGS__);      \
@@ -855,7 +857,7 @@ static gboolean ctrl_cb(int fd, G_GNUC_UNUSED GIOCondition condition, G_GNUC_UNU
 	return G_SOURCE_CONTINUE;
 }
 
-static gboolean terminal_accept_cb(int fd, G_GNUC_UNUSED GIOCondition condition, G_GNUC_UNUSED gpointer user_data)
+static gboolean terminal_accept_cb(int fd, G_GNUC_UNUSED GIOCondition condition, gpointer user_data)
 {
 	const char *csname = user_data;
 	struct file_t console;
@@ -893,6 +895,11 @@ static gboolean terminal_accept_cb(int fd, G_GNUC_UNUSED GIOCondition condition,
 	 * stdout. stderr is ignored. */
 	masterfd_stdin = console.fd;
 	masterfd_stdout = console.fd;
+
+	ninfo("Existing Terminal size: %d %d", term_ws.ws_row, term_ws.ws_col);
+	if (ioctl(masterfd_stdout, TIOCSWINSZ, &term_ws) == -1) {
+		nwarn("Failed to set process pty terminal size");
+	}
 
 	/* Clean up everything */
 	close(connfd);
@@ -1355,6 +1362,9 @@ int main(int argc, char *argv[])
 
 	ninfo("about to waitpid: %d", create_pid);
 	if (csname != NULL) {
+		if (ioctl(1, TIOCGWINSZ, &term_ws) == -1)
+			pexit("Failed to get terminal size of stdout");
+
 		guint terminal_watch = g_unix_fd_add (console_socket_fd, G_IO_IN, terminal_accept_cb, csname);
 		/* Process any SIGCHLD we may have missed before the signal handler was in place.  */
 		check_child_processes (pid_to_handler);


### PR DESCRIPTION
podman needs to have the size of the tty of the terminal it is
running in passed into the tty that will be used by the container.

This seems to fix the issue we are seeing with podman, but not sure
if it breaks cri-o.  Would their be a stdout when CRI-O runs.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
