### PR TITLE
[release-1.9] runtime_status: report correct network status

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -762,18 +762,6 @@ func newPipe() (parent *os.File, child *os.File, err error) {
 	return os.NewFile(uintptr(fds[1]), "parent"), os.NewFile(uintptr(fds[0]), "child"), nil
 }
 
-// RuntimeReady checks if the runtime is up and ready to accept
-// basic containers e.g. container only needs host network.
-func (r *Runtime) RuntimeReady() (bool, error) {
-	return true, nil
-}
-
-// NetworkReady checks if the runtime network is up and ready to
-// accept containers which require container network.
-func (r *Runtime) NetworkReady() (bool, error) {
-	return true, nil
-}
-
 // PauseContainer pauses a container.
 func (r *Runtime) PauseContainer(c *Container) error {
 	c.opLock.Lock()

--- a/server/runtime_status.go
+++ b/server/runtime_status.go
@@ -1,11 +1,15 @@
 package server
 
 import (
+	"fmt"
 	"time"
 
 	"golang.org/x/net/context"
 	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
+
+// networkNotReadyReason is the reason reported when network is not ready.
+const networkNotReadyReason = "NetworkPluginNotReady"
 
 // Status returns the status of the runtime
 func (s *Server) Status(ctx context.Context, req *pb.StatusRequest) (resp *pb.StatusResponse, err error) {
@@ -15,31 +19,26 @@ func (s *Server) Status(ctx context.Context, req *pb.StatusRequest) (resp *pb.St
 		recordError(operation, err)
 	}()
 
-	// Deal with Runtime conditions
-	runtimeReady, err := s.Runtime().RuntimeReady()
-	if err != nil {
-		return nil, err
+	runtimeCondition := &pb.RuntimeCondition{
+		Type:   pb.RuntimeReady,
+		Status: true,
 	}
-	networkReady, err := s.Runtime().NetworkReady()
-	if err != nil {
-		return nil, err
+	networkCondition := &pb.RuntimeCondition{
+		Type:   pb.NetworkReady,
+		Status: true,
 	}
 
-	// Use vendored strings
-	runtimeReadyConditionString := pb.RuntimeReady
-	networkReadyConditionString := pb.NetworkReady
+	if err := s.netPlugin.Status(); err != nil {
+		networkCondition.Status = false
+		networkCondition.Reason = networkNotReadyReason
+		networkCondition.Message = fmt.Sprintf("Network plugin returns error: %v", err)
+	}
 
 	resp = &pb.StatusResponse{
 		Status: &pb.RuntimeStatus{
 			Conditions: []*pb.RuntimeCondition{
-				{
-					Type:   runtimeReadyConditionString,
-					Status: runtimeReady,
-				},
-				{
-					Type:   networkReadyConditionString,
-					Status: networkReady,
-				},
+				runtimeCondition,
+				networkCondition,
 			},
 		},
 	}


### PR DESCRIPTION
We were wrongly reporting runtime as ready even when it wasn't. This
patch correctly checks the network plugin before replying with network
ready.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
