### PR TITLE
Conmon multiple attach

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -589,7 +589,7 @@ struct conn_sock_s {
 	gboolean readable;
 	gboolean writable;
 };
-static struct conn_sock_s conn_sock = {-1, false, false};
+GPtrArray *conn_socks = NULL;
 
 static int oom_event_fd = -1;
 static int attach_socket_fd = -1;
@@ -612,6 +612,7 @@ static void conn_sock_shutdown(struct conn_sock_s *sock, int how)
 	if (!sock->writable && !sock->readable) {
 		close(sock->fd);
 		sock->fd = -1;
+		g_ptr_array_remove(conn_socks, sock);
 	}
 }
 
@@ -633,6 +634,7 @@ static bool read_stdio(int fd, stdpipe_t pipe, bool *eof)
 	char real_buf[STDIO_BUF_SIZE + 1];
 	char *buf = real_buf + 1;
 	ssize_t num_read = 0;
+	size_t i;
 
 	if (eof)
 		*eof = false;
@@ -651,10 +653,18 @@ static bool read_stdio(int fd, stdpipe_t pipe, bool *eof)
 			return G_SOURCE_CONTINUE;
 		}
 
+		if (conn_socks == NULL) {
+			return true;
+		}
+
 		real_buf[0] = pipe;
-		if (conn_sock.writable && write_all(conn_sock.fd, real_buf, num_read + 1) < 0) {
-			nwarn("Failed to write to socket");
-			conn_sock_shutdown(&conn_sock, SHUT_WR);
+		for (i = conn_socks->len; i > 0; i--) {
+			struct conn_sock_s *conn_sock = g_ptr_array_index(conn_socks, i - 1);
+
+			if (conn_sock->writable && write_all(conn_sock->fd, real_buf, num_read + 1) < 0) {
+				nwarn("Failed to write to socket");
+				conn_sock_shutdown(conn_sock, SHUT_WR);
+			}
 		}
 		return true;
 	}
