### PR TITLE
Add FIPS mode secret and vendor in libpod/pkg/secret

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -114,8 +114,23 @@ cgroup_manager = "{{ .CgroupManager }}"
 hooks_dir_path = "{{ .HooksDirPath }}"
 
 # default_mounts is the mounts list to be mounted for the container when created
+# deprecated, will be taken out in future versions, add default mounts to either
+# /usr/share/containers/mounts.conf or /etc/containers/mounts.conf
 default_mounts = [
 {{ range $mount := .DefaultMounts }}{{ printf "\t%q, \n" $mount }}{{ end }}]
+
+# CRI-O reads its default mounts from the following two files:
+# 1) /etc/containers/mounts.conf - this is the override file, where users can
+# either add in their own default mounts, or override the default mounts shipped
+# with the package.
+# 2) /usr/share/containers/mounts.conf - this is the default file read for mounts.
+# If you want CRI-O to read from a different, specific mounts file, you can change
+# the default_mounts_file path right below. Note, if this is done, CRI-O will only add
+# mounts it finds in this file.
+
+# default_mounts_file is the file path holding the default mounts to be mounted for the
+# container when created.
+# default_mounts_file = "{{ .DefaultMountsFile }}"
 
 # pids_limit is the number of processes allowed in a container
 pids_limit = {{ .PidsLimit }}

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -128,6 +128,9 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("default-mounts") {
 		config.DefaultMounts = ctx.GlobalStringSlice("default-mounts")
 	}
+	if ctx.GlobalIsSet("default-mounts-file") {
+		config.DefaultMountsFile = ctx.GlobalString("default-mounts-file")
+	}
 	if ctx.GlobalIsSet("pids-limit") {
 		config.PidsLimit = ctx.GlobalInt64("pids-limit")
 	}
