### PR TITLE
Remove unneeded/repeated Travis steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,23 +32,18 @@ jobs:
         - make .gitvalidation
         - make gofmt
         - make lint
-        - make testunit
-        - make docs
-        - make
-      go: 1.8.x
+      go: tip
     - stage: Build and Verify
       script:
-        - make .gitvalidation
-        - make gofmt
-        - make lint
         - make testunit
-        - make docs
+        - make
+      go: 1.8.x
+    - script:
+        - make testunit
         - make
       go: 1.9.x
     - script:
-        - make .gitvalidation
         - make testunit
-        - make docs
         - make
       go: tip
     - stage: Integration Test


### PR DESCRIPTION
**What I did**

Some steps are now being run with Go tip and not in all the different versions,
there were also moved to their own block so they will fail fast and in the mean
time the unit test for the different versions can start.

Also, "make docs" was removed because it's already being done by "make" without
any argument.

**How to verify it**

- Check the Travis build on this PR.

**Description for the changelog**

_Remove duplication in Travis steps and make verifications of linters and git fail fast._