### PR TITLE
cri-o: allow a prefix for all bind mounts

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -146,6 +146,9 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("read-only") {
 		config.ReadOnly = ctx.GlobalBool("read-only")
 	}
+	if ctx.GlobalIsSet("bind-mount-prefix") {
+		config.BindMountPrefix = ctx.GlobalString("bind-mount-prefix")
+	}
 	return nil
 }
 
@@ -350,6 +353,10 @@ func main() {
 		cli.BoolFlag{
 			Name:  "read-only",
 			Usage: "setup all unprivileged containers to run as read-only",
+		},
+		cli.StringFlag{
+			Name:  "bind-mount-prefix",
+			Usage: "specify a prefix to prepend to the source of a bind mount",
 		},
 	}
 

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -8,6 +8,7 @@ crio - OCI Kubernetes Container Runtime daemon
 crio
 ```
 [--apparmor-profile=[value]]
+[--bind-mount-prefix=[value]]
 [--cgroup-manager=[value]]
 [--cni-config-dir=[value]]
 [--cni-plugin-dir=[value]]
@@ -54,6 +55,8 @@ crio [GLOBAL OPTIONS] config [OPTIONS]
 ```
 # GLOBAL OPTIONS
 **--apparmor_profile**="": Name of the apparmor profile to be used as the runtime's default (default: "crio-default")
+
+**--bind-mount-prefix**="": A prefix to use for the source of the bind mounts.  This option would be useful if you were running CRI-O in a container.  And had `/` mounted on `/host` in your container.  Then if you ran CRI-O with the `--bind-mount-prefix=/host` option, CRI-O would add /host to any bind mounts it is handed over CRI.  If Kubernetes asked to have `/var/lib/foobar` bind mounted into the container, then CRI-I would bind mount `/host/var/lib/foobar`.  Since CRI-O itself is running in a container with `/` or the host mounted on `/host`, the container would end up with `/var/lib/foobar` from the host mounted in the container rather then `/var/lib/foobar` from the CRI-O container.
 
 **--cgroup-manager**="": cgroup manager (cgroupfs or systemd)
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -175,6 +175,9 @@ type RuntimeConfig struct {
 	// Will also set the readonly flag in the OCI Runtime Spec.  In this mode containers
 	// will only be able to write to volumes mounted into them
 	ReadOnly bool `toml:"read_only"`
+
+	// BindMountPrefix is the prefix to use for the source of the bind mounts.
+	BindMountPrefix string `toml:"bind_mount_prefix"`
 }
 
 // ImageConfig represents the "crio.image" TOML config table.

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -87,15 +87,15 @@ func addOCIBindMounts(mountLabel string, containerConfig *pb.ContainerConfig, sp
 		}
 		src := filepath.Join(bindMountPrefix, mount.HostPath)
 
-		if _, err := os.Lstat(src); err != nil && os.IsNotExist(err) {
-			if err1 := os.MkdirAll(src, 0644); err1 != nil {
+		resolvedSrc, err := resolveSymbolicLink(src, bindMountPrefix)
+		if err == nil {
+			src = resolvedSrc
+		} else {
+			if !os.IsNotExist(err) {
+				return nil, nil, fmt.Errorf("failed to resolve symlink %q: %v", src, err)
+			} else if err = os.MkdirAll(src, 0644); err != nil {
 				return nil, nil, fmt.Errorf("Failed to mkdir %s: %s", src, err)
 			}
-		}
-
-		src, err := resolveSymbolicLink(src, bindMountPrefix)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to resolve symlink %q: %v", src, err)
 		}
 
 		options := []string{"rw"}

--- a/server/secrets.go
+++ b/server/secrets.go
@@ -128,7 +128,7 @@ func secretMounts(defaultMountsPaths []string, mountLabel, containerWorkingDir s
 			return nil, fmt.Errorf("making container directory failed: %v", err)
 		}
 
-		hostDir, err = resolveSymbolicLink(hostDir)
+		hostDir, err = resolveSymbolicLink(hostDir, "/")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Introduce a new config --bind-mount-prefix=PREFIX that adds a prefix
to the source for every bind mount.  This allows CRI-O to run inside
of a container, and be able to see the host rootfs.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

**- What I did**
Added a new option --bind-mount-prefix=PREFIX to specify a prefix for every bind mount.

**- How I did it**
If a bind mount PREFIX is specified, the source for each bind mount is prefixed with it

**- How to verify it**
`# mkdir -p /host/foo`
`# touch /host/foo/bar`
`# crio --bind-mount-prefix=/host/host`

A mount from `/foo/bar` -> `/bar` is converted to `/host/foo/bar` -> `/bar`

**- Description for the changelog**
New option --bind-mount-prefix=PREFIX to permit CRI-O in a container to get full access to the host rootfs

Marked as WIP as I am still testing it