### PR TITLE
lib/hooks: Allow the same command in multiple hook files

### DIFF
--- a/lib/hooks.go
+++ b/lib/hooks.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"syscall"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -98,13 +97,6 @@ func readHooks(hooksPath string, hooks map[string]HookParams) error {
 				continue
 			}
 			return err
-		}
-		for key, h := range hooks {
-			// hook.Hook can only be defined in one hook file, unless it has the
-			// same name in the override path.
-			if hook.Hook == h.Hook && key != file.Name() {
-				return errors.Wrapf(syscall.EINVAL, "duplicate path,  hook %q from %q already defined in %q", hook.Hook, hooksPath, key)
-			}
 		}
 		hooks[file.Name()] = hook
 	}


### PR DESCRIPTION
Lift the constraint added in ca940957 (#1345).  For example, you may want to limit a hook to one stage for an `annotations` match and another stage for a `cmd` match.  Using two files with the same hook entry is the only way to do that.

Spun off from [this comment][1]; cc @runcom.

[1]: https://github.com/kubernetes-incubator/cri-o/pull/1345/commits/ca940957390cc830fa609a5408e002faa9cdb794#r169433007