### PR TITLE
The Makefile works without GOPATH set and without install.tools fine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,28 +158,9 @@ apt-get install -y \
 
 ### Get Source Code
 
-As with other Go projects, CRI-O must be cloned into a directory structure like:
-
-```
-GOPATH
-└── src
-    └── github.com
-        └── kubernetes-incubator
-            └── cri-o
-```
-
-First, configure a `GOPATH` (if you are using go1.8 or later, this defaults to `~/go`).
+Clone the source code using:
 
 ```bash
-export GOPATH=~/go
-mkdir -p $GOPATH
-```
-
-Next, clone the source code using:
-
-```bash
-mkdir -p $GOPATH/src/github.com/kubernetes-incubator
-cd $_ # or cd $GOPATH/src/github.com/kubernetes-incubator
 git clone https://github.com/kubernetes-incubator/cri-o # or your fork
 cd cri-o
 ```
@@ -187,7 +168,6 @@ cd cri-o
 ### Build
 
 ```bash
-make install.tools
 make
 sudo make install
 ```


### PR DESCRIPTION
The GOPATH layout is created in the Makefile:
```
mkdir -p "/home/test/cri-o/_output/src/github.com/kubernetes-incubator"
ln -s "/home/test/cri-o" "/home/test/cri-o/_output/src/github.com/kubernetes-incubator"
```

Signed-off-by: Jan Pazdziora <jpazdziora@redhat.com>

**- What I did**

I wanted to have the simplest possible way to build CRI-O. Specifically, I did not want to decide, where my "go" stuff will live -- I want the project confined to the CRI-O checkout directory like with any other (non-go) project.

**- How I did it**

Checked out the git repo, ignored the parts of README that talked about creating directory structure or installing tools -- I just run `make`.

**- How to verify it**

```
1. git clone https://github.com/kubernetes-incubator/cri-o
2. cd cri-o
3. make
4. Profit.
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
