### PR TITLE
server: prevent double channel close

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -389,7 +389,6 @@ func (s *Server) StartHooksMonitor() {
 				}
 			case err := <-watcher.Errors:
 				logrus.Debugf("watch error: %v", err)
-				close(done)
 				return
 			case <-s.monitorsChan:
 				logrus.Debug("closing hooks monitor...")
@@ -448,7 +447,6 @@ func (s *Server) StartExitMonitor() {
 				}
 			case err := <-watcher.Errors:
 				logrus.Debugf("watch error: %v", err)
-				close(done)
 				return
 			case <-s.monitorsChan:
 				logrus.Debug("closing exit monitor...")


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed a double close of a channel as reported here https://github.com/kubernetes-incubator/cri-o/pull/1345#issuecomment-369909740

@mrunalp @rhatdan PTAL

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
