### PR TITLE
pkg: storage: provide an hint when pulling w/o registries configured

### DIFF
--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -28,6 +28,8 @@ var (
 	ErrCannotParseImageID = errors.New("cannot parse an image ID")
 	// ErrImageMultiplyTagged is returned when we try to remove an image that still has multiple names
 	ErrImageMultiplyTagged = errors.New("image still has multiple names applied")
+	// ErrNoRegistriesConfigured is returned when there are no registries configured in /etc/crio.conf#additional_registries
+	ErrNoRegistriesConfigured = errors.New(`no registries configured while trying to pull an unqualified image, add at least one in /etc/crio/crio.conf under the "registries" key`)
 )
 
 // ImageResult wraps a subset of information about an image: its ID, its names,
@@ -580,7 +582,7 @@ func (svc *imageService) ResolveNames(imageName string) ([]string, error) {
 	// we got an unqualified image here, we can't go ahead w/o registries configured
 	// properly.
 	if len(svc.registries) == 0 {
-		return nil, errors.New("no registries configured while trying to pull an unqualified image")
+		return nil, ErrNoRegistriesConfigured
 	}
 	// this means we got an image in the form of "busybox"
 	// we need to use additional registries...


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Enhanced the error message we provide when pulling unqualified images w/o registries configured in `/etc/crio/crio.conf`. There have been questions around this in sig-node slack so better improving this.

**- How I did it**

vim

**- How to verify it**

pull an unqualified image (`busybox`) w/o a registry configured, you should see the new error message

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