@@ -328,8 +331,12 @@ func main() {
 			Hidden: true,
 		},
 		cli.StringSliceFlag{
-			Name:   "default-mounts",
-			Usage:  "add one or more default mount paths in the form host:container",
+			Name:  "default-mounts",
+			Usage: "add one or more default mount paths in the form host:container (deprecated)",
+		},
+		cli.StringFlag{
+			Name:   "default-mounts-file",
+			Usage:  "path to default mounts file",
 			Hidden: true,
 		},
 		cli.BoolFlag{

--- a/contrib/test/integration/build/cri-o.yml
+++ b/contrib/test/integration/build/cri-o.yml
@@ -61,7 +61,7 @@
     name: /etc/crio/crio.conf
     backup: yes
 
-- name: add quay.io default registry
+- name: add quay.io and docker.io as default registries
   lineinfile:
     dest: /etc/crio/crio.conf
     line: |

--- a/lib/config.go
+++ b/lib/config.go
@@ -149,6 +149,10 @@ type RuntimeConfig struct {
 	// The format of each mount is "host-path:container-path"
 	DefaultMounts []string `toml:"default_mounts"`
 
+	// DefaultMountsFile is the file path for the default mounts to be mounted for the container
+	// Note, for testing purposes mainly
+	DefaultMountsFile string `toml:"default_mounts_file"`
+
 	// Hooks List of hooks to run with container
 	Hooks map[string]HookParams
 
@@ -309,6 +313,7 @@ func DefaultConfig() *Config {
 			ContainerExitsDir: containerExitsDir,
 			HooksDirPath:      DefaultHooksDirPath,
 			LogSizeMax:        DefaultLogSizeMax,
+			DefaultMountsFile: "",
 		},
 		ImageConfig: ImageConfig{
 			DefaultTransport:    defaultTransport,

--- a/vendor.conf
+++ b/vendor.conf
@@ -121,3 +121,4 @@ github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
 github.com/cyphar/filepath-securejoin v0.2.1
 gopkg.in/square/go-jose.v2 v2.1.3
 golang.org/x/time f51c12702a4d776e4c1fa9b0fabab841babae631
+github.com/projectatomic/libpod master

--- a/vendor/github.com/projectatomic/libpod/pkg/secrets/secrets.go
+++ b/vendor/github.com/projectatomic/libpod/pkg/secrets/secrets.go
@@ -1,0 +1,281 @@
+package secrets
+
+import (
+	"bufio"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	// DefaultMountsFile holds the default mount paths in the form
+	// "host_path:container_path"
+	DefaultMountsFile = "/usr/share/containers/mounts.conf"
+	// OverrideMountsFile holds the default mount paths in the form
+	// "host_path:container_path" overridden by the user
+	OverrideMountsFile = "/etc/containers/mounts.conf"
+)
+
+// secretData stores the name of the file and the content read from it
+type secretData struct {
+	name string
+	data []byte
+}
+
+// saveTo saves secret data to given directory
+func (s secretData) saveTo(dir string) error {
+	path := filepath.Join(dir, s.name)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil && !os.IsExist(err) {
+		return err
+	}
+	return ioutil.WriteFile(path, s.data, 0700)
+}
+
+func readAll(root, prefix string) ([]secretData, error) {
+	path := filepath.Join(root, prefix)
+
+	data := []secretData{}
+
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return data, nil
+		}
+
+		return nil, err
+	}
+
+	for _, f := range files {
+		fileData, err := readFile(root, filepath.Join(prefix, f.Name()))
+		if err != nil {
+			// If the file did not exist, might be a dangling symlink
+			// Ignore the error
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		data = append(data, fileData...)
+	}
+
+	return data, nil
+}
+
+func readFile(root, name string) ([]secretData, error) {
+	path := filepath.Join(root, name)
+
+	s, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if s.IsDir() {
+		dirData, err := readAll(root, name)
+		if err != nil {
+			return nil, err
+		}
+		return dirData, nil
+	}
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return []secretData{{name: name, data: bytes}}, nil
+}
+
+func getHostSecretData(hostDir string) ([]secretData, error) {
+	var allSecrets []secretData
+	hostSecrets, err := readAll(hostDir, "")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read secrets from %q", hostDir)
+	}
+	return append(allSecrets, hostSecrets...), nil
+}
+
+func getMounts(filePath string) []string {
+	file, err := os.Open(filePath)
+	if err != nil {
+		logrus.Warnf("file %q not found, skipping...", filePath)
+		return nil
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	if err = scanner.Err(); err != nil {
+		logrus.Warnf("error reading file %q, skipping...", filePath)
+		return nil
+	}
+	var mounts []string
+	for scanner.Scan() {
+		mounts = append(mounts, scanner.Text())
+	}
+	return mounts
+}
+
+// getHostAndCtrDir separates the host:container paths
+func getMountsMap(path string) (string, string, error) {
+	arr := strings.SplitN(path, ":", 2)
+	if len(arr) == 2 {
+		return arr[0], arr[1], nil
+	}
+	return "", "", errors.Errorf("unable to get host and container dir")
+}
+
+// SecretMounts copies, adds, and mounts the secrets to the container root filesystem
+func SecretMounts(mountLabel, containerWorkingDir string, mountFile string) []rspec.Mount {
+	var (
+		secretMounts []rspec.Mount
+		mountFiles   []string
+	)
+	// Add secrets from paths given in the mounts.conf files
+	// mountFile will have a value if the hidden --default-mounts-file flag is set
+	// Note for testing purposes only
+	if mountFile == "" {
+		mountFiles = append(mountFiles, []string{OverrideMountsFile, DefaultMountsFile}...)
+	} else {
+		mountFiles = append(mountFiles, mountFile)
+	}
+	for _, file := range mountFiles {
+		mounts, err := addSecretsFromMountsFile(file, mountLabel, containerWorkingDir)
+		if err != nil {
+			logrus.Warnf("error mounting secrets, skipping: %v", err)
+		}
+		secretMounts = append(secretMounts, mounts...)
+	}
+
+	// Add FIPS mode secret if /etc/system-fips exists on the host
+	_, err := os.Stat("/etc/system-fips")
+	if err == nil {
+		if err := addFIPSsModeSecret(&secretMounts, containerWorkingDir); err != nil {
+			logrus.Warnf("error adding FIPS mode secret to container: %v", err)
+		}
+	} else if os.IsNotExist(err) {
+		logrus.Debug("/etc/system-fips does not exist on host, not mounting FIPS mode secret")
+	} else {
+		logrus.Errorf("error stating /etc/system-fips for FIPS mode secret: %v", err)
+	}
+	return secretMounts
+}
+
+// addSecretsFromMountsFile copies the contents of host directory to container directory
+// and returns a list of mounts
+func addSecretsFromMountsFile(filePath, mountLabel, containerWorkingDir string) ([]rspec.Mount, error) {
+	var mounts []rspec.Mount
+	defaultMountsPaths := getMounts(filePath)
+	for _, path := range defaultMountsPaths {
+		hostDir, ctrDir, err := getMountsMap(path)
+		if err != nil {
+			return nil, err
+		}
+		// skip if the hostDir path doesn't exist
+		if _, err = os.Stat(hostDir); os.IsNotExist(err) {
+			logrus.Warnf("%q doesn't exist, skipping", hostDir)
+			continue
+		}
+
+		ctrDirOnHost := filepath.Join(containerWorkingDir, ctrDir)
+
+		// In the event of a restart, don't want to copy secrets over again as they already would exist in ctrDirOnHost
+		_, err = os.Stat(ctrDirOnHost)
+		if os.IsNotExist(err) {
+			if err = os.MkdirAll(ctrDirOnHost, 0755); err != nil {
+				return nil, errors.Wrapf(err, "making container directory failed")
+			}
+
+			hostDir, err = resolveSymbolicLink(hostDir)
+			if err != nil {
+				return nil, err
+			}
+
+			data, err := getHostSecretData(hostDir)
+			if err != nil {
+				return nil, errors.Wrapf(err, "getting host secret data failed")
+			}
+			for _, s := range data {
+				if err := s.saveTo(ctrDirOnHost); err != nil {
+					return nil, errors.Wrapf(err, "error saving data to container filesystem on host %q", ctrDirOnHost)
+				}
+			}
+
+			err = label.Relabel(ctrDirOnHost, mountLabel, false)
+			if err != nil {
+				return nil, errors.Wrap(err, "error applying correct labels")
+			}
+		} else if err != nil {
+			return nil, errors.Wrapf(err, "error getting status of %q", ctrDirOnHost)
+		}
+
+		m := rspec.Mount{
+			Source:      ctrDirOnHost,
+			Destination: ctrDir,
+			Type:        "bind",
+			Options:     []string{"bind"},
+		}
+
+		mounts = append(mounts, m)
+	}
+	return mounts, nil
+}
+
+// addFIPSModeSecret creates /run/secrets/system-fips in the container
+// root filesystem if /etc/system-fips exists on hosts.
+// This enables the container to be FIPS compliant and run openssl in
+// FIPS mode as the host is also in FIPS mode.
+func addFIPSsModeSecret(mounts *[]rspec.Mount, containerWorkingDir string) error {
+	secretsDir := "/run/secrets"
+	ctrDirOnHost := filepath.Join(containerWorkingDir, secretsDir)
+	if _, err := os.Stat(ctrDirOnHost); os.IsNotExist(err) {
+		if err = os.MkdirAll(ctrDirOnHost, 0755); err != nil {
+			return errors.Wrapf(err, "making container directory on host failed")
+		}
+	}
+	fipsFile := filepath.Join(ctrDirOnHost, "system-fips")
+	// In the event of restart, it is possible for the FIPS mode file to already exist
+	if _, err := os.Stat(fipsFile); os.IsNotExist(err) {
+		file, err := os.Create(fipsFile)
+		if err != nil {
+			return errors.Wrapf(err, "error creating system-fips file in container for FIPS mode")
+		}
+		defer file.Close()
+	}
+
+	if !mountExists(*mounts, secretsDir) {
+		m := rspec.Mount{
+			Source:      ctrDirOnHost,
+			Destination: secretsDir,
+			Type:        "bind",
+			Options:     []string{"bind"},
+		}
+		*mounts = append(*mounts, m)
+	}
+
+	return nil
+}
+
+// mountExists checks if a mount already exists in the spec
+func mountExists(mounts []rspec.Mount, dest string) bool {
+	for _, mount := range mounts {
+		if mount.Destination == dest {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveSymbolicLink resolves a possbile symlink path. If the path is a symlink, returns resolved
+// path; if not, returns the original path.
+func resolveSymbolicLink(path string) (string, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != os.ModeSymlink {
+		return path, nil
+	}
+	return filepath.EvalSymlinks(path)
+}

--- a/vendor/github.com/projectatomic/libpod/pkg/secrets/secrets_test.go
+++ b/vendor/github.com/projectatomic/libpod/pkg/secrets/secrets_test.go
@@ -1,4 +1,4 @@
-package server
+package secrets
 
 import (
 	"testing"
@@ -32,15 +32,15 @@ func TestGetMountsMap(t *testing.T) {
 func TestGetHostSecretData(t *testing.T) {
 	testCases := []struct {
 		Path string
-		Want []SecretData
+		Want []secretData
 	}{
 		{
 			"emptyPath",
-			[]SecretData{},
+			[]secretData{},
 		},
 		{
 			secretDataPath,
-			[]SecretData{
+			[]secretData{
 				{"testDataA", []byte("secretDataA")},
 				{"testDataB", []byte("secretDataB")},
 			},
@@ -51,9 +51,9 @@ func TestGetHostSecretData(t *testing.T) {
 			t.Error(err)
 		} else {
 			for index, data := range secretData {
-				if data.Name != c.Want[index].Name || string(data.Data) != string(c.Want[index].Data) {
+				if data.name != c.Want[index].name || string(data.data) != string(c.Want[index].data) {
 					t.Errorf("expect: (%v, %v) \n but got: (%v, %v) \n",
-						c.Want[index].Name, string(c.Want[index].Data), data.Name, string(data.Data))
+						c.Want[index].name, string(c.Want[index].data), data.name, string(data.data))
 				}
 			}
 		}


### PR DESCRIPTION
Update cri-o to use the secrets package from libpod/pkg/secret,
which also brings in support for FIPS mode secret.
If the host is in FIPS mode (i.e /etc/system-fips exists) /run/secrets/system-fips
is created in the container so that the container can also run in FIPS mode.

Signed-off-by: umohnani8 <umohnani@redhat.com>