### PR TITLE
conmon: implement --version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+include Makefile.inc
+
 GO ?= go
 EPOCH_TEST_COMMIT ?= 1cc5a27
 PROJECT := github.com/kubernetes-incubator/cri-o
@@ -20,8 +22,6 @@ OCIUMOUNTINSTALLDIR=$(PREFIX)/share/oci-umount/oci-umount.d
 SELINUXOPT ?= $(shell test -x /usr/sbin/selinuxenabled && selinuxenabled && echo -Z)
 PACKAGES ?= $(shell go list -tags "${BUILDTAGS}" ./... | grep -v github.com/kubernetes-incubator/cri-o/vendor)
 
-COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
-GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
 BUILD_INFO := $(shell date +%s)
 
 # If GOPATH not specified, use one in the local directory

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,0 +1,2 @@
+COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
+GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")

--- a/conmon/Makefile
+++ b/conmon/Makefile
@@ -1,8 +1,13 @@
+include ../Makefile.inc
+
 src = $(wildcard *.c)
 obj = $(src:.c=.o)
 
 override LIBS += $(shell pkg-config --libs glib-2.0)
-override CFLAGS += -std=c99 -Os -Wall -Wextra $(shell pkg-config --cflags glib-2.0)
+
+VERSION = $(shell sed -n -e 's/^const Version = "\([^"]*\)"/\1/p' ../version/version.go)
+
+override CFLAGS += -std=c99 -Os -Wall -Wextra $(shell pkg-config --cflags glib-2.0) -DVERSION=\"$(VERSION)\" -DGIT_COMMIT=\"$(GIT_COMMIT)\"
 
 conmon: $(obj)
 	$(CC) -o ../bin/$@ $^ $(CFLAGS) $(LIBS)

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -97,6 +97,7 @@ static inline void strv_cleanup(char ***strv)
 
 #define DEFAULT_SOCKET_PATH "/var/lib/crio"
 
+static bool opt_version = false;
 static bool opt_terminal = false;
 static bool opt_stdin = false;
 static bool opt_leave_stdin_open = false;
@@ -135,6 +136,7 @@ static GOptionEntry opt_entries[] =
   { "timeout", 'T', 0, G_OPTION_ARG_INT, &opt_timeout, "Timeout in seconds", NULL },
   { "log-size-max", 0, 0, G_OPTION_ARG_INT64, &opt_log_size_max, "Maximum size of log file", NULL },
   { "socket-dir-path", 0, 0, G_OPTION_ARG_STRING, &opt_socket_path, "Location of container attach sockets", NULL },
+  { "version", 0, 0, G_OPTION_ARG_NONE, &opt_version, "Print the version and exit", NULL },
   { NULL }
 };
 
@@ -1118,6 +1120,10 @@ int main(int argc, char *argv[])
 	if (!g_option_context_parse(context, &argc, &argv, &error)) {
 	        g_print("option parsing failed: %s\n", error->message);
 	        exit(1);
+	}
+	if (opt_version) {
+		g_print("conmon version " VERSION "\ncommit: " GIT_COMMIT "\n");
+		exit(0);
 	}
 
 	if (opt_cid == NULL)


### PR DESCRIPTION
**- What I did**

Implemented `conmon --version`

**- How I did it**

Refactored the Makefile, create a `version.h` file that is used by `conmon.c` to read its version and print it.

**- How to verify it**

`conmon --version` doesn't raise an error

**- Description for the changelog**
conmon supports `--version`
