### PR TITLE
crio-shutdown.service was not working correctly

### DIFF
--- a/contrib/systemd/crio-shutdown.service
+++ b/contrib/systemd/crio-shutdown.service
@@ -6,8 +6,8 @@ Documentation=man:crio(8)
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/true
-ExecStop=mkdir -p /var/lib/crio; touch /var/lib/crio/crio.shutdown
+ExecStart=/usr/bin/rm -f /var/lib/crio/crio.shutdown
+ExecStop=/usr/bin/bash -c "/usr/bin/mkdir /var/lib/crio; /usr/bin/touch /var/lib/crio/crio.shutdown"
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
We need to make sure the crio-shutdown file does not exist when the service
starts and then make sure the directory and file exist on shutdown.
The current version of this service script is blowing up.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
