### PR TITLE
server/sandbox: clean up network even if networkStart() fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,22 +79,8 @@ RUN set -x \
        && cp bin/* /opt/cni/bin/ \
        && rm -rf "$GOPATH"
 
-# Install custom CNI bridge test plugin
-# XXX: this plugin is meant to be a replacement for the old "test_plugin_args.bash"
-# we need this in testing because sandbox_run now gather IP address and the mock
-# plugin wasn't able to properly setup the net ns.
-# The bridge is based on the same commit as the one above.
-#ENV CNI_COMMIT 6bfe036c38c8e1410f1acaa4b2ee16f1851472e4
-ENV CNI_TEST_BRANCH custom-bridge
-RUN set -x \
-       && export GOPATH="$(mktemp -d)" \
-       && git clone https://github.com/runcom/plugins.git "$GOPATH/src/github.com/containernetworking/plugins" \
-       && cd "$GOPATH/src/github.com/containernetworking/plugins" \
-       && git checkout -q "$CNI_TEST_BRANCH" \
-       && ./build.sh \
-       && mkdir -p /opt/cni/bin \
-       && cp bin/bridge /opt/cni/bin/bridge-custom \
-       && rm -rf "$GOPATH"
+# Install CNI bridge plugin test wrapper
+COPY test/cni_plugin_helper.bash /opt/cni/bin/cni_plugin_helper.bash
 
 # Install crictl
 ENV CRICTL_COMMIT 7962f60f0e751b0fb2a3c3f3320a74ed15bfb50d

--- a/contrib/test/integration/build/plugins.yml
+++ b/contrib/test/integration/build/plugins.yml
@@ -30,21 +30,14 @@
     - tuning
     - vlan
 
-- name: clone runcom plugins source repo
-  git:
-    repo: "https://github.com/runcom/plugins.git"
-    dest: "{{ ansible_env.GOPATH }}/src/github.com/containernetworking/plugins"
-    version: "custom-bridge"
-    force: yes
-
 - name: build plugins
   command: "./build.sh"
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/containernetworking/plugins"
 
-- name: install custom bridge
+- name: install CNI plugin test helper
   copy:
-    src: "{{ ansible_env.GOPATH }}/src/github.com/containernetworking/plugins/bin/bridge"
-    dest: "/opt/cni/bin/bridge-custom"
+    src: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o/test/cni_plugin_helper.bash"
+    dest: "/opt/cni/bin/cni_plugin_helper.bash"
     mode: "o=rwx,g=rx,o=rx"
     remote_src: yes

--- a/server/sandbox_network.go
+++ b/server/sandbox_network.go
@@ -76,7 +76,7 @@ func (s *Server) GetSandboxIP(sb *sandbox.Sandbox) (string, error) {
 
 // networkStop cleans up and removes a pod's network.  It is best-effort and
 // must call the network plugin even if the network namespace is already gone
-func (s *Server) networkStop(sb *sandbox.Sandbox) error {
+func (s *Server) networkStop(sb *sandbox.Sandbox) {
 	if !sb.HostNetwork() {
 		if err := s.hostportManager.Remove(sb.ID(), &hostport.PodPortMapping{
 			Name:         sb.Name(),
@@ -93,6 +93,4 @@ func (s *Server) networkStop(sb *sandbox.Sandbox) error {
 				sb.Name(), sb.ID(), err)
 		}
 	}
-
-	return nil
 }

--- a/test/cni_plugin_helper.bash
+++ b/test/cni_plugin_helper.bash
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# This script wraps the CNI 'bridge' plugin to provide additional testing
+# capabilities
+
+if [[ -z "${CNI_ARGS}" ]]; then
+	exit 1
+fi
+
+IFS=';' read -ra array <<< "${CNI_ARGS}"
+for arg in "${array[@]}"; do
+	IFS='=' read -ra item <<< "${arg}"
+	if [[ "${item[0]}" = "K8S_POD_NAMESPACE" ]]; then
+		K8S_POD_NAMESPACE="${item[1]}"
+	elif [[ "${item[0]}" = "K8S_POD_NAME" ]]; then
+		K8S_POD_NAME="${item[1]}"
+	fi
+done
+
+if [[ -z "${CNI_CONTAINERID}" ]]; then
+	exit 1
+elif [[ -z "${K8S_POD_NAMESPACE}" ]]; then
+	exit 1
+elif [[ -z "${K8S_POD_NAME}" ]]; then
+	exit 1
+fi
+
+echo "FOUND_CNI_CONTAINERID=${CNI_CONTAINERID}" >> /tmp/plugin_test_args.out
+echo "FOUND_K8S_POD_NAMESPACE=${K8S_POD_NAMESPACE}" >> /tmp/plugin_test_args.out
+echo "FOUND_K8S_POD_NAME=${K8S_POD_NAME}" >> /tmp/plugin_test_args.out
+
+. /tmp/cni_plugin_helper_input.env
+rm -f /tmp/cni_plugin_helper_input.env
+
+result=$(/opt/cni/bin/bridge $@) || exit $?
+
+if [[ "${DEBUG_ARGS}" == "malformed-result" ]]; then
+	cat <<-EOF
+{
+   adsfasdfasdfasfdasdfsadfsafd
+}
+EOF
+
+else
+	echo $result
+fi

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -396,13 +396,6 @@ function prepare_network_conf() {
 }
 EOF
 
-	cat >$CRIO_CNI_CONFIG/99-loopback.conf <<-EOF
-{
-    "cniVersion": "0.2.0",
-    "type": "loopback"
-}
-EOF
-
 	echo 0
 }
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -399,13 +399,13 @@ EOF
 	echo 0
 }
 
-function prepare_plugin_test_args_network_conf() {
+function write_plugin_test_args_network_conf() {
 	mkdir -p $CRIO_CNI_CONFIG
 	cat >$CRIO_CNI_CONFIG/10-plugin-test-args.conf <<-EOF
 {
     "cniVersion": "0.2.0",
     "name": "crionet_test_args",
-    "type": "bridge-custom",
+    "type": "cni_plugin_helper.bash",
     "bridge": "cni0",
     "isGateway": true,
     "ipMasq": true,
@@ -419,7 +419,15 @@ function prepare_plugin_test_args_network_conf() {
 }
 EOF
 
+	if [[ -n "$2" ]]; then
+		echo "DEBUG_ARGS=$2" > /tmp/cni_plugin_helper_input.env
+	fi
+
 	echo 0
+}
+
+function prepare_plugin_test_args_network_conf() {
+	write_plugin_test_args_network_conf $1 ""
 }
 
 function check_pod_cidr() {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -430,6 +430,10 @@ function prepare_plugin_test_args_network_conf() {
 	write_plugin_test_args_network_conf $1 ""
 }
 
+function prepare_plugin_test_args_network_conf_malformed_result() {
+	write_plugin_test_args_network_conf $1 "malformed-result"
+}
+
 function check_pod_cidr() {
 	run crictl exec --sync $1 ip addr show dev eth0 scope global 2>&1
 	echo "$output"

--- a/test/network.bats
+++ b/test/network.bats
@@ -185,3 +185,17 @@ function teardown() {
 	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args | wc -l)
 	[[ "${num_allocated}" == "0" ]]
 }
+
+@test "Clean up network if pod sandbox fails after plugin success" {
+	start_crio "" "" "" "" "prepare_plugin_test_args_network_conf_malformed_result"
+
+	run crictl runp "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -ne 0 ]
+
+	# ensure that the server cleaned up sandbox networking if the sandbox
+	# failed during network setup after the CNI plugin itself succeeded
+	rm -f /var/lib/cni/networks/crionet_test_args/last_reserved_ip
+	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args | wc -l)
+	[[ "${num_allocated}" == "0" ]]
+}

--- a/test/network.bats
+++ b/test/network.bats
@@ -128,9 +128,6 @@ function teardown() {
 }
 
 @test "Ensure correct CNI plugin namespace/name/container-id arguments" {
-	if [[ ! -e "$CRIO_CNI_PLUGIN"/bridge-custom ]]; then
-		skip "bridge-custom plugin not available"
-	fi
 	start_crio "" "" "" "" "prepare_plugin_test_args_network_conf"
 	run crictl runp "$TESTDATA"/sandbox_config.json
 	[ "$status" -eq 0 ]
@@ -172,9 +169,6 @@ function teardown() {
 }
 
 @test "Clean up network if pod sandbox fails" {
-	if [[ ! -e "$CRIO_CNI_PLUGIN"/bridge-custom ]]; then
-		skip "bridge-custom plugin not available"
-	fi
 	start_crio "" "" "" "" "prepare_plugin_test_args_network_conf"
 
 	# make conmon non-executable to cause the sandbox setup to fail after


### PR DESCRIPTION
If the CNI network plugin completes successfully, but something fails
between that success and CRIO's sandbox setup code, plugin resources
may not be cleaned up.  A non-trivial amount of code runs after the
plugin itself exits and ocicni's SetUpPod() returns, and any error
condition recognized by that code would cause this leakage.

The Kubernetes CRI RunPodSandbox() request does not attempt to clean
up on errors, since it cannot know how much (if any) networking
was actually set up.  It depends on the CRI implementation to do
that cleanup for it.

Concrete examples include if the sandbox's container is somehow
removed during during that time, or another OS error is encountered,
or the plugin returns a malformed result to ocicni.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1532965

@runcom 