### PR TITLE
conmon/pause: Allow user-specified CFLAGS

### DIFF
--- a/conmon/Makefile
+++ b/conmon/Makefile
@@ -9,7 +9,8 @@ override LIBS += $(shell pkg-config --libs glib-2.0)
 
 VERSION = $(shell sed -n -e 's/^const Version = "\([^"]*\)"/\1/p' ../version/version.go)
 
-override CFLAGS += -std=c99 -Os -Wall -Wextra $(shell pkg-config --cflags glib-2.0) -DVERSION=\"$(VERSION)\" -DGIT_COMMIT=\"$(GIT_COMMIT)\"
+CFLAGS ?= -std=c99 -Os -Wall -Wextra
+override CFLAGS += $(shell pkg-config --cflags glib-2.0) -DVERSION=\"$(VERSION)\" -DGIT_COMMIT=\"$(GIT_COMMIT)\"
 
 config.h: ../oci/oci.go
 	$(MAKE) -C .. conmon/config.h

--- a/conmon/cmsg.c
+++ b/conmon/cmsg.c
@@ -26,6 +26,12 @@
 
 #include "cmsg.h"
 
+#if __STDC_VERSION__ >= 199901L
+/* C99 or later */
+#else
+#error cmsg.c requires C99 or later
+#endif
+
 #define error(s) \
 	do { \
 		fprintf(stderr, "nsenter: %s %s\n", s, strerror(errno)); \

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -22,6 +22,12 @@
 #include <unistd.h>
 #include <inttypes.h>
 
+#if __STDC_VERSION__ >= 199901L
+/* C99 or later */
+#else
+#error conmon.c requires C99 or later
+#endif
+
 #include <glib.h>
 #include <glib-unix.h>
 

--- a/pause/Makefile
+++ b/pause/Makefile
@@ -2,7 +2,8 @@ src = $(wildcard *.c)
 obj = $(src:.c=.o)
 
 override LIBS +=
-override CFLAGS += -std=c99 -Os -Wall -Wextra -static
+CFLAGS ?= -std=c99 -Os -Wall -Wextra
+override CFLAGS += -static
 
 ../bin/pause: $(obj) | ../bin
 	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)


### PR DESCRIPTION
`-std`, `-O`, and `-W` are all options that the caller should be able to set for themselves.  My personal preference is to drop these defaults (and leave it up to the compiler and system configuration to get reasonable defaults, #1361), but that approach [was not acceptable to the CRI-O maintainers][2].  This pull-request moves options that CRI-O doesn't really need into a fallback [`?=` definition][3].  The options that we do need stay in the [`override +=` append][4].  The main drawback to this approach (vs. dropping the `?=` definition default completely) is that a user setting, for example, `CFLAGS=-O2` will clobber our default `-std`, etc. values.  But I can't see a way around that besides the approach in #1361.

CC @rhatdan and @giuseppe, who both had opinions about #1361.

[2]: https://github.com/kubernetes-incubator/cri-o/pull/1361#issuecomment-373504858
[3]: https://www.gnu.org/software/make/manual/html_node/Setting.html
[4]: https://www.gnu.org/software/make/manual/html_node/Override-Directive.html