### PR TITLE
Fix two integration nits

### DIFF
--- a/contrib/test/integration/README.md
+++ b/contrib/test/integration/README.md
@@ -1,21 +1,22 @@
-# Fedora and RHEL Integration and End-to-End Tests
+# Fedora and RHEL Test execution
 
-This directory contains playbooks to set up for and run the integration and
-end-to-end tests for CRI-O on RHEL and Fedora hosts. Two entrypoints exist:
+This directory contains playbooks to set up and run, all the CRI-O CI tests
+for both RHEL and Fedora hosts. Two entry-point playbooks exist:
 
- - `main.yml`: sets up the machine and runs tests
- - `results.yml`: gathers test output to `/tmp/artifacts`
+ - `main.yml`: sets up the machine and runs tests.
+ - `results.yml`: gathers test output to `/tmp/artifacts`.
 
-When running `main.yml`, three tags are present:
+When running the `main.yml` playbook, multiple tags are present:
 
- - `setup`: run all tasks to set up the system for testing
- - `e2e`: build CRI-O from source and run Kubernetes node E2Es
- - `integration`: build CRI-O from source and run the local integration suite
+ - `setup`: run all tasks to set up the system for testing.
+ - `e2e`: build CRI-O from source and run Kubernetes end-to-end tests.
+ - `node-e2e`: build CRI-O from source and run Kubernetes 'node' end-to-end tests.
+ - `integration`: build CRI-O from source and run the local integration suite.
 
 The playbooks assume the following things about your system:
 
- - on RHEL, the server and extras repos are configured and certs are present
- - `ansible` is installed and the host is boot-strapped to allow `ansible` to run against it
- - the `$GOPATH` is set and present for all shells (*e.g.* written in `/etc/environment`)
- - CRI-O is checked out to the correct state at `${GOPATH}/src/github.com/kubernetes-incubator/cri-o`
- - the user running the playbook has access to passwordless `sudo`
+ - On RHEL, the repositories for EPEL, rhel-server, and extras repos are configured and functional.
+ - The system has been rebooted after installing/updating low-level packages, to ensure they're active.
+ - Ansible is installed, and functional with access to the 'root' user.
+ - The `$GOPATH` is set and present for all shells (*e.g.* written in `/etc/environment`).
+ - The CRI-O repository is present in the desired state at `${GOPATH}/src/github.com/kubernetes-incubator/cri-o`.

--- a/contrib/test/integration/system.yml
+++ b/contrib/test/integration/system.yml
@@ -55,7 +55,7 @@
     - socat
     - tar
     - wget
-  async: 600
+  async: '{{ 20 * 60 }}'
   poll: 10
 
 - name: Add python2-boto for Fedora


### PR DESCRIPTION
**- What I did**

* Add an EPEL requirement to the ``contrib/test/integration/README.md``
* Double the rpm installation timeout

**- How I did it**

* With ``vim``

**- How to verify it**

* Read the ``README.md``
* Execute the integration test playbook inside a slow-networking environment