### PR TITLE
Makefile: fix SELINUXOPT generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ CRICTL_CONFIG_DIR=${DESTDIR}/etc
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 OCIUMOUNTINSTALLDIR=$(PREFIX)/share/oci-umount/oci-umount.d
 
-SELINUXOPT ?= $(shell command -v selinuxenabled && selinuxenabled && echo -Z)
+SELINUXOPT ?= $(shell command -v selinuxenabled >/dev/null 2>&1 && selinuxenabled && echo -Z)
 PACKAGES ?= $(shell go list -tags "${BUILDTAGS}" ./... | grep -v github.com/kubernetes-incubator/cri-o/vendor)
 
 COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)


### PR DESCRIPTION
This patch fixes selinuxopt generation as found in:

```
install /usr/sbin/selinuxenabled -D -m 644 crio.conf /etc/crio/crio.conf
```

The above is clearly wrong when installing the configuration because
`commmand -v` outputs the path of selinuxenabled as well, resulting in

/usr/bin/selinuxenabled -Z

This patch fixes that by just echoing the -Z as needed.

Issue introduced in
https://github.com/kubernetes-incubator/cri-o/pull/1363

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
