### PR TITLE
Fix create container failure due to wrong image reference

### DIFF
--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -616,6 +616,8 @@ func splitDockerDomain(name string) (domain, remainder string) {
 	return
 }
 
+// ResolveNames resolves an image name into a storage image ID or a fully-qualified image name (domain/repo/image:tag).
+// Will only return an empty slice if err != nil.
 func (svc *imageService) ResolveNames(imageName string) ([]string, error) {
 	// _Maybe_ it's a truncated image ID.  Don't prepend a registry name, then.
 	if len(imageName) >= minimumTruncatedIDLength && svc.store != nil {


### PR DESCRIPTION
When the image name is resolved with the registries from crio.conf only
the resolved name with the first registry is passed to create_container
eventhough there are more registries in the crio.conf file.
Fix this to try the resolved image names with all the registries given in the conf file.

Fixes https://github.com/kubernetes-incubator/cri-o/issues/1396

Signed-off-by: umohnani8 <umohnani@redhat.com>
