### PR TITLE
Fix handling of /dev/shm mounting inside of containers

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1063,10 +1063,13 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	specgen.AddAnnotation(annotations.ImageRef, imageRef)
 	specgen.AddAnnotation(annotations.IP, sb.IP())
 
+	// Remove the default /dev/shm mount to ensure we overwrite it
+	specgen.RemoveMount("/dev/shm")
+
 	mnt = rspec.Mount{
 		Type:        "bind",
 		Source:      sb.ShmPath(),
-		Destination: "/etc/shm",
+		Destination: "/dev/shm",
 		Options:     []string{"rw", "bind"},
 	}
 	// bind mount the pod shm

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -292,6 +292,9 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	g.SetProcessSelinuxLabel(processLabel)
 	g.SetLinuxMountLabel(mountLabel)
 
+	// Remove the default /dev/shm mount to ensure we overwrite it
+	g.RemoveMount("/dev/shm")
+
 	// create shm mount for the pod containers.
 	var shmPath string
 	if securityContext.GetNamespaceOptions().GetIpc() == pb.NamespaceMode_NODE {
@@ -309,6 +312,15 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 			}
 		}()
 	}
+
+	mnt := runtimespec.Mount{
+		Type:        "bind",
+		Source:      shmPath,
+		Destination: "/dev/shm",
+		Options:     []string{"rw", "bind"},
+	}
+	// bind mount the pod shm
+	g.AddMount(mnt)
 
 	err = s.setPodSandboxMountLabel(id, mountLabel)
 	if err != nil {
@@ -505,7 +517,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	if err := label.Relabel(hostnamePath, mountLabel, true); err != nil && err != unix.ENOTSUP {
 		return nil, err
 	}
-	mnt := runtimespec.Mount{
+	mnt = runtimespec.Mount{
 		Type:        "bind",
 		Source:      hostnamePath,
 		Destination: "/etc/hostname",

--- a/test/shm.bats
+++ b/test/shm.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function teardown() {
+	cleanup_test
+}
+
+@test "ctr check shared /dev/shm" {
+	start_crio
+	run crictl runp "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+	run crictl create "$pod_id" "$TESTDATA"/container_sleep.json "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run crictl start "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crictl exec --sync "$ctr_id" touch /dev/shm/testdata
+	echo "$output"
+	[ "$status" -eq 0 ]
+
+	run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run crictl start "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crictl exec --sync "$ctr_id" ls /dev/shm/testdata
+	echo "$output"
+	[ "$status" -eq 0 ]
+
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}

--- a/test/testdata/container_sleep.json
+++ b/test/testdata/container_sleep.json
@@ -1,0 +1,37 @@
+{
+	"metadata": {
+		"name": "podsandbox-sleep"
+	},
+	"image": {
+		"image": "quay.io/crio/redis:alpine"
+	},
+	"command": [
+		  "/bin/sleep", "6000"
+	],
+	"args": [
+                "6000"
+	],
+	"working_dir": "/",
+	"envs": [
+		{
+			"key": "PATH",
+			"value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+		}
+	],
+	"annotations": {
+		"pod": "podsandbox"
+	},
+	"readonly_rootfs": false,
+	"log_path": "",
+	"stdin": false,
+	"stdin_once": false,
+	"tty": false,
+	"linux": {
+		"resources": {
+			"cpu_period": 10000,
+			"cpu_quota": 20000,
+			"cpu_shares": 512,
+			"oom_score_adj": 30
+		}
+	}
+}


### PR DESCRIPTION
Add test to make sure /dev/shm is shared between containers in CRI-O

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
