### PR TITLE
syscontainers: use --bind-mount-prefix

### DIFF
--- a/contrib/system_containers/centos/config.json.template
+++ b/contrib/system_containers/centos/config.json.template
@@ -297,28 +297,6 @@
             "source": "/root",
             "type": "bind"
         },
-        {
-            "destination": "/home",
-            "options": [
-                "rbind",
-                "rprivate",
-                "rw",
-                "mode=755"
-            ],
-            "source": "/home",
-            "type": "bind"
-        },
-        {
-            "destination": "/mnt",
-            "options": [
-                "rbind",
-                "rw",
-                "rprivate",
-                "mode=755"
-            ],
-            "source": "/mnt",
-            "type": "bind"
-        },
 	{
 	    "type": "bind",
 	    "source": "${RUN_DIRECTORY}",

--- a/contrib/system_containers/centos/config.json.template
+++ b/contrib/system_containers/centos/config.json.template
@@ -414,6 +414,16 @@
             "type": "bind"
         },
         {
+            "destination": "/host",
+            "options": [
+                "rbind",
+                "rshared",
+                "rw"
+            ],
+            "source": "/",
+            "type": "bind"
+        },
+        {
             "destination": "/sys",
             "options": [
                 "rprivate",

--- a/contrib/system_containers/centos/run.sh
+++ b/contrib/system_containers/centos/run.sh
@@ -8,4 +8,4 @@ printf %s $LABEL > /proc/self/attr/exec
 test -e /etc/sysconfig/crio-storage && source /etc/sysconfig/crio-storage
 test -e /etc/sysconfig/crio-network && source /etc/sysconfig/crio-network
 
-exec /usr/bin/crio --log-level=$LOG_LEVEL
+exec /usr/bin/crio --bind-mount-prefix=/host --log-level=$LOG_LEVEL

--- a/contrib/system_containers/fedora/config.json.template
+++ b/contrib/system_containers/fedora/config.json.template
@@ -302,28 +302,6 @@
             "source": "/root",
             "type": "bind"
         },
-        {
-            "destination": "/home",
-            "options": [
-                "rbind",
-                "rprivate",
-                "rw",
-                "mode=755"
-            ],
-            "source": "/home",
-            "type": "bind"
-        },
-        {
-            "destination": "/mnt",
-            "options": [
-                "rbind",
-                "rw",
-                "rprivate",
-                "mode=755"
-            ],
-            "source": "/mnt",
-            "type": "bind"
-        },
 	{
 	    "type": "bind",
 	    "source": "${RUN_DIRECTORY}",

--- a/contrib/system_containers/fedora/config.json.template
+++ b/contrib/system_containers/fedora/config.json.template
@@ -419,6 +419,16 @@
             "type": "bind"
         },
         {
+            "destination": "/host",
+            "options": [
+                "rbind",
+                "rshared",
+                "rw"
+            ],
+            "source": "/",
+            "type": "bind"
+        },
+        {
             "destination": "/sys",
             "options": [
                 "rprivate",

--- a/contrib/system_containers/fedora/run.sh
+++ b/contrib/system_containers/fedora/run.sh
@@ -8,4 +8,4 @@ printf %s $LABEL > /proc/self/attr/exec
 test -e /etc/sysconfig/crio-storage && source /etc/sysconfig/crio-storage
 test -e /etc/sysconfig/crio-network && source /etc/sysconfig/crio-network
 
-exec /usr/bin/crio --log-level=$LOG_LEVEL
+exec /usr/bin/crio --bind-mount-prefix=/host --log-level=$LOG_LEVEL

--- a/contrib/system_containers/rhel/config.json.template
+++ b/contrib/system_containers/rhel/config.json.template
@@ -293,28 +293,6 @@
       "type": "bind"
     },
     {
-      "destination": "/home",
-      "options": [
-        "rbind",
-        "rprivate",
-        "rw",
-        "mode=755"
-      ],
-      "source": "/home",
-      "type": "bind"
-    },
-    {
-      "destination": "/mnt",
-      "options": [
-        "rbind",
-        "rw",
-        "rprivate",
-        "mode=755"
-      ],
-      "source": "/mnt",
-      "type": "bind"
-    },
-    {
       "type": "bind",
       "source": "${RUN_DIRECTORY}",
       "destination": "/run",

--- a/contrib/system_containers/rhel/config.json.template
+++ b/contrib/system_containers/rhel/config.json.template
@@ -409,6 +409,16 @@
       "type": "bind"
     },
     {
+      "destination": "/host",
+      "options": [
+        "rbind",
+        "rshared",
+        "rw"
+      ],
+      "source": "/",
+      "type": "bind"
+    },
+    {
       "destination": "/sys",
       "options": [
         "rprivate",

--- a/contrib/system_containers/rhel/run.sh
+++ b/contrib/system_containers/rhel/run.sh
@@ -8,4 +8,4 @@ printf %s $LABEL > /proc/self/attr/exec
 test -e /etc/sysconfig/crio-storage && source /etc/sysconfig/crio-storage
 test -e /etc/sysconfig/crio-network && source /etc/sysconfig/crio-network
 
-exec /usr/bin/crio --log-level=$LOG_LEVEL
+exec /usr/bin/crio --bind-mount-prefix=/host --log-level=$LOG_LEVEL


### PR DESCRIPTION
**- What I did**

use --bind-mount-prefix for the system containers

**- How I did it**

hardcoded to the system container cmdline

**- How to verify it**

build a CRI-O system container and be able to bind mount every directory from the host

**- Description for the changelog**
