### PR TITLE
WIP: Fix missing ansible dependency

### DIFF
--- a/contrib/test/integration/system.yml
+++ b/contrib/test/integration/system.yml
@@ -26,6 +26,8 @@
     - libgpg-error-devel
     - libguestfs-tools
     - libseccomp-devel
+    - libselinux-python
+    - libsemanage-python
     - libvirt-client
     - libvirt-python
     - libxml2-devel


### PR DESCRIPTION
**- What I did**
Ran AMI-build test with Fedora, playbook encountered encountered this error:

```
TASK [Containers using cgroups and/or systemd after 7.5 are permitted] *********
task path: /go/src/github.com/kubernetes-incubator/cri-o/contrib/test/integration/system.yml:130
fatal: [localhost]: FAILED! => {
    "changed": false
}

MSG:
---
This module requires libsemanage-python support
```

**- How I did it**
Including the necessary RPM in the packages-to-install list.

**- How to verify it**
/test ami_fedora will pass