### PR TITLE
Using "/var/run/crio/crio.sock" as endpoint is deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ You can run a local version of kubernetes with CRI-O using `local-up-cluster.sh`
 ```shell
 CGROUP_DRIVER=systemd \
 CONTAINER_RUNTIME=remote \
-CONTAINER_RUNTIME_ENDPOINT='/var/run/crio/crio.sock  --runtime-request-timeout=15m' \
+CONTAINER_RUNTIME_ENDPOINT='unix:///var/run/crio/crio.sock  --runtime-request-timeout=15m' \
 ./hack/local-up-cluster.sh
 ```
 

--- a/contrib/test/integration/node-e2e.yml
+++ b/contrib/test/integration/node-e2e.yml
@@ -18,7 +18,7 @@
     # parametrize crio socket
     # cgroup-driver???
     # TODO(runcom): remove conformance focus, we want everything for testgrid
-    make test-e2e-node PARALLELISM=1 RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT=/var/run/crio.sock IMAGE_SERVICE_ENDPOINT=/var/run/crio/crio.sock TEST_ARGS='--prepull-images=true --kubelet-flags="--cgroup-driver=systemd"' FOCUS="\[Conformance\]" &> {{ artifacts }}/node-e2e.log
+    make test-e2e-node PARALLELISM=1 RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/crio.sock IMAGE_SERVICE_ENDPOINT=/var/run/crio/crio.sock TEST_ARGS='--prepull-images=true --kubelet-flags="--cgroup-driver=systemd"' FOCUS="\[Conformance\]" &> {{ artifacts }}/node-e2e.log
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
   async: 7200

--- a/kubernetes.md
+++ b/kubernetes.md
@@ -77,7 +77,7 @@ KUBELET_ARGS="--pod-manifest-path=/etc/kubernetes/manifests
 You need to add following parameters to `KUBELET_ARGS`:
 * `--experimental-cri=true` - Use Container Runtime Interface. Will be true by default from kubernetes 1.6 release.
 * `--container-runtime=remote` - Use remote runtime with provided socket.
-* `--container-runtime-endpoint=/var/run/crio/crio.sock` - Socket for remote runtime (default `crio` socket localization).
+* `--container-runtime-endpoint=unix:///var/run/crio/crio.sock` - Socket for remote runtime (default `crio` socket localization).
 * `--runtime-request-timeout=10m` - Optional but useful. Some requests, especially pulling huge images, may take longer than default (2 minutes) and will cause an error. 
 
 Kubelet is prepared now.


### PR DESCRIPTION
Addressing deprecation warning
```
I0220 12:43:39.634359    2270 remote_runtime.go:43] Connecting to runtime service /var/run/crio/crio.sock
W0220 12:43:39.634394    2270 util_unix.go:75] Using "/var/run/crio/crio.sock" as endpoint is deprecated, please consider using full url format "unix:///var/run/crio/crio.sock".
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Attempted to start Kubernetes based on the `./hack/local-up-cluster.sh` example in `README.md` and then investigated why I've got no `kubectl get nodes`.

**- How I did it**

```
PATH=/home/test/kubernetes/third_party/etcd:${PATH} CGROUP_DRIVER=systemd CONTAINER_RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT='/var/run/crio/crio.sock  --runtime-request-timeout=15m' ./hack/local-up-cluster.sh
```

and then checked `/tmp/kubelet.log`.

**- How to verify it**

The above command with Kubernetes master (I was at `v1.11.0-alpha.0-166-g5b98dbcfe5`) should reproduce the issue.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
