### PR TITLE
Fix c compiler warning

### DIFF
--- a/conmon/cmsg.c
+++ b/conmon/cmsg.c
@@ -55,7 +55,7 @@
 ssize_t sendfd(int sockfd, struct file_t file)
 {
 	struct msghdr msg = {0};
-	struct iovec iov[1] = {0};
+	struct iovec iov[1] = {{0}};
 	struct cmsghdr *cmsg;
 	int *fdptr;
 
@@ -101,7 +101,7 @@ ssize_t sendfd(int sockfd, struct file_t file)
 struct file_t recvfd(int sockfd)
 {
 	struct msghdr msg = {0};
-	struct iovec iov[1] = {0};
+	struct iovec iov[1] = {{0}};
 	struct cmsghdr *cmsg;
 	struct file_t file = {0};
 	int *fdptr;


### PR DESCRIPTION
Everytime we build conmon we get the following warnings.
STDERR:
---
cmsg.c: In function ‘sendfd’:
cmsg.c:58:9: warning: missing braces around initializer [-Wmissing-braces]
  struct iovec iov[1] = {0};
         ^
cmsg.c:58:9: warning: (near initialization for ‘iov[0]’) [-Wmissing-braces]
cmsg.c: In function ‘recvfd’:
cmsg.c:104:9: warning: missing braces around initializer [-Wmissing-braces]
  struct iovec iov[1] = {0};
         ^
cmsg.c:104:9: warning: (near initialization for ‘iov[0]’) [-Wmissing-braces]

This patch fixes these warnings.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
