### PR TITLE
[release 1.9] server/sandbox_stop: Pass context through StopAllPodSandboxes

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -164,11 +164,12 @@ func catchShutdown(gserver *grpc.Server, sserver *server.Server, hserver *http.S
 				continue
 			}
 			*signalled = true
+			ctx := context.Background()
 			gserver.GracefulStop()
-			hserver.Shutdown(context.Background())
+			hserver.Shutdown(ctx)
 			sserver.StopStreamServer()
 			sserver.StopExitMonitor()
-			if err := sserver.Shutdown(); err != nil {
+			if err := sserver.Shutdown(ctx); err != nil {
 				logrus.Warnf("error shutting down main service %v", err)
 			}
 			return
@@ -408,6 +409,7 @@ func main() {
 	}
 
 	app.Action = func(c *cli.Context) error {
+		ctx := context.Background()
 		if c.GlobalBool("profile") {
 			profilePort := c.GlobalInt("profile-port")
 			profileEndpoint := fmt.Sprintf("localhost:%v", profilePort)
@@ -454,7 +456,7 @@ func main() {
 
 		s := grpc.NewServer()
 
-		service, err := server.New(config)
+		service, err := server.New(ctx, config)
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -522,7 +524,7 @@ func main() {
 		case <-serverCloseCh:
 		}
 
-		service.Shutdown()
+		service.Shutdown(ctx)
 
 		<-streamServerCloseCh
 		logrus.Debug("closed stream server")

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -116,13 +116,13 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 }
 
 // StopAllPodSandboxes removes all pod sandboxes
-func (s *Server) StopAllPodSandboxes() {
+func (s *Server) StopAllPodSandboxes(ctx context.Context) {
 	logrus.Debugf("StopAllPodSandboxes")
 	for _, sb := range s.ContainerServer.ListSandboxes() {
 		pod := &pb.StopPodSandboxRequest{
 			PodSandboxId: sb.ID(),
 		}
-		if _, err := s.StopPodSandbox(nil, pod); err != nil {
+		if _, err := s.StopPodSandbox(ctx, pod); err != nil {
 			logrus.Warnf("could not StopPodSandbox %s: %v", sb.ID(), err)
 		}
 	}


### PR DESCRIPTION
Backported from d3b76361 (#1494), fixing a trivial merge conflict in `cmd/crio/main.go`.

I haven't backported 28a0a53a9, because `server/sandbox_status_test.go` doesn't exist in the 1.9 branch.