### PR TITLE
Drop libapparmor dependency from build docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 before_install:
   - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq update; fi
-  - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq install btrfs-tools libdevmapper-dev libgpgme11-dev libapparmor-dev libseccomp-dev; fi
+  - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq install btrfs-tools libdevmapper-dev libgpgme11-dev libseccomp-dev; fi
   - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq install autoconf automake bison clang-format-3.9 e2fslibs-dev libfuse-dev libtool liblzma-dev gettext; fi
 
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN apt-get update && apt-get install -y \
     protobuf-compiler \
     python-minimal \
     libglib2.0-dev \
-    libapparmor-dev \
     btrfs-tools \
     libdevmapper1.02.1 \
     libdevmapper-dev \

--- a/README.md
+++ b/README.md
@@ -143,19 +143,6 @@ If using an older release or a long-term support release, be careful to double-c
 
 Be careful to double-check that the version of golang is new enough, version 1.8.x or higher is required.  If needed, golang kits are avaliable at https://golang.org/dl/
 
-**Optional**
-
-Fedora, CentOS, RHEL, and related distributions:
-
-(no optional packages)
-
-Debian, Ubuntu, and related distributions:
-
-```bash
-apt-get install -y \
-  libapparmor-dev
-```
-
 ### Get Source Code
 
 Clone the source code using:
@@ -194,7 +181,7 @@ make BUILDTAGS='seccomp apparmor'
 |-----------|------------------------------------|-------------|
 | seccomp   | syscall filtering                  | libseccomp  |
 | selinux   | selinux process and mount labeling | libselinux  |
-| apparmor  | apparmor profile support           | libapparmor |
+| apparmor  | apparmor profile support           | <none>      |
 
 ### Running pods and containers
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -114,7 +114,6 @@ make install
 ```
 sudo apt-get update && apt-get install -y libglib2.0-dev \
                                           libseccomp-dev \
-                                          libapparmor-dev \
                                           libgpgme11-dev \
                                           libdevmapper-dev \
                                           make \


### PR DESCRIPTION
As of opencontainers/runc@db093f6 runc no longer depends on libapparmor
thus libapparmor-dev no longer needs to be installed to build it or
anythind that depends on it (like cri-o). Adjust the documentation
accordingly.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>
