### PR TITLE
server/server: Watch OverrideHooksDirPath for hook updates

### DIFF
--- a/hooks.md
+++ b/hooks.md
@@ -15,6 +15,8 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 CRI-O reads all [JSON][] files in `/usr/share/containers/oci/hooks.d/*.json` and `/etc/containers/oci/hooks.d/*.json` to load hook configuration.
 If the same file is in both directories, the one in `/etc/containers/oci/hooks.d` takes precedence.
 
+CRI-O watches both hook directories for file creation, writes, and removals, so you can adjust the hooks there without restarting `crio`.
+
 Each JSON file should contain an object with the following properties:
 
 * **`hook`** (REQUIRED, string) Sets [`path`][spec-hooks] in the injected hook.

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -180,8 +180,9 @@ func New(config *Config) (*ContainerServer, error) {
 		if err := readHooks(config.HooksDirPath, hooks); err != nil {
 			return nil, err
 		}
-		// If user overrode default hooks, this means it is in a test, so don't
-		// use OverrideHooksDirPath
+		// If user overrode default hooks, this means it is in a test, so
+		// don't use OverrideHooksDirPath.  Sync with server/server.go's
+		// StartHooksMonitor.
 		if config.HooksDirPath == DefaultHooksDirPath {
 			if err := readHooks(OverrideHooksDirPath, hooks); err != nil {
 				return nil, err


### PR DESCRIPTION
This avoids:

1. Hook loaded from `/usr/share/containers/oci/hooks.d/abc.json`.
2. Hook overridden `/etc/containers/oci/hooks.d/abc.json`.
3. User touches `/usr/share/containers/oci/hooks.d/abc.json`, which triggers CRI-O to update the hook, overriding the `/etc/containers/oci/hooks.d/abc.json` entry.

With this pull-request, `/etc/containers/oci/hooks.d` entries always override `/usr/share/containers/oci/hooks.d` entries.  I've also added documentation for this behavior.

An outstanding hole is if, instead of the touch in step 3 above, the user had removed `/usr/share/containers/oci/hooks.d/abc.json`.  I think the ideal behavior there would be attempting to reload the hook from `/usr/share/containers/oci/hooks.d/abc.json` and only removing the hook if it was unlisted in both locations.  But I've left that particular issue alone in this pull-request.

Spun off from [this comment][1].  Discussed in that comment but not implemented here: I no longer monitor `/usr/share/containers/oci/hooks.d`.  Users (who don't read the new docs) might expect `crio` to notice changes there which were not masked by `/etc/containers/oci/hooks.d` entries, but I didn't have time to add the `HookParams` property discussed there.

The directory change is a breaking change for folks relying on the current logic.  But it's currently only in `v1.10.0-beta.1`, so if we're going to break the current logic, now's the time :).

CC @runcom.

[1]: https://github.com/kubernetes-incubator/cri-o/pull/1345/commits/ca940957390cc830fa609a5408e002faa9cdb794#r169435113