### PR TITLE
Return error for container exec

### DIFF
--- a/server/container_exec.go
+++ b/server/container_exec.go
@@ -30,7 +30,7 @@ func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (resp *pb.ExecRe
 
 	resp, err = s.GetExec(req)
 	if err != nil {
-		return nil, fmt.Errorf("unable to prepare exec endpoint")
+		return nil, fmt.Errorf("unable to prepare exec endpoint: %v", err)
 	}
 
 	return resp, nil


### PR DESCRIPTION
Adds the actual error reason to the error message returned when exec fails.

Signed-off-by: umohnani8 <umohnani@redhat.com>
