### PR TITLE
conmon: fix typo servier->server

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -339,7 +339,7 @@ func main() {
 		},
 		cli.BoolFlag{
 			Name:  "enable-metrics",
-			Usage: "enable metrics endpoint for the servier on localhost:9090",
+			Usage: "enable metrics endpoint for the server on localhost:9090",
 		},
 		cli.IntFlag{
 			Name:  "metrics-port",


### PR DESCRIPTION
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

**- What I did**

fixed a typo

**- How I did it**
sed -i -e 's|servier|server|' cmd/crio/main.go

**- How to verify it**
no "servier" in crio --help
