### PR TITLE
CONTRIBUTING: Document test steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 before_install:
   - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq update; fi
   - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq install btrfs-tools libdevmapper-dev libgpgme11-dev libapparmor-dev libseccomp-dev; fi
-  - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq install autoconf automake bison e2fslibs-dev libfuse-dev libtool liblzma-dev gettext; fi
+  - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq install autoconf automake bison clang-format-3.9 e2fslibs-dev libfuse-dev libtool liblzma-dev gettext; fi
 
 install:
   - make install.tools
@@ -34,7 +34,7 @@ jobs:
     - stage: Build and Verify
       script:
         - make .gitvalidation
-        - make gofmt
+        - make fmt
         - make lint
       go: tip
     - stage: Build and Verify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,20 @@ separate from the rest of the PRs. But, squashing down to just one commit is ok
 too since in the end the entire PR will be reviewed anyway. When in doubt,
 squash.
 
+Test your changes by running:
+
+```console
+$ make fmt
+$ make lint
+```
+
+And you can run the test suite if you have access to elevated permissions:
+
+```console
+# make testunit
+# make integration  # or, if you don't want to use Docker, localintegration
+```
+
 PRs that fix issues should include a reference like `Closes #XXXX` in the
 commit message so that github will automatically close the referenced issue
 when the PR is merged.


### PR DESCRIPTION
So users can check their pull requests locally without leaning on Travis.

Also configure Travis to run `fmt` instead of `gofmt`, taking advantage of the changes from #1460.