### PR TITLE
test: Update to golang 1.10.2

### DIFF
--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -76,7 +76,7 @@
     - name: install Golang tools
       include: golang.yml
       vars:
-          version: "1.10.1"
+          version: "1.10.2"
     - name: setup critest
       include: "build/cri-tools.yml"
       vars:
@@ -95,7 +95,7 @@
     - name: install Golang tools
       include: golang.yml
       vars:
-          version: "1.10.1"
+          version: "1.10.2"
     - name: clone build and install kubernetes
       include: "build/kubernetes.yml"
       vars:
@@ -116,7 +116,7 @@
     - name: install Golang tools
       include: golang.yml
       vars:
-          version: "1.10.1"
+          version: "1.10.2"
     - name: clone build and install kubernetes
       include: "build/kubernetes.yml"
       vars:


### PR DESCRIPTION
Latest k8s requires 1.10.2 as the minimum version.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

