### PR TITLE
conmon: Remove info logs

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -336,7 +336,6 @@ static int write_k8s_log(int fd, stdpipe_t pipe, const char *buf, ssize_t buflen
 		 * a timestamp.
 		 */
 		if ((opt_log_size_max > 0) && (bytes_written + bytes_to_be_written) > opt_log_size_max) {
-			ninfo("Creating new log file");
 			bytes_written = 0;
 
 			/* Close the existing fd */
@@ -397,8 +396,6 @@ next:
 	if (writev_buffer_flush (fd, &bufv) < 0) {
 		nwarn("failed to flush buffer to log");
 	}
-
-	ninfo("Total bytes written: %"PRId64"", bytes_written);
 
 	return 0;
 }


### PR DESCRIPTION
We don't need this in the logging path.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

