### PR TITLE
Add read-only flag

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -124,6 +124,9 @@ pids_limit = {{ .PidsLimit }}
 # Negative values indicate that no limit is imposed.
 log_size_max = {{ .LogSizeMax }}
 
+# read-only indicates whether all containers will run in read-only mode
+read_only = {{ .ReadOnly }}
+
 # The "crio.image" table contains settings pertaining to the
 # management of OCI images.
 [crio.image]

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -143,6 +143,9 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("image-volumes") {
 		config.ImageVolumes = lib.ImageVolumesType(ctx.GlobalString("image-volumes"))
 	}
+	if ctx.GlobalIsSet("read-only") {
+		config.ReadOnly = ctx.GlobalBool("read-only")
+	}
 	return nil
 }
 
@@ -342,6 +345,10 @@ func main() {
 			Name:  "metrics-port",
 			Value: 9090,
 			Usage: "port for the metrics endpoint",
+		},
+		cli.BoolFlag{
+			Name:  "read-only",
+			Usage: "setup all unprivileged containers to run as read-only",
 		},
 	}
 

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -23,6 +23,7 @@ crio
 [--log-level value]
 [--pause-command=[value]]
 [--pause-image=[value]]
+[--read-only]
 [--registry=[value]]
 [--root=[value]]
 [--runroot=[value]]
@@ -93,6 +94,8 @@ crio [GLOBAL OPTIONS] config [OPTIONS]
 **--pause-image**="": Image which contains the pause executable (default: "kubernetes/pause")
 
 **--pids-limit**="": Maximum number of processes allowed in a container (default: 1024)
+
+**--read-only**=**true**|**false**: Run all containers in read-only mode (default: false). Automatically mount tmpfs on `/run`, `/tmp` and `/var/tmp`.
 
 **--root**="": The crio root dir (default: "/var/lib/containers/storage")
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -108,6 +108,10 @@ Example:
 **default_mounts**=[]
   List of mount points, in the form host:container, to be mounted in every container
 
+**read_only**==*true*|*false*
+  Run every container in read-only mode. Automatically mount tmpfs on `/run`, `/tmp` and `/var/tmp`.
+  Setup images to run in read-only. (default: false)
+
 ## CRIO.IMAGE TABLE
 
 **default_transport**

--- a/lib/config.go
+++ b/lib/config.go
@@ -167,6 +167,12 @@ type RuntimeConfig struct {
 	// ManageNetworkNSLifecycle determines whether we pin and remove network namespace
 	// and manage its lifecycle
 	ManageNetworkNSLifecycle bool `toml:"manage_network_ns_lifecycle"`
+
+	// ReadOnly run all pods/containers in read-only mode.
+	// This mode will mount tmpfs on /run, /tmp and /var/tmp, if those are not mountpoints
+	// Will also set the readonly flag in the OCI Runtime Spec.  In this mode containers
+	// will only be able to write to volumes mounted into them
+	ReadOnly bool `toml:"read_only"`
 }
 
 // ImageConfig represents the "crio.image" TOML config table.


### PR DESCRIPTION
Taking over @rhatdan PR https://github.com/kubernetes-incubator/cri-o/pull/1402/files

Add a read-only flag to the cri-o config.  This will force all containers
run on the system to run in readonly mode.  In order to make most containers
work this patch mounts a tmpfs on /run, /tmp and /var/tmp so that these directories can continue to be written to, but the rest of the file system will be
read-only.  If the container needs to write to other locations, then volumes
must be mounted into the container.

Running in read-only mode increases the container security, since a hacked
container will not be able to overwrite existing code.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
Signed-off-by: umohnani8 <umohnani@redhat.com>