### PR TITLE
runtime_status: report correct network status

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -779,18 +779,6 @@ func (r *Runtime) ContainerStatus(c *Container) *ContainerState {
 	return c.state
 }
 
-// RuntimeReady checks if the runtime is up and ready to accept
-// basic containers e.g. container only needs host network.
-func (r *Runtime) RuntimeReady() (bool, error) {
-	return true, nil
-}
-
-// NetworkReady checks if the runtime network is up and ready to
-// accept containers which require container network.
-func (r *Runtime) NetworkReady() (bool, error) {
-	return true, nil
-}
-
 // PauseContainer pauses a container.
 func (r *Runtime) PauseContainer(c *Container) error {
 	c.opLock.Lock()


### PR DESCRIPTION
We were wrongly reporting runtime as ready even when it wasn't. This
patch correctly checks the network plugin before replying with network
ready.

@mrunalp PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
