### PR TITLE
tutorial.md: fix path to cri-tools

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -104,7 +104,7 @@ go version go1.8.5 linux/amd64
 
 ```
 go get github.com/kubernetes-incubator/cri-tools/cmd/crictl
-cd $GOPATH/src/github.com/kubernetes-incubator/cri-tools/cmd/crictl
+cd $GOPATH/src/github.com/kubernetes-incubator/cri-tools
 make
 make install
 ```


### PR DESCRIPTION
Closes: https://github.com/kubernetes-incubator/cri-o/issues/1570

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
