### PR TITLE
Fix accidental positive side-effect of RHEL 7.4- bug

### DIFF
--- a/contrib/test/integration/system.yml
+++ b/contrib/test/integration/system.yml
@@ -132,3 +132,6 @@
 - name: Update the kernel cmdline to include quota support
   command: grubby --update-kernel=ALL --args="rootflags=pquota"
   when: ansible_distribution in ['RedHat', 'CentOS']
+
+- name: Containers using cgroups and/or systemd after 7.5 are permitted
+  seboolean: name=container_manage_cgroup persistent=yes state=yes


### PR DESCRIPTION
There is a bug-fix in 7.5.0 which fixes containers access to cgroups on
the host, despite the default container_manage_cgroup == 0.  When
testing with 7.5.0 and later, this access will be blocked unless this
boolean is enabled.  

**- What I did**
Since it's also required in Fedora, and there's no negative consequence
for using it in <= 7.4, simply enable it for all VMs.

**- How I did it**
With the ``seboolean`` Ansible module

**- How to verify it**
Automated 'ami' tests should pass.  Bonous points if e2e passes after enabling SELinux.  Until then, manual testing is required :face_with_head_bandage: as per ``README.md``.