### PR TITLE
server: O_WRONLY is not unix only

### DIFF
--- a/server/container_reopen_log.go
+++ b/server/container_reopen_log.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kubernetes-incubator/cri-o/oci"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
-	"golang.org/x/sys/unix"
 	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
@@ -40,7 +39,7 @@ func (s *Server) ReopenContainerLog(ctx context.Context, req *pb.ReopenContainer
 	}
 
 	controlPath := filepath.Join(c.BundlePath(), "ctl")
-	controlFile, err := os.OpenFile(controlPath, unix.O_WRONLY, 0)
+	controlFile, err := os.OpenFile(controlPath, os.O_WRONLY, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open container ctl file: %v", err)
 	}


### PR DESCRIPTION
Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