@@ -842,15 +852,25 @@ static gboolean conn_sock_cb(int fd, GIOCondition condition, gpointer user_data)
 
 static gboolean attach_cb(int fd, G_GNUC_UNUSED GIOCondition condition, G_GNUC_UNUSED gpointer user_data)
 {
-	conn_sock.fd = accept(fd, NULL, NULL);
-	if (conn_sock.fd == -1) {
+	int conn_fd = accept(fd, NULL, NULL);
+	if (conn_fd == -1) {
 		if (errno != EWOULDBLOCK)
 			nwarn("Failed to accept client connection on attach socket");
 	} else {
-		conn_sock.readable = true;
-		conn_sock.writable = true;
-		g_unix_fd_add(conn_sock.fd, G_IO_IN | G_IO_HUP | G_IO_ERR, conn_sock_cb, &conn_sock);
-		ninfof("Accepted connection %d", conn_sock.fd);
+		struct conn_sock_s *conn_sock;
+		if (conn_socks == NULL) {
+			conn_socks = g_ptr_array_new_with_free_func(free);
+		}
+		conn_sock = malloc(sizeof(*conn_sock));
+		if (conn_sock == NULL) {
+			pexit("Failed to allocate memory");
+		}
+		conn_sock->fd = conn_fd;
+		conn_sock->readable = true;
+		conn_sock->writable = true;
+		g_unix_fd_add(conn_sock->fd, G_IO_IN | G_IO_HUP | G_IO_ERR, conn_sock_cb, conn_sock);
+		g_ptr_array_add(conn_socks, conn_sock);
+		ninfof("Accepted connection %d", conn_sock->fd);
 	}
 
 	return G_SOURCE_CONTINUE;

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -584,9 +584,12 @@ static int masterfd_stdout = -1;
 static int masterfd_stderr = -1;
 
 /* Used for attach */
-static int conn_sock = -1;
-static int conn_sock_readable;
-static int conn_sock_writable;
+struct conn_sock_s {
+	int fd;
+	gboolean readable;
+	gboolean writable;
+};
+static struct conn_sock_s conn_sock = {-1, false, false};
 
 static int oom_event_fd = -1;
 static int attach_socket_fd = -1;
@@ -597,18 +600,18 @@ static bool timed_out = FALSE;
 
 static GMainLoop *main_loop = NULL;
 
-static void conn_sock_shutdown(int how)
+static void conn_sock_shutdown(struct conn_sock_s *sock, int how)
 {
-	if (conn_sock == -1)
+	if (sock->fd == -1)
 		return;
-	shutdown(conn_sock, how);
+	shutdown(sock->fd, how);
 	if (how & SHUT_RD)
-		conn_sock_readable = false;
+		sock->readable = false;
 	if (how & SHUT_WR)
-		conn_sock_writable = false;
-	if (!conn_sock_writable && !conn_sock_readable) {
-		close(conn_sock);
-		conn_sock = -1;
+		sock->writable = false;
+	if (!sock->writable && !sock->readable) {
+		close(sock->fd);
+		sock->fd = -1;
 	}
 }
 
@@ -649,9 +652,9 @@ static bool read_stdio(int fd, stdpipe_t pipe, bool *eof)
 		}
 
 		real_buf[0] = pipe;
-		if (conn_sock_writable && write_all(conn_sock, real_buf, num_read + 1) < 0) {
+		if (conn_sock.writable && write_all(conn_sock.fd, real_buf, num_read + 1) < 0) {
 			nwarn("Failed to write to socket");
-			conn_sock_shutdown(SHUT_WR);
+			conn_sock_shutdown(&conn_sock, SHUT_WR);
 		}
 		return true;
 	}
@@ -805,10 +808,11 @@ static gboolean oom_cb(int fd, GIOCondition condition, G_GNUC_UNUSED gpointer us
 }
 
 #define CONN_SOCK_BUF_SIZE 32 * 1024 /* Match the write size in CopyDetachable */
-static gboolean conn_sock_cb(int fd, GIOCondition condition, G_GNUC_UNUSED gpointer user_data)
+static gboolean conn_sock_cb(int fd, GIOCondition condition, gpointer user_data)
 {
 	char buf[CONN_SOCK_BUF_SIZE];
 	ssize_t num_read = 0;
+	struct conn_sock_s *sock = (struct conn_sock_s *)user_data;
 
 	if ((condition & G_IO_IN) != 0) {
 		num_read = read(fd, buf, CONN_SOCK_BUF_SIZE);
@@ -824,7 +828,7 @@ static gboolean conn_sock_cb(int fd, GIOCondition condition, G_GNUC_UNUSED gpoin
 	}
 
 	/* End of input */
-	conn_sock_shutdown(SHUT_RD);
+	conn_sock_shutdown(sock, SHUT_RD);
 	if (masterfd_stdin >= 0 && opt_stdin) {
 		if (!opt_leave_stdin_open) {
 			close(masterfd_stdin);
@@ -838,15 +842,15 @@ static gboolean conn_sock_cb(int fd, GIOCondition condition, G_GNUC_UNUSED gpoin
 
 static gboolean attach_cb(int fd, G_GNUC_UNUSED GIOCondition condition, G_GNUC_UNUSED gpointer user_data)
 {
-	conn_sock = accept(fd, NULL, NULL);
-	if (conn_sock == -1) {
+	conn_sock.fd = accept(fd, NULL, NULL);
+	if (conn_sock.fd == -1) {
 		if (errno != EWOULDBLOCK)
 			nwarn("Failed to accept client connection on attach socket");
 	} else {
-		conn_sock_readable = true;
-		conn_sock_writable = true;
-		g_unix_fd_add(conn_sock, G_IO_IN | G_IO_HUP | G_IO_ERR, conn_sock_cb, GINT_TO_POINTER(STDOUT_PIPE));
-		ninfof("Accepted connection %d", conn_sock);
+		conn_sock.readable = true;
+		conn_sock.writable = true;
+		g_unix_fd_add(conn_sock.fd, G_IO_IN | G_IO_HUP | G_IO_ERR, conn_sock_cb, &conn_sock);
+		ninfof("Accepted connection %d", conn_sock.fd);
 	}
 
 	return G_SOURCE_CONTINUE;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
added support in conmon for multiple ttys attached at the same time

Closes: #1481 

**- How I did it**
changed conmon to store an array of ttys instead of a single fd

**- How to verify it**
```
# podman  run --rm --name foo --interactive fedora cat
```
and in another terminal:
```
# podman attach foo
```

What is written in one terminal is visible to the other.

**- Description for the changelog**

conmon supports more than one attached tty at the same time.