### PR TITLE
test: Fix race condition in ctr.bats

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -882,11 +882,19 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run crictl inspect "$ctr_id"
-	echo "$output"
-	[ "$status" -eq 0 ]
-	[[ "$output" =~ "State: CONTAINER_EXITED" ]]
-	[[ "$output" =~ "Exit Code: 0" ]]
+	# Wait for container to exit
+	attempt=0
+	while [ $attempt -le 100 ]; do
+		attempt=$((attempt+1))
+		run crictl inspect "$ctr_id"
+		echo "$output"
+		[ "$status" -eq 0 ]
+		if [[ "$output" =~ "State: CONTAINER_EXITED" ]]; then
+			[[ "$output" =~ "Exit Code: 0" ]]
+			break
+		fi
+		sleep 1
+	done
 
 	run crictl create "$pod_id" "$TESTDATA"/container_config_resolvconf_ro.json "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -895,10 +903,18 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run crictl inspect "$ctr_id"
-	echo "$output"
-	[ "$status" -eq 0 ]
-	[[ "$output" =~ "State: CONTAINER_EXITED" ]]
+	# Wait for container to exit
+	attempt=0
+	while [ $attempt -le 100 ]; do
+		attempt=$((attempt+1))
+		run crictl inspect "$ctr_id"
+		echo "$output"
+		[ "$status" -eq 0 ]
+		if [[ "$output" =~ "State: CONTAINER_EXITED" ]]; then
+			break
+		fi
+		sleep 1
+	done
 
 	cleanup_ctrs
 	cleanup_pods


### PR DESCRIPTION
When running BATS testing from ctr.bats, it works very well for
runc, but in case of Kata Containers, we can expect actions to
take longer time to be achieved. In the specific case of the test
"ctr /etc/resolv.conf rw/ro mode" from ctr.bats, we should not expect
the container state to be CONTAINER_EXITED right after the start
returned. Indeed, it might take some time for the container to exit
and the call to "crictl inspect $ctr_id --output table" should be
tried several times before we consider the output as failing.

This patch relies on the "ctr oom" test as an example of how to
implement this retry behavior.

This is a backport of #1489

Fixes #1491

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>
