### PR TITLE
conmon: Avoid strlen in logging path

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -249,9 +249,6 @@ ssize_t writev_buffer_append_segment(int fd, writev_buffer_t *buf, const void *d
 	if (data == NULL)
 		return 1;
 
-	if (len < 0)
-		len = strlen ((char *)data);
-
 	if (buf->iovcnt == WRITEV_BUFFER_N_IOV &&
 	    writev_buffer_flush (fd, buf) < 0)
 		return -1;
@@ -403,19 +400,19 @@ static int write_k8s_log(int fd, stdpipe_t pipe, const char *buf, ssize_t buflen
 		}
 
 		/* Output the timestamp */
-		if (writev_buffer_append_segment(fd, &bufv, tsbuf, -1) < 0) {
+		if (writev_buffer_append_segment(fd, &bufv, tsbuf, TSBUFLEN - 1) < 0) {
 			nwarn("failed to write (timestamp, stream) to log");
 			goto next;
 		}
 
 		/* Output log tag for partial or newline */
 		if (partial) {
-			if (writev_buffer_append_segment(fd, &bufv, "P ", -1) < 0) {
+			if (writev_buffer_append_segment(fd, &bufv, "P ", 2) < 0) {
 				nwarn("failed to write partial log tag");
 				goto next;
 			}
 		} else {
-			if (writev_buffer_append_segment(fd, &bufv, "F ", -1) < 0) {
+			if (writev_buffer_append_segment(fd, &bufv, "F ", 2) < 0) {
 				nwarn("failed to write end log tag");
 				goto next;
 			}
@@ -429,7 +426,7 @@ static int write_k8s_log(int fd, stdpipe_t pipe, const char *buf, ssize_t buflen
 
 		/* Output a newline for partial */
 		if (partial) {
-			if (writev_buffer_append_segment(fd, &bufv, "\n", -1) < 0) {
+			if (writev_buffer_append_segment(fd, &bufv, "\n", 1) < 0) {
 				nwarn("failed to write newline to log");
 				goto next;
 			}


### PR DESCRIPTION
Pass length as we already know it instead of
calling strlen in logging path.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

