### PR TITLE
test/testdata/container_redis.json: Set cpuset_cpus to 0

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1079,7 +1079,7 @@ function teardown() {
 	run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpuset/cpuset.cpus"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "0-1" ]]
+	[[ "$output" =~ "0" ]]
 	run crictl exec --sync "$ctr_id" sh -c "cat /sys/fs/cgroup/cpuset/cpuset.mems"
 	echo "$output"
 	[ "$status" -eq 0 ]

--- a/test/testdata/container_redis.json
+++ b/test/testdata/container_redis.json
@@ -50,7 +50,7 @@
 			"cpu_quota": 20000,
 			"cpu_shares": 512,
 			"oom_score_adj": 30,
-			"cpuset_cpus": "0-1",
+			"cpuset_cpus": "0",
 			"cpuset_mems": "0"
 		},
 		"security_context": {


### PR DESCRIPTION
Only require a single CPU to avoid failures on single-CPU systems. We could make this conditional, but it's Redis, which isn't particularly CPU intensive.  One CPU would probably be fine in production, and these are just integration tests.

Fixes #1397.