### PR TITLE
*: Return err from AddHook and ok from RemoveHook

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -62,22 +62,23 @@ func (c *ContainerServer) Hooks() map[string]HookParams {
 }
 
 // RemoveHook removes an hook by name
-func (c *ContainerServer) RemoveHook(hook string) {
+func (c *ContainerServer) RemoveHook(hook string) (ok bool) {
 	c.hooksLock.Lock()
 	defer c.hooksLock.Unlock()
-	if _, ok := c.hooks[hook]; ok {
+	_, ok = c.hooks[hook]
+	if ok {
 		delete(c.hooks, hook)
 	}
+	return ok
 }
 
 // AddHook adds an hook by hook's path
-func (c *ContainerServer) AddHook(hookPath string) {
+func (c *ContainerServer) AddHook(hookPath string) (err error) {
 	c.hooksLock.Lock()
 	defer c.hooksLock.Unlock()
 	hook, err := readHook(hookPath)
 	if err != nil {
-		logrus.Debugf("error while reading hook %s", hookPath)
-		return
+		return err
 	}
 	for key, h := range c.hooks {
 		// hook.Hook can only be defined in one hook file, unless it has the
@@ -87,6 +88,7 @@ func (c *ContainerServer) AddHook(hookPath string) {
 		}
 	}
 	c.hooks[filepath.Base(hookPath)] = hook
+	return nil
 }
 
 // Store returns the Store for the ContainerServer

--- a/lib/hooks.go
+++ b/lib/hooks.go
@@ -31,14 +31,16 @@ type HookParams struct {
 }
 
 var (
-	errNotJSON = errors.New("hook file isn't a JSON")
+	// ErrNoJSONSuffix represents hook-add attempts where the filename
+	// does not end in '.json'.
+	ErrNoJSONSuffix = errors.New("hook filename does not end in '.json'")
 )
 
 // readHook reads hooks json files, verifies it and returns the json config
 func readHook(hookPath string) (HookParams, error) {
 	var hook HookParams
 	if !strings.HasSuffix(hookPath, ".json") {
-		return hook, errNotJSON
+		return hook, ErrNoJSONSuffix
 	}
 	raw, err := ioutil.ReadFile(hookPath)
 	if err != nil {
@@ -92,7 +94,7 @@ func readHooks(hooksPath string, hooks map[string]HookParams) error {
 	for _, file := range files {
 		hook, err := readHook(filepath.Join(hooksPath, file.Name()))
 		if err != nil {
-			if err == errNotJSON {
+			if err == ErrNoJSONSuffix {
 				continue
 			}
 			return err


### PR DESCRIPTION
Also rename `errNotJSON` to the public `ErrNoJSONSuffix`.  This allows us to push success/failure logging out into `server/server.go` which understands that it is not filtering for `.json` suffixes.  With this change, we no longer log noise when someone:

* Touches a non-`.json` path in the watched directories.
* Removes a non-hook path in the watched directories.

Addition now only results in a logged success or error; previously we'd log the “adding” attempt and possibly *also* log the hook-reading error.

This PR implements [this suggestion][1] from #1345; ping @runcom.

[1]: https://github.com/kubernetes-incubator/cri-o/pull/1345#discussion_r169433836