### PR TITLE
.travis.yml: Add allowed-to-fail OS X compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,18 @@ before_install:
 
 install:
   - make install.tools
-  - OSTREE_VERSION=v2017.9
-  - git clone https://github.com/ostreedev/ostree ${TRAVIS_BUILD_DIR}/ostree
-  - pushd ${TRAVIS_BUILD_DIR}/ostree
-  -   git checkout $OSTREE_VERSION
-  -   ./autogen.sh --prefix=/usr/local
-  -   make all
-  -   sudo make install
-  - popd
+  - >
+    if [ "{TRAVIS_OS_NAME}" = linux ]; then
+      OSTREE_VERSION=v2017.9;
+      git clone https://github.com/ostreedev/ostree ${TRAVIS_BUILD_DIR}/ostree &&
+      (
+        cd ${TRAVIS_BUILD_DIR}/ostree &&
+        git checkout $OSTREE_VERSION &&
+        ./autogen.sh --prefix=/usr/local &&
+        make all &&
+        sudo make install
+      )
+    fi
 
 before_script:
   - export PATH=$HOME/gopath/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ services:
   - docker
 
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get -qq install btrfs-tools libdevmapper-dev libgpgme11-dev libapparmor-dev libseccomp-dev
-  - sudo apt-get -qq install autoconf automake bison e2fslibs-dev libfuse-dev libtool liblzma-dev gettext
+  - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq update; fi
+  - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq install btrfs-tools libdevmapper-dev libgpgme11-dev libapparmor-dev libseccomp-dev; fi
+  - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq install autoconf automake bison e2fslibs-dev libfuse-dev libtool liblzma-dev gettext; fi
 
 install:
   - make install.tools
@@ -46,10 +46,16 @@ jobs:
         - make testunit
         - make
       go: tip
+    - script:
+        - make testunit
+        - make
+      os: osx
     - stage: Integration Test
       script:
         - make integration
       go: 1.9.x
+  allow_failures:
+    - os: osx
 
 notifications:
   irc: "chat.freenode.net#cri-o"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ MANDIR ?= ${PREFIX}/share/man
 ETCDIR ?= ${DESTDIR}/etc
 ETCDIR_CRIO ?= ${ETCDIR}/crio
 DATAROOTDIR ?= ${PREFIX}/share/containers
-BUILDTAGS ?= seccomp $(shell hack/btrfs_tag.sh) $(shell hack/libdm_installed.sh) $(shell hack/libdm_no_deferred_remove_tag.sh) $(shell hack/btrfs_installed_tag.sh) $(shell hack/ostree_tag.sh) $(shell hack/selinux_tag.sh)
+BUILDTAGS ?= $(shell hack/btrfs_tag.sh) $(shell hack/libdm_installed.sh) $(shell hack/libdm_no_deferred_remove_tag.sh) $(shell hack/btrfs_installed_tag.sh) $(shell hack/ostree_tag.sh) $(shell hack/seccomp_tag.sh) $(shell hack/selinux_tag.sh)
 CRICTL_CONFIG_DIR=${DESTDIR}/etc
 
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions

--- a/hack/seccomp_tag.sh
+++ b/hack/seccomp_tag.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+if pkg-config libseccomp 2> /dev/null ; then
+	echo seccomp
+fi


### PR DESCRIPTION
As an initial step in continuous integration testing for @vbatts' cross-platform work.  Once we get this passing on OS X we can remove the `allow_failures` entry.  The best docs I could find for using `allow_failures` with [build stages][0] was [here][1], so that's the pattern I'm following.  Travis' OS X docs are [here][3].

[0]: https://docs.travis-ci.com/user/build-stages/
[1]: https://github.com/travis-ci/travis-ci/issues/7789#issuecomment-303685412
[3]: https://docs.travis-ci.com/user/reference/osx