### PR TITLE
conmon: Respect start-pipe read errors

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -1172,7 +1172,10 @@ int main(int argc, char *argv[])
 		/* Block for an initial write to the start pipe before
 		   spawning any childred or exiting, to ensure the
 		   parent can put us in the right cgroup. */
-		read(start_pipe_fd, buf, BUF_SIZE);
+		num_read = read(start_pipe_fd, buf, BUF_SIZE);
+		if (num_read < 0) {
+			pexit("start-pipe read failed");
+		}
 		close(start_pipe_fd);
 	}
 


### PR DESCRIPTION
Avoid:

```console
$ make clean && make conmon.o 2>&1
rm -f conmon.o cmsg.o ../bin/conmon
cc -std=c99 -Os -Wall -Wextra -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -DVERSION=\"1.9.0-dev\" -DGIT_COMMIT=\""74cd1ec97c13a9784ce5e67a9e50e8977b5d2f38"\"   -c -o conmon.o conmon.c
conmon.c: In function ‘main’:
conmon.c:1175:3: warning: ignoring return value of ‘read’, declared with attribute warn_unused_result [-Wunused-result]
   read(start_pipe_fd, buf, BUF_SIZE);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

by catching and exiting on any read errors.  A read error here would be because the caller died before writing to the start pipe, and we don't want to continue in those cases because it would reopen the cgroup race discussed in af4fbcd9 (#583).  af4fbcd9 is where this line originally landed, and it didn't have error checking then.