### PR TITLE
container_exec: Fix terminal setting for exec

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -766,6 +766,9 @@ func PrepareProcessExec(c *Container, cmd []string, tty bool) (*os.File, error) 
 
 	pspec := c.Spec().Process
 	pspec.Args = cmd
+	// We need to default this to false else it will inherit terminal as true
+	// from the container.
+	pspec.Terminal = false
 	if tty {
 		pspec.Terminal = true
 	}


### PR DESCRIPTION
We were incorrectly inheriting tty true from main container.

@runcom @rhatdan PTAL

Closes #1433

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

