### PR TITLE
lib/container_server: Allow the same command in multiple hook files

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -80,13 +80,6 @@ func (c *ContainerServer) AddHook(hookPath string) (err error) {
 	if err != nil {
 		return err
 	}
-	for key, h := range c.hooks {
-		// hook.Hook can only be defined in one hook file, unless it has the
-		// same name in the override path.
-		if hook.Hook == h.Hook && key != filepath.Base(hookPath) {
-			logrus.Debugf("duplicate path,  hook %q from %q already defined in %q", hook.Hook, c.config.HooksDirPath, key)
-		}
-	}
 	c.hooks[filepath.Base(hookPath)] = hook
 	return nil
 }


### PR DESCRIPTION
Lift the constraint added in ca94095 (#1345).  For example, you may want to limit a hook to one stage for an annotations match and another stage for a cmd match.  Using two files with the same hook entry is the only way to do that.

This is very similar to dbd16413 (#1468), where I'd *attempted* to remove the constraint from ca94095, but actually ended up removing a very similar constraint which had been added in 139d0841 (#562).

CC @runcom, @rhatdan.