### PR TITLE
execsync: Set terminal to true when we pass -t to conmon

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -441,7 +441,7 @@ func (r *Runtime) ExecSync(c *Container, command []string, timeout int64) (resp 
 	args = append(args, "-l", logPath)
 	args = append(args, "--socket-dir-path", ContainerAttachSocketDir)
 
-	processFile, err := PrepareProcessExec(c, command, false)
+	processFile, err := PrepareProcessExec(c, command, c.terminal)
 	if err != nil {
 		return nil, ExecSyncError{
 			ExitCode: -1,


### PR DESCRIPTION
We may consider setting it to true all the time but this
should match our previous behavior before we started
using process json for exec.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

