### PR TITLE
.gitignore: Ignore /.gopathok

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.artifacts/
+/.gopathok
 /_output/
 /conmon/conmon.o
 /docs/*.[158]


### PR DESCRIPTION
We've been occasionally creating this file since 9c44933b (#410).  But it's recording information about the local environment, not part of our common source.  Adding it to .gitignore helps avoid having it accidentally committed.