### PR TITLE
Makefile: Avoid needless binary rebuilds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,11 @@ gofmt:
 	find . -name '*.go' ! -path './vendor/*' -exec gofmt -s -w {} \+
 	git diff --exit-code
 
-conmon: conmon/config.h
-	$(MAKE) -C $@
+bin/conmon: conmon/config.h
+	$(MAKE) -C conmon
 
-pause:
-	$(MAKE) -C $@
+bin/pause:
+	$(MAKE) -C pause
 
 test/bin2img/bin2img: .gopathok $(wildcard test/bin2img/*.go)
 	$(GO) build -i $(LDFLAGS) -tags "$(BUILDTAGS) containers_image_ostree_stub" -o $@ $(PROJECT)/test/bin2img
@@ -84,10 +84,10 @@ test/copyimg/copyimg: .gopathok $(wildcard test/copyimg/*.go)
 test/checkseccomp/checkseccomp: .gopathok $(wildcard test/checkseccomp/*.go)
 	$(GO) build -i $(LDFLAGS) -tags "$(BUILDTAGS) containers_image_ostree_stub" -o $@ $(PROJECT)/test/checkseccomp
 
-crio: .gopathok $(shell hack/find-godeps.sh $(GOPKGDIR) cmd/crio $(PROJECT))
-	$(GO) build -i $(LDFLAGS) -tags "$(BUILDTAGS) containers_image_ostree_stub" -o bin/$@ $(PROJECT)/cmd/crio
+bin/crio: .gopathok $(shell hack/find-godeps.sh $(GOPKGDIR) cmd/crio $(PROJECT))
+	$(GO) build -i $(LDFLAGS) -tags "$(BUILDTAGS) containers_image_ostree_stub" -o $@ $(PROJECT)/cmd/crio
 
-crio.conf: crio
+crio.conf: bin/crio
 	./bin/crio --config="" config --default > crio.conf
 
 release-note:
@@ -128,7 +128,7 @@ testunit:
 localintegration: clean binaries test-binaries
 	./test/test_runner.sh ${TESTFLAGS}
 
-binaries: crio conmon pause
+binaries: bin/crio bin/conmon bin/pause
 test-binaries: test/bin2img/bin2img test/copyimg/copyimg test/checkseccomp/checkseccomp
 
 MANPAGES_MD := $(wildcard docs/*.md)
@@ -227,14 +227,14 @@ install.tools: .install.gitvalidation .install.gometalinter .install.md2man .ins
 	fi
 
 .PHONY: \
+	bin/conmon \
+	bin/pause \
 	binaries \
 	clean \
-	conmon \
 	default \
 	docs \
 	gofmt \
 	help \
 	install \
 	lint \
-	pause \
 	uninstall

--- a/conmon/Makefile
+++ b/conmon/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.inc
 
-all: conmon
+all: ../bin/conmon
 
 src = $(wildcard *.c)
 obj = $(src:.c=.o)
@@ -14,8 +14,8 @@ override CFLAGS += -std=c99 -Os -Wall -Wextra $(shell pkg-config --cflags glib-2
 config.h: ../oci/oci.go
 	$(MAKE) -C .. conmon/config.h
 
-conmon: config.h $(obj)
-	$(CC) -o ../bin/$@ $^ $(CFLAGS) $(LIBS)
+../bin/conmon: config.h $(obj)
+	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
 
 .PHONY: clean
 clean:

--- a/pause/Makefile
+++ b/pause/Makefile
@@ -4,8 +4,8 @@ obj = $(src:.c=.o)
 override LIBS +=
 override CFLAGS += -std=c99 -Os -Wall -Wextra -static
 
-pause: $(obj)
-	$(CC) -o ../bin/$@ $^ $(CFLAGS) $(LIBS)
+../bin/pause: $(obj)
+	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
With this change, we avoid needless rebuilds after a successful build:

```console
$ make binaries
…real build stuff…
$ make binaries
make -C conmon
make[1]: Entering directory '/home/wking/.local/lib/go/src/github.com/kubernetes-incubator/cri-o/conmon'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/home/wking/.local/lib/go/src/github.com/kubernetes-incubator/cri-o/conmon'
make -C pause
make[1]: Entering directory '/home/wking/.local/lib/go/src/github.com/kubernetes-incubator/cri-o/pause'
make[1]: '../bin/pause' is up to date.
make[1]: Leaving directory '/home/wking/.local/lib/go/src/github.com/kubernetes-incubator/cri-o/pause'
```

Previously `make binaries` would rebuild `conmon`, `pause`, and `crio` every time.