### PR TITLE
Make conmon and crio share the same constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.artifacts/
 /.gopathok
 /_output/
+/conmon/config.h
 /conmon/conmon.o
 /docs/*.[158]
 /docs/*.[158].gz

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/kubernetes-incubator/cri-o/lib"
+	"github.com/kubernetes-incubator/cri-o/oci"
 	"github.com/kubernetes-incubator/cri-o/server"
 	"github.com/kubernetes-incubator/cri-o/version"
 	"github.com/sirupsen/logrus"
@@ -40,8 +41,8 @@ func validateConfig(config *server.Config) error {
 	}
 
 	// This needs to match the read buffer size in conmon
-	if config.LogSizeMax >= 0 && config.LogSizeMax < 8192 {
-		return fmt.Errorf("log size max should be negative or >= 8192")
+	if config.LogSizeMax >= 0 && config.LogSizeMax < oci.BufSize {
+		return fmt.Errorf("log size max should be negative or >= %d", oci.BufSize)
 	}
 	return nil
 }

--- a/conmon/Makefile
+++ b/conmon/Makefile
@@ -1,5 +1,7 @@
 include ../Makefile.inc
 
+all: conmon
+
 src = $(wildcard *.c)
 obj = $(src:.c=.o)
 
@@ -9,9 +11,13 @@ VERSION = $(shell sed -n -e 's/^const Version = "\([^"]*\)"/\1/p' ../version/ver
 
 override CFLAGS += -std=c99 -Os -Wall -Wextra $(shell pkg-config --cflags glib-2.0) -DVERSION=\"$(VERSION)\" -DGIT_COMMIT=\"$(GIT_COMMIT)\"
 
-conmon: $(obj)
+config.h: config.go ../oci/oci.go
+	go run config.go
+
+conmon: config.h $(obj)
 	$(CC) -o ../bin/$@ $^ $(CFLAGS) $(LIBS)
 
 .PHONY: clean
 clean:
 	rm -f $(obj) ../bin/conmon
+	rm -f config.h

--- a/conmon/config.go
+++ b/conmon/config.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/kubernetes-incubator/cri-o/oci"
+	"github.com/sirupsen/logrus"
+)
+
+func main() {
+	output := `
+#if !defined(CONFIG_H)
+#define CONFIG_H
+
+#define BUF_SIZE %d
+#define STDIO_BUF_SIZE %d
+#define DEFAULT_SOCKET_PATH "%s"
+
+#endif // CONFIG_H
+`
+	if err := ioutil.WriteFile("config.h", []byte(fmt.Sprintf(output, oci.BufSize, oci.BufSize, oci.ContainerAttachSocketDir)), 0700); err != nil {
+		logrus.Fatal(err)
+	}
+}

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -26,6 +26,7 @@
 #include <glib-unix.h>
 
 #include "cmsg.h"
+#include "config.h"
 
 #define pexit(s)                                                                \
 	do {                                                                    \
@@ -117,11 +118,8 @@ static inline void strv_cleanup(char ***strv)
 #define _cleanup_gstring_ _cleanup_(gstring_free_cleanup)
 #define _cleanup_strv_ _cleanup_(strv_cleanup)
 
-#define BUF_SIZE 8192
 #define CMD_SIZE 1024
 #define MAX_EVENTS 10
-
-#define DEFAULT_SOCKET_PATH "/var/lib/crio"
 
 static volatile pid_t container_pid = -1;
 static volatile pid_t create_pid = -1;
@@ -613,7 +611,6 @@ static gboolean tty_hup_timeout_cb (G_GNUC_UNUSED gpointer user_data)
 
 static bool read_stdio(int fd, stdpipe_t pipe, bool *eof)
 {
-	#define STDIO_BUF_SIZE 8192 /* Sync with redirectResponseToOutputStreams() */
 	/* We use one extra byte at the start, which we don't read into, instead
 	   we use that for marking the pipe when we write to the attached socket */
 	char real_buf[STDIO_BUF_SIZE + 1];

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -42,6 +42,8 @@ const (
 	ContainerExitsDir = "/var/run/crio/exits"
 	// ContainerAttachSocketDir is the location for container attach sockets
 	ContainerAttachSocketDir = "/var/run/crio"
+	// BufSize is the size of buffers passed in to socekts
+	BufSize = 8192
 
 	// killContainerTimeout is the timeout that we wait for the container to
 	// be SIGKILLed.

--- a/server/container_attach.go
+++ b/server/container_attach.go
@@ -115,7 +115,7 @@ func (ss streamService) Attach(containerID string, inputStream io.Reader, output
 
 func redirectResponseToOutputStreams(outputStream, errorStream io.Writer, conn io.Reader) error {
 	var err error
-	buf := make([]byte, 8192+1) /* Sync with conmon STDIO_BUF_SIZE */
+	buf := make([]byte, oci.BufSize+1) /* Sync with conmon STDIO_BUF_SIZE */
 
 	for {
 		nr, er := conn.Read(buf)


### PR DESCRIPTION
This patch adds a little program config.go, which
outputs config.h based on the constants set in oci.go

This will make sure that conmon and crio use the same constants.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
