### PR TITLE
Make capabilities an option in crio.conf

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -110,6 +110,14 @@ apparmor_profile = "{{ .ApparmorProfile }}"
 # for the runtime.
 cgroup_manager = "{{ .CgroupManager }}"
 
+# default_capabilities is the list of capabilities to add and can be modified here.
+# If capabilities below is commented out, the default list of capabilities defined in the
+# spec will be added.
+# If capabilities is empty below, only the capabilities defined in the container json
+# file by the user/kube will be added.
+default_capabilities = [
+{{ range $capability := .DefaultCapabilities}}{{ printf "\t%q, \n" $capability}}{{ end }}]
+
 # hooks_dir_path is the oci hooks directory for automatically executed hooks
 hooks_dir_path = "{{ .HooksDirPath }}"
 

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -138,6 +138,9 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("default-mounts-file") {
 		config.DefaultMountsFile = ctx.GlobalString("default-mounts-file")
 	}
+	if ctx.GlobalIsSet("default-capabilities") {
+		config.DefaultCapabilities = strings.Split(ctx.GlobalString("default-capabilities"), ",")
+	}
 	if ctx.GlobalIsSet("pids-limit") {
 		config.PidsLimit = ctx.GlobalInt64("pids-limit")
 	}
@@ -351,6 +354,10 @@ func main() {
 			Name:   "default-mounts-file",
 			Usage:  "path to default mounts file",
 			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:  "default-capabilities",
+			Usage: "capabilities to add to the containers",
 		},
 		cli.BoolFlag{
 			Name:  "profile",

--- a/lib/config.go
+++ b/lib/config.go
@@ -57,6 +57,21 @@ const (
 	DefaultLogSizeMax = -1
 )
 
+// DefaultCapabilities for the capabilities option in the crio.conf file
+var DefaultCapabilities = []string{
+	"CHOWN",
+	"DAC_OVERRIDE",
+	"FSETID",
+	"FOWNER",
+	"NET_RAW",
+	"SETGID",
+	"SETUID",
+	"SETPCAP",
+	"NET_BIND_SERVICE",
+	"SYS_CHROOT",
+	"KILL",
+}
+
 // This structure is necessary to fake the TOML tables when parsing,
 // while also not requiring a bunch of layered structs for no good
 // reason.
@@ -192,6 +207,9 @@ type RuntimeConfig struct {
 	// A range is specified in the form containerUID:HostUID:Size.  Multiple
 	// ranges are separed by comma.
 	GIDMappings string `toml:"gid_mappings"`
+
+	// Capabilities to add to all containers.
+	DefaultCapabilities []string `toml:"default_capabilities"`
 }
 
 // ImageConfig represents the "crio.image" TOML config table.
@@ -315,15 +333,16 @@ func DefaultConfig() *Config {
 			ConmonEnv: []string{
 				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			},
-			SELinux:           selinuxEnabled(),
-			SeccompProfile:    seccompProfilePath,
-			ApparmorProfile:   apparmorProfileName,
-			CgroupManager:     cgroupManager,
-			PidsLimit:         DefaultPidsLimit,
-			ContainerExitsDir: containerExitsDir,
-			HooksDirPath:      DefaultHooksDirPath,
-			LogSizeMax:        DefaultLogSizeMax,
-			DefaultMountsFile: "",
+			SELinux:             selinuxEnabled(),
+			SeccompProfile:      seccompProfilePath,
+			ApparmorProfile:     apparmorProfileName,
+			CgroupManager:       cgroupManager,
+			PidsLimit:           DefaultPidsLimit,
+			ContainerExitsDir:   containerExitsDir,
+			HooksDirPath:        DefaultHooksDirPath,
+			LogSizeMax:          DefaultLogSizeMax,
+			DefaultMountsFile:   "",
+			DefaultCapabilities: DefaultCapabilities,
 		},
 		ImageConfig: ImageConfig{
 			DefaultTransport:    defaultTransport,

--- a/test/namespaces.bats
+++ b/test/namespaces.bats
@@ -8,13 +8,11 @@ function teardown() {
 
 @test "pid_namespace_mode_pod_test" {
 	start_crio
-	pidNamespaceMode=$(cat "$TESTDATA"/sandbox_config.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["linux"]["security_context"]["namespace_options"]["pid"] = 0; json.dump(obj, sys.stdout)')
-	echo "$pidNamespaceMode" > "$TESTDIR"/sandbox_pidnamespacemode_config.json
-	run crictl runp "$TESTDIR"/sandbox_pidnamespacemode_config.json
+	run crictl runp "$TESTDATA"/sandbox_pidnamespacemode_config.json
 	echo "$output"
 	[ "$status" -eq 0 ]
 	pod_id="$output"
-	run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDIR"/sandbox_pidnamespacemode_config.json
+	run crictl create "$pod_id" "$TESTDATA"/container_redis_namespace.json "$TESTDATA"/sandbox_pidnamespacemode_config.json
 	echo "$output"
 	[ "$status" -eq 0 ]
 	ctr_id="$output"

--- a/test/network.bats
+++ b/test/network.bats
@@ -131,7 +131,7 @@ function teardown() {
 	if [[ ! -e "$CRIO_CNI_PLUGIN"/bridge-custom ]]; then
 		skip "bridge-custom plugin not available"
 	fi
-	start_crio "" "" "" "prepare_plugin_test_args_network_conf"
+	start_crio "" "" "" "" "prepare_plugin_test_args_network_conf"
 	run crictl runp "$TESTDATA"/sandbox_config.json
 	[ "$status" -eq 0 ]
 
@@ -175,7 +175,7 @@ function teardown() {
 	if [[ ! -e "$CRIO_CNI_PLUGIN"/bridge-custom ]]; then
 		skip "bridge-custom plugin not available"
 	fi
-	start_crio "" "" "" "prepare_plugin_test_args_network_conf"
+	start_crio "" "" "" "" "prepare_plugin_test_args_network_conf"
 
 	# make conmon non-executable to cause the sandbox setup to fail after
 	# networking has been configured

--- a/test/testdata/container_config.json
+++ b/test/testdata/container_config.json
@@ -50,6 +50,9 @@
 			"oom_score_adj": 30
 		},
 		"security_context": {
+			"namespace_options": {
+				"pid": 1
+			},
 			"readonly_rootfs": false,
 			"selinux_options": {
 				"user": "system_u",

--- a/test/testdata/container_config_by_imageid.json
+++ b/test/testdata/container_config_by_imageid.json
@@ -51,6 +51,9 @@
 			"oom_score_adj": 30
 		},
 		"security_context": {
+			"namespace_options": {
+				"pid": 1
+			},
 			"capabilities": {
 				"add_capabilities": [
 					"setuid",

--- a/test/testdata/container_config_hostport.json
+++ b/test/testdata/container_config_hostport.json
@@ -53,6 +53,9 @@
 			"oom_score_adj": 30
 		},
 		"security_context": {
+			"namespace_options": {
+				"pid": 1
+			},
 			"capabilities": {
 				"add_capabilities": [
 					"setuid",

--- a/test/testdata/container_config_logging.json
+++ b/test/testdata/container_config_logging.json
@@ -53,6 +53,9 @@
 			"oom_score_adj": 30
 		},
 		"security_context": {
+			"namespace_options": {
+				"pid": 1
+			},
 			"capabilities": {
 				"add_capabilities": [
 					"setuid",

--- a/test/testdata/container_config_resolvconf.json
+++ b/test/testdata/container_config_resolvconf.json
@@ -52,6 +52,9 @@
 			"oom_score_adj": 30
 		},
 		"security_context": {
+			"namespace_options": {
+				"pid": 1
+			},
 			"readonly_rootfs": false,
 			"capabilities": {
 				"add_capabilities": [

--- a/test/testdata/container_config_resolvconf_ro.json
+++ b/test/testdata/container_config_resolvconf_ro.json
@@ -52,6 +52,9 @@
 			"oom_score_adj": 30
 		},
 		"security_context": {
+			"namespace_options": {
+				"pid": 1
+			},
 			"readonly_rootfs": true,
 			"capabilities": {
 				"add_capabilities": [

--- a/test/testdata/container_config_seccomp.json
+++ b/test/testdata/container_config_seccomp.json
@@ -51,6 +51,9 @@
 			"oom_score_adj": 30
 		},
 		"security_context": {
+			"namespace_options": {
+				"pid": 1
+			},
 			"seccomp_profile_path": "%VALUE%",
 			"capabilities": {
 				"add_capabilities": [

--- a/test/testdata/container_config_sleep.json
+++ b/test/testdata/container_config_sleep.json
@@ -51,6 +51,9 @@
 			"oom_score_adj": 30
 		},
 		"security_context": {
+			"namespace_options": {
+				"pid": 1
+			},
 			"readonly_rootfs": false,
 			"selinux_options": {
 				"user": "system_u",

--- a/test/testdata/container_exit_test.json
+++ b/test/testdata/container_exit_test.json
@@ -18,5 +18,12 @@
 	"log_path": "",
 	"stdin": false,
 	"stdin_once": false,
-	"tty": false
+	"tty": false,
+	"linux": {
+		"security_context": {
+			"namespace_options": {
+				"pid": 1
+			}
+		}
+	}
 }

--- a/test/testdata/container_redis.json
+++ b/test/testdata/container_redis.json
@@ -54,6 +54,9 @@
 			"cpuset_mems": "0"
 		},
 		"security_context": {
+			"namespace_options": {
+				"pid": 1
+			},
 			"capabilities": {
 				"add_capabilities": [
 					"sys_admin"

--- a/test/testdata/container_redis_default_mounts.json
+++ b/test/testdata/container_redis_default_mounts.json
@@ -57,6 +57,9 @@
 			"oom_score_adj": 30
 		},
 		"security_context": {
+			"namespace_options": {
+				"pid": 1
+			},
 			"capabilities": {
 				"add_capabilities": [
 					"sys_admin"

--- a/test/testdata/container_redis_device.json
+++ b/test/testdata/container_redis_device.json
@@ -58,6 +58,9 @@
 			"oom_score_adj": 30
 		},
 		"security_context": {
+			"namespace_options": {
+				"pid": 1
+			},
 			"capabilities": {
 				"add_capabilities": [
 					"sys_admin"

--- a/test/testdata/container_redis_namespace.json
+++ b/test/testdata/container_redis_namespace.json
@@ -13,7 +13,7 @@
 	"envs": [
 		{
 			"key": "PATH",
-			"value": "/acustompathinpath:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+			"value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 		},
 		{
 			"key": "TERM",
@@ -49,12 +49,11 @@
 			"cpu_period": 10000,
 			"cpu_quota": 20000,
 			"cpu_shares": 512,
-			"oom_score_adj": 30
+			"oom_score_adj": 30,
+			"cpuset_cpus": "0",
+			"cpuset_mems": "0"
 		},
 		"security_context": {
-			"namespace_options": {
-				"pid": 1
-			},
 			"capabilities": {
 				"add_capabilities": [
 					"sys_admin"

--- a/test/testdata/container_sleep.json
+++ b/test/testdata/container_sleep.json
@@ -27,6 +27,11 @@
 	"stdin_once": false,
 	"tty": false,
 	"linux": {
+		"security_context": {
+			"namespace_options": {
+				"pid": 1
+			}
+		},
 		"resources": {
 			"cpu_period": 10000,
 			"cpu_quota": 20000,

--- a/test/testdata/sandbox1_config.json
+++ b/test/testdata/sandbox1_config.json
@@ -36,9 +36,9 @@
 		"cgroup_parent": "/Burstable/pod_123-456",
 		"security_context": {
 			"namespace_options": {
-				"host_network": false,
-				"host_pid": false,
-				"host_ipc": false
+				"network": 0,
+				"pid": 1,
+				"ipc": 0
 			},
 			"selinux_options": {
 				"user": "system_u",

--- a/test/testdata/sandbox2_config.json
+++ b/test/testdata/sandbox2_config.json
@@ -36,9 +36,9 @@
 		"cgroup_parent": "/Burstable/pod_123-456",
 		"security_context": {
 			"namespace_options": {
-				"host_network": false,
-				"host_pid": false,
-				"host_ipc": false
+				"network": 0,
+				"pid": 1,
+				"ipc": 0
 			},
 			"selinux_options": {
 				"user": "system_u",

--- a/test/testdata/sandbox3_config.json
+++ b/test/testdata/sandbox3_config.json
@@ -36,9 +36,9 @@
 		"cgroup_parent": "/Burstable/pod_123-456",
 		"security_context": {
 			"namespace_options": {
-				"host_network": false,
-				"host_pid": false,
-				"host_ipc": false
+				"network": 0,
+				"pid": 1,
+				"ipc": 0
 			},
 			"selinux_options": {
 				"user": "system_u",

--- a/test/testdata/sandbox_config.json
+++ b/test/testdata/sandbox_config.json
@@ -34,9 +34,9 @@
 		"cgroup_parent": "/Burstable/pod_123-456",
 		"security_context": {
 			"namespace_options": {
-				"host_network": false,
-				"host_pid": false,
-				"host_ipc": false
+				"network": 0,
+				"pid": 1,
+				"ipc": 0
 			},
 			"selinux_options": {
 				"user": "system_u",

--- a/test/testdata/sandbox_config_hostnet.json
+++ b/test/testdata/sandbox_config_hostnet.json
@@ -38,9 +38,9 @@
 		"cgroup_parent": "/Burstable/pod_123-456",
 		"security_context": {
 			"namespace_options": {
-				"host_network": true,
-				"host_pid": false,
-				"host_ipc": false
+				"network": 0,
+				"pid": 1,
+				"ipc": 0
 			}
 		}
 	}

--- a/test/testdata/sandbox_config_seccomp.json
+++ b/test/testdata/sandbox_config_seccomp.json
@@ -38,9 +38,9 @@
 		"security_context": {
 			"seccomp_profile_path": "%VALUE%",
 			"namespace_options": {
-				"host_network": false,
-				"host_pid": false,
-				"host_ipc": false
+				"network": 0,
+				"pid": 1,
+				"ipc": 0
 			},
 			"selinux_options": {
 				"user": "system_u",

--- a/test/testdata/sandbox_config_selinux.json
+++ b/test/testdata/sandbox_config_selinux.json
@@ -34,9 +34,9 @@
 		"cgroup_parent": "/Burstable/pod_123-456",
 		"security_context": {
 			"namespace_options": {
-				"host_network": false,
-				"host_pid": false,
-				"host_ipc": false
+				"network": 0,
+				"pid": 1,
+				"ipc": 0
 			},
 			"selinux_options": {
 				"level": "s0"

--- a/test/testdata/sandbox_config_sysctl.json
+++ b/test/testdata/sandbox_config_sysctl.json
@@ -39,9 +39,9 @@
 		"cgroup_parent": "/Burstable/pod_123-456",
 		"security_context": {
 			"namespace_options": {
-				"host_network": false,
-				"host_pid": false,
-				"host_ipc": false
+				"network": 0,
+				"pid": 1,
+				"ipc": 0
 			},
 			"selinux_options": {
 				"user": "system_u",

--- a/test/testdata/sandbox_pidnamespacemode_config.json
+++ b/test/testdata/sandbox_pidnamespacemode_config.json
@@ -1,28 +1,19 @@
+
 {
 	"metadata": {
 		"name": "podsandbox1",
-		"uid": "redhat-test-crio",
+		"uid": "redhat-test-crio-1",
 		"namespace": "redhat.test.crio",
 		"attempt": 1
 	},
 	"hostname": "crictl_host",
 	"log_directory": "",
-	"dns_options": {
-		"servers": [
-			"server1.redhat.com",
-			"server2.redhat.com"
-		],
+	"dns_config": {
 		"searches": [
 			"8.8.8.8"
 		]
 	},
-	"port_mappings": [
-		{
-			"protocol": 0,
-			"container_port": 80,
-			"host_port": 4888
-		}
-	],
+	"port_mappings": [],
 	"resources": {
 		"cpu": {
 			"limits": 3,
@@ -34,7 +25,9 @@
 		}
 	},
 	"labels": {
-		"group": "test"
+		"name": "podsandbox1",
+		"group": "test",
+		"version": "v1.0.0"
 	},
 	"annotations": {
 		"owner": "hmeng",
@@ -44,9 +37,16 @@
 		"cgroup_parent": "/Burstable/pod_123-456",
 		"security_context": {
 			"namespace_options": {
-				"network": 0,
-				"pid": 1,
-				"ipc": 0
+				"host_network": false,
+				"host_pid": false,
+                "host_ipc": false,
+                "pid": 0
+			},
+			"selinux_options": {
+				"user": "system_u",
+				"role": "system_r",
+				"type": "svirt_lxc_net_t",
+				"level": "s0:c4,c5"
 			}
 		}
 	}

--- a/test/testdata/template_container_config.json
+++ b/test/testdata/template_container_config.json
@@ -6,7 +6,7 @@
 	"image": {
 		"image": "${IMAGE}"
 	},
-	"command": ${COMMAND},
+	"command": "${COMMAND}",
 	"args": [],
 	"working_dir": "/",
 	"envs": [

--- a/test/testdata/template_sandbox_config.json
+++ b/test/testdata/template_sandbox_config.json
@@ -34,9 +34,9 @@
 		"cgroup_parent": "/Burstable/pod_123-456",
 		"security_context": {
 			"namespace_options": {
-				"host_network": false,
-				"host_pid": false,
-				"host_ipc": false
+				"network": 0,
+				"pid": 1,
+				"ipc": 0
 			},
 			"selinux_options": {
 				"user": "system_u",


### PR DESCRIPTION
The list of capabilities to be added can be defined in
/etc/crio/crio.conf. 

Fixes https://github.com/kubernetes-incubator/cri-o/issues/1536

Signed-off-by: umohnani8 <umohnani@redhat.com>