### PR TITLE
Fix crio man page bugs.

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -116,8 +116,6 @@ crio [GLOBAL OPTIONS] config [OPTIONS]
 
 **--cni-plugin-dir**="": CNI plugin binaries directory (default: "/opt/cni/bin/")
 
-**--cpu-profile**: Set the CPU profile file path
-
 **--version, -v**: Print the version
 
 # COMMANDS

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -56,6 +56,10 @@ crio [GLOBAL OPTIONS] config [OPTIONS]
 
 **--cgroup-manager**="": cgroup manager (cgroupfs or systemd)
 
+**--cni-config-dir**="": CNI configuration files directory (default: "/etc/cni/net.d/")
+
+**--cni-plugin-dir**="": CNI plugin binaries directory (default: "/opt/cni/bin/")
+
 **--config**="": path to configuration file
 
 **--conmon**="": path to the conmon executable (default: "/usr/local/libexec/crio/conmon")
@@ -111,10 +115,6 @@ crio [GLOBAL OPTIONS] config [OPTIONS]
 **--storage-driver**: OCI storage driver (default: "devicemapper")
 
 **--storage-opt**: OCI storage driver option (no default)
-
-**--cni-config-dir**="": CNI configuration files directory (default: "/etc/cni/net.d/")
-
-**--cni-plugin-dir**="": CNI plugin binaries directory (default: "/opt/cni/bin/")
 
 **--version, -v**: Print the version
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This PR fixes two (trivial) issues in the man page `doc/crio.8.md`. The first fix is the removal of double `--cpu-profile` command line option description and the second is fixing the bit broken alphabetical order of the command line options.

**- Description for the changelog**

Updated the man page options.