### PR TITLE
server/sandbox_stop: Pass context through StopAllPodSandboxes

### DIFF
--- a/server/sandbox_status_test.go
+++ b/server/sandbox_status_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -80,11 +81,12 @@ func setupServer(t *testing.T) (*Server, string, func()) {
 }
 
 func TestPodSandboxStatus(t *testing.T) {
+	ctx := context.Background()
 	server, sandboxID, teardown := setupServer(t)
 	defer teardown()
 
 	t.Run("Without verbose information", func(t *testing.T) {
-		resp, err := server.PodSandboxStatus(nil, &pb.PodSandboxStatusRequest{
+		resp, err := server.PodSandboxStatus(ctx, &pb.PodSandboxStatusRequest{
 			PodSandboxId: sandboxID,
 		})
 		if err != nil {
@@ -100,7 +102,7 @@ func TestPodSandboxStatus(t *testing.T) {
 	})
 
 	t.Run("With verbose information", func(t *testing.T) {
-		resp, err := server.PodSandboxStatus(nil, &pb.PodSandboxStatusRequest{
+		resp, err := server.PodSandboxStatus(ctx, &pb.PodSandboxStatusRequest{
 			PodSandboxId: sandboxID,
 			Verbose:      true,
 		})

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -124,13 +124,13 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 }
 
 // StopAllPodSandboxes removes all pod sandboxes
-func (s *Server) StopAllPodSandboxes() {
+func (s *Server) StopAllPodSandboxes(ctx context.Context) {
 	logrus.Debugf("StopAllPodSandboxes")
 	for _, sb := range s.ContainerServer.ListSandboxes() {
 		pod := &pb.StopPodSandboxRequest{
 			PodSandboxId: sb.ID(),
 		}
-		if _, err := s.StopPodSandbox(nil, pod); err != nil {
+		if _, err := s.StopPodSandbox(ctx, pod); err != nil {
 			logrus.Warnf("could not StopPodSandbox %s: %v", sb.ID(), err)
 		}
 	}


### PR DESCRIPTION
Fixes #1490, avoiding:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x91b13f]
goroutine 1 [running]:
…
runtime.sigpanic()
        /…/runtime/signal_unix.go:388 +0x17a fp=0xc42093a670 sp=0xc42093a620 pc=0x44816a
github.com/kubernetes-incubator/cri-o/oci.waitContainerStop(0x0, 0x0, 0xc4208a2140, 0x2540be400, 0x1873be0, 0xc42000e020)
        /…/cri-o/oci/oci.go:589 +0xaf fp=0xc42093a7a0 sp=0xc42093a670 pc=0x91b13f
github.com/kubernetes-incubator/cri-o/oci.(*Runtime).StopContainer(0xc4205294a0, 0x0, 0x0, 0xc4208a2140, 0xa, 0x0, 0x0)
        /…/cri-o/oci/oci.go:620 +0x57f fp=0xc42093a920 sp=0xc42093a7a0 pc=0x91b99f
github.com/kubernetes-incubator/cri-o/server.(*Server).StopPodSandbox(0xc4202dc000, 0x0, 0x0, 0xc4201e0fd0, 0x0, 0x0, 0x0)
        /…/cri-o/server/sandbox_stop.go:62 +0x29c fp=0xc42093abc8 sp=0xc42093a920 pc=0x13387bc
github.com/kubernetes-incubator/cri-o/server.(*Server).StopAllPodSandboxes(0xc4202dc000)
        /…/cri-o/server/sandbox_stop.go:125 +0x112 fp=0xc42093ac80 sp=0xc42093abc8 pc=0x1339712
github.com/kubernetes-incubator/cri-o/server.(*Server).cleanupSandboxesOnShutdown(0xc4202dc000)
        /…/cri-o/server/server.go:153 +0x85 fp=0xc42093acd0 sp=0xc42093ac80 pc=0x133be15
github.com/kubernetes-incubator/cri-o/server.(*Server).Shutdown(0xc4202dc000, 0x2, 0x0)
        /…/cri-o/server/server.go:168 +0x2b fp=0xc42093acf8 sp=0xc42093acd0 pc=0x133beeb
…
```

by passing a `Context` instance down the stack so we don't have to hard-code `nil` in `StopAllPodSandboxes`' `StopPodSandbox` call.

I've also included an orthogonal commit with a similar cleanup for `sandbox_status_test.go`.