### PR TITLE
Makefile: Drop man1 uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,9 +168,6 @@ uninstall:
 	rm -f $(BINDIR)/crio
 	rm -f $(LIBEXECDIR)/crio/conmon
 	rm -f $(LIBEXECDIR)/crio/pause
-	for i in $(filter %.1,$(MANPAGES)); do \
-		rm -f $(MANDIR)/man8/$$(basename $${i}); \
-	done
 	for i in $(filter %.5,$(MANPAGES)); do \
 		rm -f $(MANDIR)/man5/$$(basename $${i}); \
 	done


### PR DESCRIPTION
This should have happened in f4883dd2 (#1129).  It may have been missed due to the `man1`/`man8` typo from e61c672a (#230).