### PR TITLE
Tweak test timeouts to be readable + realistic

### DIFF
--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -70,3 +70,5 @@
   shell: "{{ e2e_shell_cmd | regex_replace('\\s+', ' ') }}"
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
+  async: '{{ 60 * 60 * 4 }}'  # seconds
+  poll: 60

--- a/contrib/test/integration/node-e2e.yml
+++ b/contrib/test/integration/node-e2e.yml
@@ -21,6 +21,6 @@
     make test-e2e-node PARALLELISM=1 RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT=/var/run/crio.sock IMAGE_SERVICE_ENDPOINT=/var/run/crio/crio.sock TEST_ARGS='--prepull-images=true --kubelet-flags="--cgroup-driver=systemd"' FOCUS="\[Conformance\]" &> {{ artifacts }}/node-e2e.log
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
-  async: 7200
-  poll: 10
+  async: '{{ 60 * 60 * 2 }}'  # seconds
+  poll: 60
   ignore_errors: true

--- a/contrib/test/integration/test.yml
+++ b/contrib/test/integration/test.yml
@@ -21,5 +21,5 @@
   shell: "CGROUP_MANAGER=cgroupfs STORAGE_OPTIONS='--storage-driver=overlay{{ extra_storage_opts | default('') }}' make localintegration >& {{ artifacts }}/testout.txt"
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o"
-  async: 5400
+  async: '{{ 60 * 30 }}'  # seconds
   poll: 30


### PR DESCRIPTION
All-else being equal, there should be as small a timeout as possible so we're not wasting engineer-time.  However, it needs to be long enough that tests don't fail due to minor/random hiccups.

**- What I did**

* Added an async/poll statement to ``e2e.yml`` (was missing one)
* Updated all timeouts to be closer to reality (may still need tweaking)

**- How I did it**

* Async timeouts are specified in seconds, but since everybody isn't a math-wizz, I wrote out the formula as a jinja2 template.  That way normal people can easily make sense of it.

**- How to verify it**

* All CI tests should pass.