### PR TITLE
conmon/pause: Simplify default CFLAGS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ sudo: required
 services:
   - docker
 
+env:
+  global:
+    - CFLAGS='-std=c99 -Os -Wall -Wextra'
+
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get -qq install btrfs-tools libdevmapper-dev libgpgme11-dev libapparmor-dev libseccomp-dev

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ dbuild: crioimage
 	docker run --name=${CRIO_INSTANCE} -e BUILDTAGS --privileged -v ${PWD}:/go/src/${PROJECT} --rm ${CRIO_IMAGE} make binaries
 
 integration: crioimage
-	docker run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e TRAVIS -t --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${CRIO_IMAGE} make localintegration
+	docker run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e TRAVIS -t --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${CRIO_IMAGE} make CFLAGS="$(CFLAGS)" localintegration
 
 testunit:
 	$(GO) test -tags "$(BUILDTAGS) containers_image_ostree_stub" -cover $(PACKAGES)

--- a/conmon/Makefile
+++ b/conmon/Makefile
@@ -7,7 +7,7 @@ override LIBS += $(shell pkg-config --libs glib-2.0)
 
 VERSION = $(shell sed -n -e 's/^const Version = "\([^"]*\)"/\1/p' ../version/version.go)
 
-override CFLAGS += -std=c99 -Os -Wall -Wextra $(shell pkg-config --cflags glib-2.0) -DVERSION=\"$(VERSION)\" -DGIT_COMMIT=\"$(GIT_COMMIT)\"
+override CFLAGS += $(shell pkg-config --cflags glib-2.0) -DVERSION=\"$(VERSION)\" -DGIT_COMMIT=\"$(GIT_COMMIT)\"
 
 conmon: $(obj)
 	$(CC) -o ../bin/$@ $^ $(CFLAGS) $(LIBS)

--- a/conmon/cmsg.c
+++ b/conmon/cmsg.c
@@ -26,6 +26,12 @@
 
 #include "cmsg.h"
 
+#if __STDC_VERSION__ >= 199901L
+	/* C99 or later */
+#else
+#error cmsg.c requires C99 or later
+#endif
+
 #define error(fmt, ...)							\
 	({								\
 		fprintf(stderr, "nsenter: " fmt ": %m\n", ##__VA_ARGS__); \

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -22,6 +22,12 @@
 #include <unistd.h>
 #include <inttypes.h>
 
+#if __STDC_VERSION__ >= 199901L
+	/* C99 or later */
+#else
+#error conmon.c requires C99 or later
+#endif
+
 #include <glib.h>
 #include <glib-unix.h>
 

--- a/pause/Makefile
+++ b/pause/Makefile
@@ -2,7 +2,7 @@ src = $(wildcard *.c)
 obj = $(src:.c=.o)
 
 override LIBS +=
-override CFLAGS += -std=c99 -Os -Wall -Wextra -static
+override CFLAGS += -static
 
 pause: $(obj)
 	$(CC) -o ../bin/$@ $^ $(CFLAGS) $(LIBS)


### PR DESCRIPTION
`-std`, `-O`, and `-W` are all options that the caller should be able to set for themselves.  This commit moves those defaults into `.travis.yml`.  Package managers and other folks building the binaries can set these up as they see fit.