### PR TITLE
pkg/findprocess: Add a new package for portable process detection

### DIFF
--- a/pkg/findprocess/findprocess.go
+++ b/pkg/findprocess/findprocess.go
@@ -1,0 +1,26 @@
+// Package findprocess provides an os.FindProcess wrapper that
+// portably detects non-existent processes.
+package findprocess
+
+import (
+	"errors"
+	"os"
+)
+
+// ErrNotFound represents a target process that does not exist or is
+// otherwise not available to the calling process.
+var ErrNotFound = errors.New("process not found")
+
+// FindProcess wraps os.Findprocess [1] to return a public ErrNotFound
+// if the process does not exist.  The returned process will be nil if
+// and only if the returned err is non-nil.
+//
+// [1]: https://golang.org/pkg/os/#FindProcess
+func FindProcess(pid int) (process *os.Process, err error) {
+	process, err = findProcess(pid)
+	if err != nil {
+		process.Release()
+		process = nil
+	}
+	return process, err
+}

--- a/pkg/findprocess/findprocess_test.go
+++ b/pkg/findprocess/findprocess_test.go
@@ -1,0 +1,41 @@
+package findprocess
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestFindEngine(t *testing.T) {
+	cmd := exec.Command("sleep", "1")
+	err := cmd.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	process, err := FindProcess(cmd.Process.Pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = process.Release()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	process, err = FindProcess(cmd.Process.Pid)
+	if err == ErrNotFound {
+		return
+	}
+	if err == nil {
+		err = process.Release()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Fatalf("found the reaped process %d", cmd.Process.Pid)
+	}
+	t.Fatal(err)
+}

--- a/pkg/findprocess/findprocess_unix.go
+++ b/pkg/findprocess/findprocess_unix.go
@@ -1,0 +1,23 @@
+// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
+
+package findprocess
+
+import (
+	"os"
+	"syscall"
+)
+
+func findProcess(pid int) (process *os.Process, err error) {
+	process, err = os.FindProcess(pid)
+	if err != nil {
+		return process, err
+	}
+	err = process.Signal(syscall.Signal(0))
+	if err == nil {
+		return process, nil
+	}
+	if err.Error() == "os: process already finished" {
+		return process, ErrNotFound
+	}
+	return process, err
+}

--- a/pkg/findprocess/findprocess_windows.go
+++ b/pkg/findprocess/findprocess_windows.go
@@ -1,0 +1,14 @@
+package findprocess
+
+import (
+	"os"
+)
+
+func findProcess(pid int) (process *os.Process, err error) {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		// FIXME: is there an analog to POSIX's ESRCH we can check for?
+		return process, err
+	}
+	return process, nil
+}


### PR DESCRIPTION
And use the new package for portable process-existence checks in the `oci` package, addressing that part of #1407's portability goals.

The traditional POSIX approach to detecting processes is to [`kill(pid, 0)` them and check for `ESRCH`][1].  However, Go's `os.Process` makes detecting that a bit awkward.

On Unix, [Go's `os.FindProcess` implementation always succeeds][2].  And [`os.Process`'s `Signal` translates `ESRCH`][3] to [an internal `errFinished`][4].  The Unix wrapper here rolls the `FindProcess` and `Signal(0)` calls together, and translates `os`'s `errFinished` to a public `ESRCH`.

On Windows, [`os.Process`'s `Signal` only supports kills][5], so we can't perform a check like [POSIX's `kill(pid, 0)`][1].  Instead, this commit assumes `os.FindProcess` will return errors on nonexistent processes, although that behavior is not covered in [the Go docs][2].  The Windows [`os.FindProcess` wraps an `OpenProcess` call][6].  [`OpenProcess`][7] can set a few errors, including `ERROR_INVALID_PARAMETER` and `ERROR_ACCESS_DENIED`.  It's possible there's an ESRCH analog in [their system error codes][8], but I'm not going to dig through and find it ;).  Once someone can test this on a Windows machine, they can tell us what error(s) to look for.

Another possible portability issue is the use of `sleep` in the tests.  That's [fine for POSIX systems][8], but we may need to slot in another command for Windows.

[1]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/kill.html
[2]: https://golang.org/pkg/os/#FindProcess
[3]: https://github.com/golang/go/blob/010579c2377654e575d46857ec7dc77bab586438/src/os/exec_unix.go#L72-L73
[4]: https://github.com/golang/go/blob/010579c2377654e575d46857ec7dc77bab586438/src/os/exec_unix.go#L53
[5]: https://github.com/golang/go/blob/010579c2377654e575d46857ec7dc77bab586438/src/os/exec_windows.go#L65-L71
[6]: https://github.com/golang/go/blob/010579c2377654e575d46857ec7dc77bab586438/src/os/exec_windows.go#L92-L95
[7]: https://msdn.microsoft.com/en-us/library/windows/desktop/ms684320(v=vs.85).aspx
[8]: https://msdn.microsoft.com/en-us/library/windows/desktop/ms681381(v=vs.85).aspx
[9]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/sleep.html