### PR TITLE
container_create: Remove ambient capabilities

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -492,6 +492,11 @@ func setupContainerUser(specgen *generate.Generator, rootfs string, sc *pb.Linux
 
 // setupCapabilities sets process.capabilities in the OCI runtime config.
 func setupCapabilities(specgen *generate.Generator, capabilities *pb.Capability) error {
+	// Remove all ambient capabilities. Kubernetes is not yet ambient capabilities aware
+	// and pods expect that switching to a non-root user results in the capabilities being
+	// dropped. This should be revisited in the future.
+	specgen.Spec().Process.Capabilities.Ambient = []string{}
+
 	if capabilities == nil {
 		return nil
 	}
@@ -510,9 +515,6 @@ func setupCapabilities(specgen *generate.Generator, capabilities *pb.Capability)
 	// see https://github.com/kubernetes/kubernetes/issues/51980
 	if inStringSlice(capabilities.GetAddCapabilities(), "ALL") {
 		for _, c := range getOCICapabilitiesList() {
-			if err := specgen.AddProcessCapabilityAmbient(c); err != nil {
-				return err
-			}
 			if err := specgen.AddProcessCapabilityBounding(c); err != nil {
 				return err
 			}
@@ -529,9 +531,6 @@ func setupCapabilities(specgen *generate.Generator, capabilities *pb.Capability)
 	}
 	if inStringSlice(capabilities.GetDropCapabilities(), "ALL") {
 		for _, c := range getOCICapabilitiesList() {
-			if err := specgen.DropProcessCapabilityAmbient(c); err != nil {
-				return err
-			}
 			if err := specgen.DropProcessCapabilityBounding(c); err != nil {
 				return err
 			}
@@ -552,9 +551,6 @@ func setupCapabilities(specgen *generate.Generator, capabilities *pb.Capability)
 			continue
 		}
 		capPrefixed := toCAPPrefixed(cap)
-		if err := specgen.AddProcessCapabilityAmbient(capPrefixed); err != nil {
-			return err
-		}
 		if err := specgen.AddProcessCapabilityBounding(capPrefixed); err != nil {
 			return err
 		}
@@ -574,9 +570,6 @@ func setupCapabilities(specgen *generate.Generator, capabilities *pb.Capability)
 			continue
 		}
 		capPrefixed := toCAPPrefixed(cap)
-		if err := specgen.DropProcessCapabilityAmbient(capPrefixed); err != nil {
-			return fmt.Errorf("failed to drop cap %s %v", capPrefixed, err)
-		}
 		if err := specgen.DropProcessCapabilityBounding(capPrefixed); err != nil {
 			return fmt.Errorf("failed to drop cap %s %v", capPrefixed, err)
 		}


### PR DESCRIPTION
Pod workloads expect capabilities to be dropped when switching to a non-root
user.

@umohnani8 @rhatdan @runcom PTAL

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

