### PR TITLE
Conmon reopen log file support

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -902,6 +902,9 @@ static gboolean ctrl_cb(int fd, G_GNUC_UNUSED GIOCondition condition, G_GNUC_UNU
 			case 1:
 				resize_winsz(height, width);
 				break;
+			case 2:
+				reopen_log_file();
+				break;
 			default:
 				ninfof("Unknown message type: %d", ctl_msg_type);
 				break;


### PR DESCRIPTION
@rhatdan @runcom @giuseppe  PTAL

**- What I did**
Added support for supporting reopening files via conmon ctl file.

**- How I did it**
Refactored to add helper functions for reopening log file, resizing tty size and handling
ctl messages to call reopen log file function.

**- How to verify it**
This will be exercised in follow-on changes in CRI log re-open API.

**- Description for the changelog**
<!--
conmon: Add support for log reopen through ctl file
-->
