### PR TITLE
[release-1.9] vendor: update c/image to handle text/plain from registries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ integration: crioimage
 	docker run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e TRAVIS -t --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${CRIO_IMAGE} make localintegration
 
 testunit:
-	$(GO) test -tags "$(BUILDTAGS)" -cover $(PACKAGES)
+	$(GO) test -tags "$(BUILDTAGS) containers_image_ostree_stub" -cover $(PACKAGES)
 
 localintegration: clean binaries test-binaries
 	./test/test_runner.sh ${TESTFLAGS}

--- a/vendor.conf
+++ b/vendor.conf
@@ -12,7 +12,7 @@ github.com/gregjones/httpcache 787624de3eb7bd915c329cba748687a3b22666a6
 github.com/json-iterator/go 1.0.0
 github.com/peterbourgon/diskv v2.0.1
 github.com/sirupsen/logrus v1.0.0
-github.com/containers/image 3d0304a02154dddc8f97cc833aa0861cea5e9ade
+github.com/containers/image 701221f0891d76aeac3f25912e6bb9f84e88de1c
 github.com/docker/docker-credential-helpers d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1
 github.com/ostreedev/ostree-go master
 github.com/containers/storage 0d32dfce498e06c132c60dac945081bf44c22464

--- a/vendor/github.com/containers/image/copy/manifest.go
+++ b/vendor/github.com/containers/image/copy/manifest.go
@@ -46,6 +46,11 @@ func (ic *imageCopier) determineManifestConversion(destSupportedManifestMIMEType
 	if err != nil { // This should have been cached?!
 		return "", nil, errors.Wrap(err, "Error reading manifest")
 	}
+	normalizedSrcType := manifest.NormalizedMIMEType(srcType)
+	if srcType != normalizedSrcType {
+		logrus.Debugf("Source manifest MIME type %s, treating it as %s", srcType, normalizedSrcType)
+		srcType = normalizedSrcType
+	}
 
 	if forceManifestMIMEType != "" {
 		destSupportedManifestMIMETypes = []string{forceManifestMIMEType}

--- a/vendor/github.com/containers/image/directory/directory_dest.go
+++ b/vendor/github.com/containers/image/directory/directory_dest.go
@@ -70,7 +70,7 @@ func newImageDestination(ref dirReference, compress bool) (types.ImageDestinatio
 		}
 	}
 	// create version file
-	err = ioutil.WriteFile(d.ref.versionPath(), []byte(version), 0755)
+	err = ioutil.WriteFile(d.ref.versionPath(), []byte(version), 0644)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating version file %q", d.ref.versionPath())
 	}

--- a/vendor/github.com/containers/image/image/docker_schema1.go
+++ b/vendor/github.com/containers/image/image/docker_schema1.go
@@ -95,7 +95,7 @@ func (m *manifestSchema1) imageInspectInfo() (*types.ImageInspectInfo, error) {
 // This is a horribly specific interface, but computing InformationOnly.LayerDiffIDs can be very expensive to compute
 // (most importantly it forces us to download the full layers even if they are already present at the destination).
 func (m *manifestSchema1) UpdatedImageNeedsLayerDiffIDs(options types.ManifestUpdateOptions) bool {
-	return options.ManifestMIMEType == manifest.DockerV2Schema2MediaType
+	return (options.ManifestMIMEType == manifest.DockerV2Schema2MediaType || options.ManifestMIMEType == imgspecv1.MediaTypeImageManifest)
 }
 
 // UpdatedImage returns a types.Image modified according to options.

--- a/vendor/github.com/containers/image/image/oci.go
+++ b/vendor/github.com/containers/image/image/oci.go
@@ -149,6 +149,16 @@ func (m *manifestOCI1) UpdatedImage(options types.ManifestUpdateOptions) (types.
 
 	switch options.ManifestMIMEType {
 	case "": // No conversion, OK
+	case manifest.DockerV2Schema1MediaType, manifest.DockerV2Schema1SignedMediaType:
+		// We can't directly convert to V1, but we can transitively convert via a V2 image
+		m2, err := copy.convertToManifestSchema2()
+		if err != nil {
+			return nil, err
+		}
+		return m2.UpdatedImage(types.ManifestUpdateOptions{
+			ManifestMIMEType: options.ManifestMIMEType,
+			InformationOnly:  options.InformationOnly,
+		})
 	case manifest.DockerV2Schema2MediaType:
 		return copy.convertToManifestSchema2()
 	default:

--- a/vendor/github.com/containers/image/storage/storage_reference.go
+++ b/vendor/github.com/containers/image/storage/storage_reference.go
@@ -71,8 +71,8 @@ func (s *storageReference) resolveImage() (*storage.Image, error) {
 		}
 	}
 	if s.id == "" {
-		logrus.Errorf("reference %q does not resolve to an image ID", s.StringWithinTransport())
-		return nil, ErrNoSuchImage
+		logrus.Debugf("reference %q does not resolve to an image ID", s.StringWithinTransport())
+		return nil, errors.Wrapf(ErrNoSuchImage, "reference %q does not resolve to an image ID", s.StringWithinTransport())
 	}
 	img, err := s.transport.store.Image(s.id)
 	if err != nil {

--- a/vendor/github.com/containers/image/tarball/tarball_reference.go
+++ b/vendor/github.com/containers/image/tarball/tarball_reference.go
@@ -89,5 +89,5 @@ func (r *tarballReference) DeleteImage(ctx *types.SystemContext) error {
 }
 
 func (r *tarballReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
-	return nil, fmt.Errorf("destination not implemented yet")
+	return nil, fmt.Errorf(`"tarball:" locations can only be read from, not written to`)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.9.6-dev"
+const Version = "1.9.6"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "1.9.6"
+const Version = "1.9.7-dev"


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

re-vendor c/image to pull in the fix about registries serving (wrongly) text/plain
This also bump to 1.9.6

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
