### PR TITLE
Add make install.tools to README.md and touch up tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ cd cri-o
 ### Build
 
 ```bash
+make install.tools
 make
 sudo make install
 ```
@@ -175,6 +176,7 @@ sudo make install
 Otherwise, if you do not want to build `CRI-O` with seccomp support you can add `BUILDTAGS=""` when running make.
 
 ```bash
+make install.tools
 make BUILDTAGS=""
 sudo make install
 ```

--- a/tutorial.md
+++ b/tutorial.md
@@ -104,6 +104,9 @@ go version go1.8.5 linux/amd64
 
 ```
 go get github.com/kubernetes-incubator/cri-tools/cmd/crictl
+cd ./src/github.com/kubernetes-incubator/cri-tools/cmd/crictl
+make
+make install
 ```
 
 #### Build crio from source
@@ -142,6 +145,14 @@ If you are installing for the first time, generate and install configuration fil
 
 ```
 sudo make install.config
+```
+
+#### Validate registries option in /etc/crio/crio.conf
+
+Edit `/etc/crio/crio.conf` and verify that the registries option has valid values in it.  For example:
+
+```
+registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'docker.io']
 ```
 
 #### Start the crio system daemon


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>


**- What I did**
While using the tutorial, noted a few missing pieces in the README.md and tutorial.md. Added changes to clear those up.

**- How I did it**
vi is my friend.

**- How to verify it**
Install on a new VM and follow the tutorial.

**- Description for the changelog**
Touch ups to the README.md and tutorial.md files.
