### PR TITLE
test: Skip image pull with signature

### DIFF
--- a/test/image.bats
+++ b/test/image.bats
@@ -136,6 +136,7 @@ function teardown() {
 }
 
 @test "image pull with signature" {
+	skip "registry has some issues"
 	start_crio "" "" --no-pause-image
 	run crictl pull "$SIGNED_IMAGE"
 	echo "$output"


### PR DESCRIPTION
The registry has some issues. We can re-enable this once the issues are fixed.
@runcom @rhatdan @mtrmac PTAL
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

