### PR TITLE
run stop_crio inside cleanup_test

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -301,6 +301,7 @@ function stop_crio() {
 		kill "$CRIO_PID" >/dev/null 2>&1
 		wait "$CRIO_PID"
 		rm -f "$CRIO_CONFIG"
+		CRIO_PID=
 	fi
 
 	cleanup_network_conf
@@ -318,6 +319,9 @@ function restart_crio() {
 }
 
 function cleanup_test() {
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
 	rm -rf "$TESTDIR"
 }
 


### PR DESCRIPTION
If a subtest fails it might leave crio running; this prevents
bats from exiting, causing a hang. It also prevents cleanup of
the test directory because there's an active mount in it.

Solution: run stop_crio from within cleanup_test, just before
the rm -rf. This is safe because stop_crio checks for an active
crio pid.

Signed-off-by: Ed Santiago <santiago@redhat.com>
