### PR TITLE
Makefile: Fix install.* prerequisites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,12 +139,12 @@ docs: $(MANPAGES)
 
 install: .gopathok install.bin install.man
 
-install.bin:
+install.bin: binaries
 	install ${SELINUXOPT} -D -m 755 bin/crio $(BINDIR)/crio
 	install ${SELINUXOPT} -D -m 755 bin/conmon $(LIBEXECDIR)/crio/conmon
 	install ${SELINUXOPT} -D -m 755 bin/pause $(LIBEXECDIR)/crio/pause
 
-install.man:
+install.man: $(MANPAGES)
 	install ${SELINUXOPT} -d -m 755 $(MANDIR)/man5
 	install ${SELINUXOPT} -d -m 755 $(MANDIR)/man8
 	install ${SELINUXOPT} -m 644 $(filter %.5,$(MANPAGES)) -t $(MANDIR)/man5


### PR DESCRIPTION
Without this change, hitting these targets directly will fail.  For example:

```console
$ make clean
$ make MANDIR=/tmp install.man
install  -d -m 755 /tmp/man5
install  -d -m 755 /tmp/man8
install  -m 644 docs/crio.conf.5 -t /tmp/man5
install: cannot stat 'docs/crio.conf.5': No such file or directory
make: *** [Makefile:150: install.man] Error 1
```