### PR TITLE
Make the /opt/cni mount rw

### DIFF
--- a/contrib/system_containers/centos/config.json.template
+++ b/contrib/system_containers/centos/config.json.template
@@ -396,7 +396,7 @@
             "options": [
                 "rbind",
                 "rprivate",
-                "ro",
+                "rw",
                 "mode=755"
             ],
             "source": "${OPT_CNI}",

--- a/contrib/system_containers/fedora/config.json.template
+++ b/contrib/system_containers/fedora/config.json.template
@@ -401,7 +401,7 @@
             "options": [
                 "rbind",
                 "rprivate",
-                "ro",
+                "rw",
                 "mode=755"
             ],
             "source": "${OPT_CNI}",

--- a/contrib/system_containers/rhel/config.json.template
+++ b/contrib/system_containers/rhel/config.json.template
@@ -391,7 +391,7 @@
       "options": [
         "rbind",
         "rprivate",
-        "ro",
+        "rw",
         "mode=755"
       ],
       "source": "${OPT_CNI}",


### PR DESCRIPTION
kubernetes daemon sets want to be able to drop plugin
payload into the /opt/cni/bin directory.

@giuseppe @runcom PTAL

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

