### PR TITLE
hooks: Copy-edits for the Markdown docs (RFC 2119, etc.)

### DIFF
--- a/hooks.md
+++ b/hooks.md
@@ -33,7 +33,7 @@ The post-stop hooks MUST be called after the container is deleted but before the
 
 ## CRI-O configuration files for automatically enabling Hooks
 
-The way you enable the hooks above is by editing the OCI Specification to add your hook before running the oci runtime, like runc.  But this is what `CRI-O` and `Kpod create` do for you, so we wanted a way for developers to drop configuration files onto the system, so that their hooks would be able to be plugged in.
+The way you enable the hooks above is by editing the OCI Specification to add your hook before running the oci runtime, like runc.  But this is what CRI-O and `Kpod create` do for you, so we wanted a way for developers to drop configuration files onto the system, so that their hooks would be able to be plugged in.
 
 One problem with hooks is that the runtime actually stalls execution of the container before running the hooks and stalls completion of the container, until all hooks complete.  This can cause some performance issues.  Also a lot of hooks just check if certain configuration is set and then exit early, without doing anything.  For example the [oci-systemd-hook](https://github.com/projectatomic/oci-systemd-hook) only executes if the command is `init` or `systemd`, otherwise it just exits.  This means if we automatically enable all hooks, every container will have to execute oci-systemd-hook, even if they don't run systemd inside of the container.   Also since there are three stages, prestart, poststart, poststop each hook gets executed three times.
 

--- a/hooks.md
+++ b/hooks.md
@@ -1,45 +1,14 @@
 # OCI Hooks Configuration
 
-[The OCI Runtime Specification defines POSIX-platform Hooks:](
-https://github.com/opencontainers/runtime-spec/blob/master/config.md#posix-platform-hooks)
-
-## POSIX-platform Hooks
-
-For POSIX platforms, the configuration structure supports hooks for configuring custom actions related to the life cycle of the container.
-
-hooks (object, OPTIONAL) MAY contain any of the following properties:
-
- *  prestart (array of objects, OPTIONAL) is an array of pre-start hooks. Entries in the array contain the following properties:
-    * path (string, REQUIRED) with similar semantics to [IEEE Std 1003.1-2008 execv's path][ieee-1003.1-2008-functions-exec]. This specification extends the IEEE standard in that path MUST be absolute.
-    * args (array of strings, OPTIONAL) with the same semantics as [IEEE Std 1003.1-2008 execv's argv][ieee-1003.1-2008-functions-exec].
-    * env (array of strings, OPTIONAL) with the same semantics as IEEE Std 1003.1-2008's environ.
-    * timeout (int, OPTIONAL) is the number of seconds before aborting the hook. If set, timeout MUST be greater than zero.
- * poststart (array of objects, OPTIONAL) is an array of post-start hooks. Entries in the array have the same schema as pre-start entries.
- * poststop (array of objects, OPTIONAL) is an array of post-stop hooks. Entries in the array have the same schema as pre-start entries.
-
-Hooks allow users to specify programs to run before or after various lifecycle events. Hooks MUST be called in the listed order. The state of the container MUST be passed to hooks over stdin so that they may do work appropriate to the current state of the container.
-
-### Prestart
-
-The Prestart hooks MUST be called after the start operation is called but before the user-specified program command is executed. On Linux, for example, they are called after the container namespaces are created, so they provide an opportunity to customize the container (e.g. the network namespace could be specified in this hook).
-
-### Poststart
-
-The post-start hooks MUST be called after the user-specified process is executed but before the start operation returns. For example, this hook can notify the user that the container process is spawned.
-
-### Poststop
-
-The post-stop hooks MUST be called after the container is deleted but before the delete operation returns. Cleanup or debugging functions are examples of such a hook.
-
-## CRI-O configuration files for automatically enabling Hooks
-
-The way you enable the hooks above is by editing the OCI Specification to add your hook before running the oci runtime, like runc.  But this is what CRI-O and `Kpod create` do for you, so we wanted a way for developers to drop configuration files onto the system, so that their hooks would be able to be plugged in.
+For POSIX platforms, the [OCI runtime configuration][runtime-spec] supports [hooks][spec-hooks] for configuring custom actions related to the life cycle of the container.
+The way you enable the hooks above is by editing the OCI runtime configuration before running the OCI runtime (e.g. [`runc`][runc]).
+CRI-O and `Kpod create` create the OCI configuration for you, and this documentation allows developers to configure CRI-O to set their intended hooks.
 
 One problem with hooks is that the runtime actually stalls execution of the container before running the hooks and stalls completion of the container, until all hooks complete.  This can cause some performance issues.  Also a lot of hooks just check if certain configuration is set and then exit early, without doing anything.  For example the [oci-systemd-hook](https://github.com/projectatomic/oci-systemd-hook) only executes if the command is `init` or `systemd`, otherwise it just exits.  This means if we automatically enable all hooks, every container will have to execute oci-systemd-hook, even if they don't run systemd inside of the container.   Also since there are three stages, prestart, poststart, poststop each hook gets executed three times.
 
 
 
-### Json Definition
+## Json Definition
 
 We decided to add a json file for hook builders which allows them to tell CRI-O when to run the hook and in which stage.
 CRI-O reads all json files in /usr/share/containers/oci/hooks.d/*.json and /etc/containers/oci/hooks.d and sets up the specified hooks to run.  If the same name is in both directories, the one in /etc/containers/oci/hooks.d takes precedence.
@@ -66,7 +35,7 @@ type HookParams struct {
 | hasbindmounts | Tells CRI-O to run the hook if the container has bind mounts from the host into the container | Optional |
 | arguments | Additional arguments to append to the hook command when executing it. For example --debug | Optional |
 
-### Example
+## Example
 
 
 ```
@@ -91,3 +60,7 @@ cat /etc/containers/oci/hooks.d/oci-systemd-hook.json
 }
 ```
 In this example the oci-umount will only be run during the prestart phase if the container has volume/bind mounts from the host into the container, it will also execute oci-umount with the --debug argument.
+
+[runc]: https://github.com/opencontainers/runc
+[runtime-spec]: https://github.com/opencontainers/runtime-spec/blob/v1.0.1/spec.md
+[spec-hooks]: https://github.com/opencontainers/runtime-spec/blob/v1.0.1/config.md#posix-platform-hooks

--- a/hooks.md
+++ b/hooks.md
@@ -4,39 +4,36 @@ For POSIX platforms, the [OCI runtime configuration][runtime-spec] supports [hoo
 The way you enable the hooks above is by editing the OCI runtime configuration before running the OCI runtime (e.g. [`runc`][runc]).
 CRI-O and `Kpod create` create the OCI configuration for you, and this documentation allows developers to configure CRI-O to set their intended hooks.
 
-One problem with hooks is that the runtime actually stalls execution of the container before running the hooks and stalls completion of the container, until all hooks complete.  This can cause some performance issues.  Also a lot of hooks just check if certain configuration is set and then exit early, without doing anything.  For example the [oci-systemd-hook](https://github.com/projectatomic/oci-systemd-hook) only executes if the command is `init` or `systemd`, otherwise it just exits.  This means if we automatically enable all hooks, every container will have to execute oci-systemd-hook, even if they don't run systemd inside of the container.   Also since there are three stages, prestart, poststart, poststop each hook gets executed three times.
+One problem with hooks is that the runtime actually stalls execution of the container before running the hooks and stalls completion of the container, until all hooks complete.  This can cause some performance issues.  Also a lot of hooks just check if certain configuration is set and then exit early, without doing anything.  For example the [oci-systemd-hook](https://github.com/projectatomic/oci-systemd-hook) only executes if the command is `init` or `systemd`, otherwise it just exits.  This means if we automatically enabled all hooks, every container would have to execute `oci-systemd-hook`, even if they don't run systemd inside of the container.   Performance would also suffer if we exectuted each hook at each stage ([pre-start][], [post-start][], and [post-stop][]).
 
+## Notational Conventions
 
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" are to be interpreted as described in [RFC 2119][rfc2119].
 
-## Json Definition
+## JSON Definition
 
-We decided to add a json file for hook builders which allows them to tell CRI-O when to run the hook and in which stage.
-CRI-O reads all json files in /usr/share/containers/oci/hooks.d/*.json and /etc/containers/oci/hooks.d and sets up the specified hooks to run.  If the same name is in both directories, the one in /etc/containers/oci/hooks.d takes precedence.
+CRI-O reads all [JSON][] files in `/usr/share/containers/oci/hooks.d/*.json` and `/etc/containers/oci/hooks.d/*.json` to load hook configuration.
+If the same file is in both directories, the one in `/etc/containers/oci/hooks.d` takes precedence.
 
-The json configuration looks like this in GO
-```
-// HookParams is the structure returned from read the hooks configuration
-type HookParams struct {
-	Hook          string   `json:"hook"`
-	Stage         []string `json:"stages"`
-	Cmds          []string `json:"cmds"`
-	Annotations   []string `json:"annotations"`
-	HasBindMounts bool     `json:"hasbindmounts"`
-	Arguments     []string `json:"arguments"`
-}
-```
+Each JSON file should contain an object with the following properties:
 
-| Key    | Description                                                                                                                        | Required/Optional |
-| ------ |----------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| hook   | Path to the hook                                                                                                                   | Required |
-| stages | List of stages to run the hook in: Valid options are `prestart`, `poststart`, `poststop`                                           | Required |
-| cmds   | List of regular expressions to match the command for running the container.  If the command matches a regex, the hook will be run  | Optional |
-| annotations | List of regular expressions to match against the Annotations in the container runtime spec, if an Annotation matches the hook will be run|optional |
-| hasbindmounts | Tells CRI-O to run the hook if the container has bind mounts from the host into the container | Optional |
-| arguments | Additional arguments to append to the hook command when executing it. For example --debug | Optional |
+* **`hook`** (REQUIRED, string) Sets [`path`][spec-hooks] in the injected hook.
+* **`arguments`** (OPTIONAL, array of strings) Additional arguments to pass to the hook.
+    The injected hook's [`args`][spec-hooks] is `hook` with `arguments` appended.
+* **`stages`** (REQUIRED, array of strings) Stages when the hook MUST be injected.
+    Entries MUST be chosen from:
+    * **`prestart`**, to inject [pre-start][].
+    * **`poststart`**, to inject [post-start][].
+    * **`poststop`**, to inject [post-stop][].
+* **`cmds`** (OPTIONAL, array of strings) The hook MUST be injected if the configured [`process.args[0]`][spec-process] matches an entry.
+    Entries MUST be [POSIX extended regular expressions][POSIX-ERE].
+* **`annotations`** (OPTIONAL, array of strings) The hook MUST be injected if the configured [`annotations`][spec-annotations] matches an entry.
+    Entries MUST be [POSIX extended regular expressions][POSIX-ERE].
+* **`hasbindmounts`** (OPTIONAL, boolean) The hook MUST be injected if `hasbindmounts` is true and the container is configured to bind-mount host directories into the container.
+
+The matching properties (`cmds`, `annotations` and `hasbindmounts`) are orthogonal, and the hook is injected if *any* of those properties match.
 
 ## Example
-
 
 ```
 cat /etc/containers/oci/hooks.d/oci-systemd-hook.json
@@ -61,6 +58,14 @@ cat /etc/containers/oci/hooks.d/oci-systemd-hook.json
 ```
 In this example the oci-umount will only be run during the prestart phase if the container has volume/bind mounts from the host into the container, it will also execute oci-umount with the --debug argument.
 
+[JSON]: https://tools.ietf.org/html/rfc8259
+[POSIX-ERE]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_04
+[post-start]: https://github.com/opencontainers/runtime-spec/blob/v1.0.1/config.md#poststart
+[post-stop]: https://github.com/opencontainers/runtime-spec/blob/v1.0.1/config.md#poststop
+[pre-start]: https://github.com/opencontainers/runtime-spec/blob/v1.0.1/config.md#prestart
+[rfc2119]: http://tools.ietf.org/html/rfc2119
 [runc]: https://github.com/opencontainers/runc
 [runtime-spec]: https://github.com/opencontainers/runtime-spec/blob/v1.0.1/spec.md
+[spec-annotations]: https://github.com/opencontainers/runtime-spec/blob/v1.0.1/config.md#annotations
 [spec-hooks]: https://github.com/opencontainers/runtime-spec/blob/v1.0.1/config.md#posix-platform-hooks
+[spec-process]: https://github.com/opencontainers/runtime-spec/blob/v1.0.1/config.md#process


### PR DESCRIPTION
This is a fairly thorough edit of the hook docs (which are mostly unchanged since #562).  The commits are mostly per-section rewrites, but I'm happy to squash/split/refactor if any particular change is (un)contentious.  Details for each set of changes in the commit messages.

I'd like to rework the hook configuration to more closely match the upstream structure (e.g. we do not expose `timeout`), but I'm leaving that alone for now.  This PR just tightens the docs for the current format.