### PR TITLE
Move cri-o test images to quay.io

### DIFF
--- a/contrib/test/integration/build/cri-o.yml
+++ b/contrib/test/integration/build/cri-o.yml
@@ -61,14 +61,14 @@
     name: /etc/crio/crio.conf
     backup: yes
 
-- name: add docker.io default registry
+- name: add quay.io default registry
   lineinfile:
     dest: /etc/crio/crio.conf
     line: |
           # Added by Ansible from build/cri-o.yml
-          registries = [ "docker.io" ]
+          registries = [ "quay.io", "docker.io" ]
     insertafter: 'registries = \['
-    regexp: 'docker\.io'
+    regexp: 'quay\.io, docker\.io'
     state: present
 
 - name: add overlay storage opts on RHEL/CentOS

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -741,7 +741,7 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "hello0 stdout" ]]
 
-	stderrconfig=$(cat "$TESTDATA"/container_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["image"]["image"] = "runcom/stderr-test"; obj["command"] = ["/bin/sleep", "600"]; json.dump(obj, sys.stdout)')
+	stderrconfig=$(cat "$TESTDATA"/container_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["image"]["image"] = "quay.io/crio/stderr-test"; obj["command"] = ["/bin/sleep", "600"]; json.dump(obj, sys.stdout)')
 	echo "$stderrconfig" > "$TESTDIR"/container_config_stderr.json
 	run crictl create "$pod_id" "$TESTDIR"/container_config_stderr.json "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -836,7 +836,7 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	pod_id="$output"
-	oomconfig=$(cat "$TESTDATA"/container_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["image"]["image"] = "mrunalp/oom"; obj["linux"]["resources"]["memory_limit_in_bytes"] = 5120000; obj["command"] = ["/oom"]; json.dump(obj, sys.stdout)')
+	oomconfig=$(cat "$TESTDATA"/container_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["image"]["image"] = "quay.io/crio/oom"; obj["linux"]["resources"]["memory_limit_in_bytes"] = 5120000; obj["command"] = ["/oom"]; json.dump(obj, sys.stdout)')
 	echo "$oomconfig" > "$TESTDIR"/container_config_oom.json
 	run crictl create "$pod_id" "$TESTDIR"/container_config_oom.json "$TESTDATA"/sandbox_config.json
 	echo "$output"

--- a/test/default_mounts.bats
+++ b/test/default_mounts.bats
@@ -2,7 +2,7 @@
 
 load helpers
 
-IMAGE="redis:alpine"
+IMAGE="quay.io/crio/redis:alpine"
 
 function teardown() {
 	cleanup_test

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -104,8 +104,8 @@ PATH=$PATH:$TESTDIR
 # Make sure we have a copy of the redis:alpine image.
 if ! [ -d "$ARTIFACTS_PATH"/redis-image ]; then
     mkdir -p "$ARTIFACTS_PATH"/redis-image
-    if ! "$COPYIMG_BINARY" --import-from=docker://redis:alpine --export-to=dir:"$ARTIFACTS_PATH"/redis-image --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
-        echo "Error pulling docker://redis"
+    if ! "$COPYIMG_BINARY" --import-from=docker://quay.io/crio/redis:alpine --export-to=dir:"$ARTIFACTS_PATH"/redis-image --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
+        echo "Error pulling quay.io/crio/redis"
         rm -fr "$ARTIFACTS_PATH"/redis-image
         exit 1
     fi
@@ -114,8 +114,8 @@ fi
 # Make sure we have a copy of the runcom/stderr-test image.
 if ! [ -d "$ARTIFACTS_PATH"/stderr-test ]; then
     mkdir -p "$ARTIFACTS_PATH"/stderr-test
-    if ! "$COPYIMG_BINARY" --import-from=docker://runcom/stderr-test:latest --export-to=dir:"$ARTIFACTS_PATH"/stderr-test --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
-        echo "Error pulling docker://stderr-test"
+    if ! "$COPYIMG_BINARY" --import-from=docker://quay.io/crio/stderr-test:latest --export-to=dir:"$ARTIFACTS_PATH"/stderr-test --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
+        echo "Error pulling quay.io/crio/stderr-test"
         rm -fr "$ARTIFACTS_PATH"/stderr-test
         exit 1
     fi
@@ -124,8 +124,8 @@ fi
 # Make sure we have a copy of the busybox:latest image.
 if ! [ -d "$ARTIFACTS_PATH"/busybox-image ]; then
     mkdir -p "$ARTIFACTS_PATH"/busybox-image
-    if ! "$COPYIMG_BINARY" --import-from=docker://busybox --export-to=dir:"$ARTIFACTS_PATH"/busybox-image --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
-        echo "Error pulling docker://busybox"
+    if ! "$COPYIMG_BINARY" --import-from=docker://quay.io/crio/busybox:latest --export-to=dir:"$ARTIFACTS_PATH"/busybox-image --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
+        echo "Error pulling quay.io/crio/busybox"
         rm -fr "$ARTIFACTS_PATH"/busybox-image
         exit 1
     fi
@@ -134,8 +134,8 @@ fi
 # Make sure we have a copy of the mrunalp/oom:latest image.
 if ! [ -d "$ARTIFACTS_PATH"/oom-image ]; then
     mkdir -p "$ARTIFACTS_PATH"/oom-image
-    if ! "$COPYIMG_BINARY" --import-from=docker://mrunalp/oom --export-to=dir:"$ARTIFACTS_PATH"/oom-image --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
-        echo "Error pulling docker://mrunalp/oom"
+    if ! "$COPYIMG_BINARY" --import-from=docker://quay.io/crio/oom:latest --export-to=dir:"$ARTIFACTS_PATH"/oom-image --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
+        echo "Error pulling quay.io/crio/oom"
         rm -fr "$ARTIFACTS_PATH"/oom-image
         exit 1
     fi
@@ -144,8 +144,8 @@ fi
 # Make sure we have a copy of the mrunalp/image-volume-test:latest image.
 if ! [ -d "$ARTIFACTS_PATH"/image-volume-test-image ]; then
     mkdir -p "$ARTIFACTS_PATH"/image-volume-test-image
-    if ! "$COPYIMG_BINARY" --import-from=docker://mrunalp/image-volume-test --export-to=dir:"$ARTIFACTS_PATH"/image-volume-test-image --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
-        echo "Error pulling docker://mrunalp/image-volume-test-image"
+    if ! "$COPYIMG_BINARY" --import-from=docker://quay.io/crio/image-volume-test:latest --export-to=dir:"$ARTIFACTS_PATH"/image-volume-test-image --signature-policy="$INTEGRATION_ROOT"/policy.json ; then
+        echo "Error pulling quay.io/crio/image-volume-test-image"
         rm -fr "$ARTIFACTS_PATH"/image-volume-test-image
         exit 1
     fi
@@ -210,12 +210,12 @@ function start_crio() {
 	if ! [ "$3" = "--no-pause-image" ] ; then
 		"$BIN2IMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --source-binary "$PAUSE_BINARY"
 	fi
-	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=docker.io/library/redis:alpine --import-from=dir:"$ARTIFACTS_PATH"/redis-image --signature-policy="$INTEGRATION_ROOT"/policy.json
-	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=docker.io/mrunalp/oom:latest --import-from=dir:"$ARTIFACTS_PATH"/oom-image --signature-policy="$INTEGRATION_ROOT"/policy.json
-	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=docker.io/mrunalp/image-volume-test:latest --import-from=dir:"$ARTIFACTS_PATH"/image-volume-test-image --signature-policy="$INTEGRATION_ROOT"/policy.json
-	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=docker.io/library/busybox:latest --import-from=dir:"$ARTIFACTS_PATH"/busybox-image --signature-policy="$INTEGRATION_ROOT"/policy.json
-	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=docker.io/runcom/stderr-test:latest --import-from=dir:"$ARTIFACTS_PATH"/stderr-test --signature-policy="$INTEGRATION_ROOT"/policy.json
-	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --cgroup-manager "$CGROUP_MANAGER" --registry "docker.io" --runtime "$RUNTIME_BINARY" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --log-size-max "$LOG_SIZE_MAX_LIMIT" --config /dev/null config >$CRIO_CONFIG
+	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/redis:alpine --import-from=dir:"$ARTIFACTS_PATH"/redis-image --signature-policy="$INTEGRATION_ROOT"/policy.json
+	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/oom:latest --import-from=dir:"$ARTIFACTS_PATH"/oom-image --signature-policy="$INTEGRATION_ROOT"/policy.json
+	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/image-volume-test:latest --import-from=dir:"$ARTIFACTS_PATH"/image-volume-test-image --signature-policy="$INTEGRATION_ROOT"/policy.json
+	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/busybox:latest --import-from=dir:"$ARTIFACTS_PATH"/busybox-image --signature-policy="$INTEGRATION_ROOT"/policy.json
+	"$COPYIMG_BINARY" --root "$TESTDIR/crio" $STORAGE_OPTIONS --runroot "$TESTDIR/crio-run" --image-name=quay.io/crio/stderr-test:latest --import-from=dir:"$ARTIFACTS_PATH"/stderr-test --signature-policy="$INTEGRATION_ROOT"/policy.json
+	"$CRIO_BINARY" ${DEFAULT_MOUNTS_OPTS} ${HOOKS_OPTS} --conmon "$CONMON_BINARY" --listen "$CRIO_SOCKET" --cgroup-manager "$CGROUP_MANAGER" --registry "quay.io" --runtime "$RUNTIME_BINARY" --root "$TESTDIR/crio" --runroot "$TESTDIR/crio-run" $STORAGE_OPTIONS --seccomp-profile "$seccomp" --apparmor-profile "$apparmor" --cni-config-dir "$CRIO_CNI_CONFIG" --cni-plugin-dir "$CRIO_CNI_PLUGIN" --signature-policy "$INTEGRATION_ROOT"/policy.json --image-volumes "$IMAGE_VOLUMES" --pids-limit "$PIDS_LIMIT" --log-size-max "$LOG_SIZE_MAX_LIMIT" --config /dev/null config >$CRIO_CONFIG
 	sed -r -e 's/^(#)?root =/root =/g' -e 's/^(#)?runroot =/runroot =/g' -e 's/^(#)?storage_driver =/storage_driver =/g' -e '/^(#)?storage_option = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -e '/^(#)?registries = (\[)?[ \t]*$/,/^#?$/s/^(#)?//g' -i $CRIO_CONFIG
 	# Prepare the CNI configuration files, we're running with non host networking by default
 	if [[ -n "$4" ]]; then
@@ -228,32 +228,32 @@ function start_crio() {
 	"$CRIO_BINARY" --log-level debug --config "$CRIO_CONFIG" & CRIO_PID=$!
 	wait_until_reachable
 
-	run crictl inspecti redis:alpine
+	run crictl inspecti quay.io/crio/redis:alpine
 	if [ "$status" -ne 0 ] ; then
-		crictl pull redis:alpine
+		crictl pull quay.io/crio/redis:alpine
 	fi
-	REDIS_IMAGEID=$(crictl inspecti redis:alpine --output table | grep ^ID: | head -n 1 | sed -e "s/ID: //g")
-	REDIS_IMAGEREF=$(crictl inspecti redis:alpine --output table | grep ^Digest: | head -n 1 | sed -e "s/Digest: //g")
-	run crictl inspecti mrunalp/oom
+	REDIS_IMAGEID=$(crictl inspecti quay.io/crio/redis:alpine --output table | grep ^ID: | head -n 1 | sed -e "s/ID: //g")
+	REDIS_IMAGEREF=$(crictl inspecti quay.io/crio/redis:alpine --output table | grep ^Digest: | head -n 1 | sed -e "s/Digest: //g")
+	run crictl inspecti quay.io/crio/oom
 	if [ "$status" -ne 0 ] ; then
-		  crictl pull mrunalp/oom
+		  crictl pull quay.io/crio/oom
 	fi
-	OOM_IMAGEID=$(crictl inspecti mrunalp/oom | grep ^ID: | head -n 1 | sed -e "s/ID: //g")
-	run crioctl image status --id=runcom/stderr-test
+	OOM_IMAGEID=$(crictl inspecti quay.io/crio/oom | grep ^ID: | head -n 1 | sed -e "s/ID: //g")
+	run crictl inspecti quay.io/crio/stderr-test
 	if [ "$status" -ne 0 ] ; then
-		crictl pull runcom/stderr-test:latest
+		crictl pull quay.io/crio/stderr-test:latest
 	fi
-	STDERR_IMAGEID=$(crictl inspecti runcom/stderr-test | grep ^ID: | head -n 1 | sed -e "s/ID: //g")
-	run crictl inspecti busybox
+	STDERR_IMAGEID=$(crictl inspecti quay.io/crio/stderr-test | grep ^ID: | head -n 1 | sed -e "s/ID: //g")
+	run crictl inspecti quay.io/crio/busybox
 	if [ "$status" -ne 0 ] ; then
-		crictl pull busybox:latest
+		crictl pull quay.io/crio/busybox:latest
 	fi
-	BUSYBOX_IMAGEID=$(crictl inspecti busybox | grep ^ID: | head -n 1 | sed -e "s/ID: //g")
-	run crictl inspecti mrunalp/image-volume-test
+	BUSYBOX_IMAGEID=$(crictl inspecti quay.io/crio/busybox | grep ^ID: | head -n 1 | sed -e "s/ID: //g")
+	run crictl inspecti quay.io/crio/image-volume-test
 	if [ "$status" -ne 0 ] ; then
-		  crictl pull mrunalp/image-volume-test:latest
+		  crictl pull quay.io/crio/image-volume-test:latest
 	fi
-	VOLUME_IMAGEID=$(crictl inspecti mrunalp/image-volume-test | grep ^ID: | head -n 1 | sed -e "s/ID: //g")
+	VOLUME_IMAGEID=$(crictl inspecti quay.io/crio/image-volume-test | grep ^ID: | head -n 1 | sed -e "s/ID: //g")
 }
 
 function cleanup_ctrs() {

--- a/test/image.bats
+++ b/test/image.bats
@@ -2,9 +2,9 @@
 
 load helpers
 
-IMAGE=kubernetes/pause
+IMAGE=quay.io/crio/pause
 SIGNED_IMAGE=registry.access.redhat.com/rhel7-atomic:latest
-UNSIGNED_IMAGE=docker.io/library/hello-world:latest
+UNSIGNED_IMAGE=quay.io/crio/hello-world:latest
 
 function teardown() {
 	cleanup_test
@@ -47,7 +47,7 @@ function teardown() {
 	run crictl inspect "$ctr_id" --output yaml
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "image: docker.io/library/redis:alpine" ]]
+	[[ "$output" =~ "image: quay.io/crio/redis:alpine" ]]
 	[[ "$output" =~ "imageRef: $REDIS_IMAGEREF" ]]
 
 	cleanup_ctrs
@@ -63,7 +63,7 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	pod_id="$output"
 
-	sed -e "s/%VALUE%/redis:alpine/g" "$TESTDATA"/container_config_by_imageid.json > "$TESTDIR"/ctr_by_imagetag.json
+	sed -e "s/%VALUE%/quay.io\/crio\/redis:alpine/g" "$TESTDATA"/container_config_by_imageid.json > "$TESTDIR"/ctr_by_imagetag.json
 
 	run crictl create "$pod_id" "$TESTDIR"/ctr_by_imagetag.json "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -73,7 +73,7 @@ function teardown() {
 	run crictl inspect "$ctr_id" --output yaml
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "image: docker.io/library/redis:alpine" ]]
+	[[ "$output" =~ "image: quay.io/crio/redis:alpine" ]]
 	[[ "$output" =~ "imageRef: $REDIS_IMAGEREF" ]]
 
 	cleanup_ctrs
@@ -103,7 +103,7 @@ function teardown() {
 	run crictl inspect "$ctr_id" --output yaml
 	echo "$output"
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "image: docker.io/library/redis:alpine" ]]
+	[[ "$output" =~ "image: quay.io/crio/redis:alpine" ]]
 	[[ "$output" =~ "imageRef: $REDIS_IMAGEREF" ]]
 
 	cleanup_ctrs
@@ -182,11 +182,11 @@ function teardown() {
 
 @test "image pull and list by digest and ID" {
 	start_crio "" "" --no-pause-image
-	run crictl pull nginx@sha256:33eb1ed1e802d4f71e52421f56af028cdf12bb3bfff5affeaf5bf0e328ffa1bc
+	run crictl pull quay.io/crio/nginx@sha256:1ad874092a55efe2be0507a01d8a300e286f8137510854606ab1dd28861507a3
 	echo "$output"
 	[ "$status" -eq 0 ]
 
-	run crictl images --quiet nginx@sha256:33eb1ed1e802d4f71e52421f56af028cdf12bb3bfff5affeaf5bf0e328ffa1bc
+	run crictl images --quiet quay.io/crio/nginx@sha256:1ad874092a55efe2be0507a01d8a300e286f8137510854606ab1dd28861507a3
 	[ "$status" -eq 0 ]
 	echo "$output"
 	[ "$output" != "" ]

--- a/test/image_remove.bats
+++ b/test/image_remove.bats
@@ -2,7 +2,7 @@
 
 load helpers
 
-IMAGE=docker.io/kubernetes/pause
+IMAGE=quay.io/crio/pause
 
 function teardown() {
 	cleanup_test

--- a/test/image_volume.bats
+++ b/test/image_volume.bats
@@ -12,7 +12,7 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	pod_id="$output"
-	image_volume_config=$(cat "$TESTDATA"/container_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["image"]["image"] = "mrunalp/image-volume-test"; obj["command"] = ["/bin/sleep", "600"]; json.dump(obj, sys.stdout)')
+	image_volume_config=$(cat "$TESTDATA"/container_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["image"]["image"] = "quay.io/crio/image-volume-test"; obj["command"] = ["/bin/sleep", "600"]; json.dump(obj, sys.stdout)')
 	echo "$image_volume_config" > "$TESTDIR"/container_image_volume.json
 	run crictl create "$pod_id" "$TESTDIR"/container_image_volume.json "$TESTDATA"/sandbox_config.json
 	echo "$output"
@@ -43,7 +43,7 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	pod_id="$output"
-	image_volume_config=$(cat "$TESTDATA"/container_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["image"]["image"] = "mrunalp/image-volume-test"; obj["command"] = ["/bin/sleep", "600"]; json.dump(obj, sys.stdout)')
+	image_volume_config=$(cat "$TESTDATA"/container_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["image"]["image"] = "quay.io/crio/image-volume-test"; obj["command"] = ["/bin/sleep", "600"]; json.dump(obj, sys.stdout)')
 	echo "$image_volume_config" > "$TESTDIR"/container_image_volume.json
 	run crictl create "$pod_id" "$TESTDIR"/container_image_volume.json "$TESTDATA"/sandbox_config.json
 	echo "$output"

--- a/test/inspect.bats
+++ b/test/inspect.bats
@@ -30,14 +30,14 @@ function teardown() {
 	out=`echo -e "GET /containers/$ctr_id HTTP/1.1\r\nHost: crio\r\n" | socat - UNIX-CONNECT:$CRIO_SOCKET`
 	echo "$out"
 	[[ "$out" =~ "\"sandbox\":\"$pod_id\"" ]]
-	[[ "$out" =~ "\"image\":\"docker.io/library/redis:alpine\"" ]]
+	[[ "$out" =~ "\"image\":\"quay.io/crio/redis:alpine\"" ]]
 	[[ "$out" =~ "\"image_ref\":\"$REDIS_IMAGEREF\"" ]]
 
 	run crictl inspect --output json "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "\"id\": \"$ctr_id\"" ]]
-	[[ "$output" =~ "\"image\": \"docker.io/library/redis:alpine\"" ]]
+	[[ "$output" =~ "\"image\": \"quay.io/crio/redis:alpine\"" ]]
 	[[ "$output" =~ "\"imageRef\": \"$REDIS_IMAGEREF\"" ]]
 
 	run crictl inspectp --output json "$pod_id"

--- a/test/policy.json
+++ b/test/policy.json
@@ -6,7 +6,7 @@
     ],
     "transports": {
         "docker": {
-            "docker.io/library/hello-world": [
+            "quay.io/crio/hello-world": [
                 {
                     "type": "reject"
                 }

--- a/test/registries.conf
+++ b/test/registries.conf
@@ -1,5 +1,5 @@
 [registries.search]
-registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'docker.io']
+registries = ['quay.io' ,'registry.access.redhat.com', 'registry.fedoraproject.org']
 
 [registries.insecure]
 registries = []

--- a/test/testdata/container_config.json
+++ b/test/testdata/container_config.json
@@ -4,7 +4,7 @@
 		"attempt": 1
 	},
 	"image": {
-		"image": "redis:alpine"
+		"image": "quay.io/crio/redis:alpine"
 	},
 	"command": [
 		"/bin/ls"

--- a/test/testdata/container_config_hostport.json
+++ b/test/testdata/container_config_hostport.json
@@ -4,7 +4,7 @@
 		"attempt": 1
 	},
 	"image": {
-		"image": "busybox:latest"
+		"image": "quay.io/crio/busybox:latest"
 	},
 	"command": [
 		"/bin/nc", "-ll", "-p", "80", "-e"

--- a/test/testdata/container_config_logging.json
+++ b/test/testdata/container_config_logging.json
@@ -4,7 +4,7 @@
 		"attempt": 1
 	},
 	"image": {
-		"image": "busybox:latest"
+		"image": "quay.io/crio/busybox:latest"
 	},
 	"command": [
 		"/bin/sh", "-c"

--- a/test/testdata/container_config_resolvconf.json
+++ b/test/testdata/container_config_resolvconf.json
@@ -4,7 +4,7 @@
 		"attempt": 1
 	},
 	"image": {
-		"image": "redis:alpine"
+		"image": "quay.io/crio/redis:alpine"
 	},
 	"command": [
 		"sh",

--- a/test/testdata/container_config_resolvconf_ro.json
+++ b/test/testdata/container_config_resolvconf_ro.json
@@ -4,7 +4,7 @@
 		"attempt": 1
 	},
 	"image": {
-		"image": "redis:alpine"
+		"image": "quay.io/crio/redis:alpine"
 	},
 	"command": [
 		"sh",

--- a/test/testdata/container_config_seccomp.json
+++ b/test/testdata/container_config_seccomp.json
@@ -4,7 +4,7 @@
 		"attempt": 1
 	},
 	"image": {
-		"image": "redis:alpine"
+		"image": "quay.io/crio/redis:alpine"
 	},
 	"args": [
                 "docker-entrypoint.sh",

--- a/test/testdata/container_config_sleep.json
+++ b/test/testdata/container_config_sleep.json
@@ -4,7 +4,7 @@
 		"attempt": 1
 	},
 	"image": {
-		"image": "docker.io/library/busybox:latest"
+		"image": "quay.io/crio/busybox:latest"
 	},
 	"command": [
 		"sleep",

--- a/test/testdata/container_exit_test.json
+++ b/test/testdata/container_exit_test.json
@@ -3,7 +3,7 @@
 		"name": "podsandbox1-exit-test"
 	},
 	"image": {
-		"image": "docker://mrunalp/exit_test:latest"
+		"image": "quay.io/crio/exit_test:latest"
 	},
 	"args": [
                 "/exit_test"

--- a/test/testdata/container_redis.json
+++ b/test/testdata/container_redis.json
@@ -3,7 +3,7 @@
 		"name": "podsandbox1-redis"
 	},
 	"image": {
-		"image": "redis:alpine"
+		"image": "quay.io/crio/redis:alpine"
 	},
 	"args": [
                 "docker-entrypoint.sh",

--- a/test/testdata/container_redis_default_mounts.json
+++ b/test/testdata/container_redis_default_mounts.json
@@ -3,7 +3,7 @@
 		"name": "podsandbox1-redis"
 	},
 	"image": {
-		"image": "redis:alpine"
+		"image": "quay.io/crio/redis:alpine"
 	},
 	"args": [
                 "docker-entrypoint.sh",

--- a/test/testdata/container_redis_device.json
+++ b/test/testdata/container_redis_device.json
@@ -3,7 +3,7 @@
 		"name": "podsandbox1-redis"
 	},
 	"image": {
-		"image": "redis:alpine"
+		"image": "quay.io/crio/redis:alpine"
 	},
 	"args": [
                 "docker-entrypoint.sh",

--- a/test/testdata/container_redis_env_custom.json
+++ b/test/testdata/container_redis_env_custom.json
@@ -3,7 +3,7 @@
 		"name": "podsandbox1-redis"
 	},
 	"image": {
-		"image": "redis:alpine"
+		"image": "quay.io/crio/redis:alpine"
 	},
 	"args": [
                 "docker-entrypoint.sh",


### PR DESCRIPTION
Created a crio organization account on quay.io and all images
used in the tests live under quay.io/crio now.

Signed-off-by: umohnani8 <umohnani@redhat.com>
