### PR TITLE
CONTRIBUTING: Explain .github/CODEOWNERS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,7 @@ commit message so that github will automatically close the referenced issue
 when the PR is merged.
 
 Most PRs will be reviewed by two [approvers][prow-approvers] (listed [here](OWNERS)).
+Some maintainers add themselves to [`CODEOWNERS`](.github/CODEOWNERS) to manage their [review notifications][code-owners], but those entries have no governance significance.
 
 ### Sign your PRs
 
@@ -122,4 +123,5 @@ and
 [PRs](https://github.com/kubernetes-incubator/cri-o/pulls)
 tracking system.
 
+[code-owners]: https://help.github.com/articles/about-codeowners/
 [prow-approvers]: https://github.com/kubernetes/test-infra/blob/master/prow/plugins/approve/approvers/README.md#overview


### PR DESCRIPTION
I initially thought this file was about scoping review (see “[Require review from Code Owners][1]”), but @rhatdan pointed out that [only the Prow `OWNERS` matter for pull-request approval][2].  @mrunalp explained that [`CODEOWNERS was for managing notifications][3], so I'm documenting that here where it's more discoverable.

[1]: https://help.github.com/articles/enabling-required-reviews-for-pull-requests/
[2]: https://github.com/kubernetes-incubator/cri-o/pull/1272#discussion_r172746401
[3]: https://github.com/kubernetes-incubator/cri-o/pull/1272#issuecomment-373788087