### PR TITLE
conmon/pause: Add order-only prereq for ../bin

### DIFF
--- a/conmon/Makefile
+++ b/conmon/Makefile
@@ -14,8 +14,11 @@ override CFLAGS += -std=c99 -Os -Wall -Wextra $(shell pkg-config --cflags glib-2
 config.h: ../oci/oci.go
 	$(MAKE) -C .. conmon/config.h
 
-../bin/conmon: config.h $(obj)
+../bin/conmon: config.h $(obj) | ../bin
 	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
+
+../bin:
+	mkdir -p $@
 
 .PHONY: clean
 clean:

--- a/pause/Makefile
+++ b/pause/Makefile
@@ -4,8 +4,11 @@ obj = $(src:.c=.o)
 override LIBS +=
 override CFLAGS += -std=c99 -Os -Wall -Wextra -static
 
-../bin/pause: $(obj)
+../bin/pause: $(obj) | ../bin
 	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
+
+../bin:
+	mkdir -p $@
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Builds on #1458; review that first.

Avoid:

```console
$ rm -rf bin
$ make -C conmon
…
cc -o ../bin/conmon config.h conmon.o cmsg.o …
In file included from <command-line>:0:0:
/usr/include/stdc-predef.h:1:0: fatal error: can’t create precompiled
header ../bin/conmon: No such file or directory
…
```

by using an [order-only prerequisite][1] for the `bin` directory.  `mkdir -p dir` is [in POSIX][2].

[1]: https://www.gnu.org/software/make/manual/html_node/Prerequisite-Types.html
[2]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/mkdir.html