### PR TITLE
Makefile: Use 'command -v selinuxenabled' instead of hard-coded path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ CRICTL_CONFIG_DIR=${DESTDIR}/etc
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 OCIUMOUNTINSTALLDIR=$(PREFIX)/share/oci-umount/oci-umount.d
 
-SELINUXOPT ?= $(shell test -x /usr/sbin/selinuxenabled && selinuxenabled && echo -Z)
+SELINUXOPT ?= $(shell command -v selinuxenabled && selinuxenabled && echo -Z)
 PACKAGES ?= $(shell go list -tags "${BUILDTAGS}" ./... | grep -v github.com/kubernetes-incubator/cri-o/vendor)
 
 COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)


### PR DESCRIPTION
The hard-coded path landed in 488216f5 (#154), but there's no need to require that path.  Using `command -v` ([in POSIX][1]) supports anyone who has `selinuxenabled` in their `PATH`.

[1]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html