### PR TITLE
info: add information about ID mappings

### DIFF
--- a/server/inspect.go
+++ b/server/inspect.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	cimage "github.com/containers/image/types"
+	"github.com/containers/storage/pkg/idtools"
 	"github.com/go-zoo/bone"
 	"github.com/kubernetes-incubator/cri-o/lib/sandbox"
 	"github.com/kubernetes-incubator/cri-o/oci"
@@ -14,11 +15,30 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func (s *Server) getIDMappingsInfo() types.IDMappings {
+	if s.defaultIDMappings == nil {
+		fullMapping := idtools.IDMap{
+			ContainerID: 0,
+			HostID:      0,
+			Size:        4294967295,
+		}
+		return types.IDMappings{
+			Uids: []idtools.IDMap{fullMapping},
+			Gids: []idtools.IDMap{fullMapping},
+		}
+	}
+	return types.IDMappings{
+		Uids: s.defaultIDMappings.UIDs(),
+		Gids: s.defaultIDMappings.GIDs(),
+	}
+}
+
 func (s *Server) getInfo() types.CrioInfo {
 	return types.CrioInfo{
-		StorageDriver: s.config.Config.Storage,
-		StorageRoot:   s.config.Config.Root,
-		CgroupDriver:  s.config.Config.CgroupManager,
+		StorageDriver:     s.config.Config.Storage,
+		StorageRoot:       s.config.Config.Root,
+		CgroupDriver:      s.config.Config.CgroupManager,
+		DefaultIDMappings: s.getIDMappingsInfo(),
 	}
 }
 

--- a/test/ctr_userns.bats
+++ b/test/ctr_userns.bats
@@ -37,7 +37,15 @@ function teardown() {
 	state=$($RUNTIME state "$ctr_id")
 	pid=$(echo $state | python -c 'import json; import sys; d=json.load(sys.stdin); print d["pid"]')
 	grep 100000 /proc/$pid/uid_map
+	[ "$status" -eq 0 ]
 	grep 200000 /proc/$pid/gid_map
+	[ "$status" -eq 0 ]
+
+	out=`echo -e "GET /info HTTP/1.1\r\nHost: crio\r\n" | socat - UNIX-CONNECT:$CRIO_SOCKET`
+	echo "$out"
+	[[ "$out" =~ "100000" ]]
+	[[ "$out" =~ "200000" ]]
+
 	cleanup_ctrs
 	cleanup_pods
 	stop_crio

--- a/types/types.go
+++ b/types/types.go
@@ -1,5 +1,9 @@
 package types
 
+import (
+	"github.com/containers/storage/pkg/idtools"
+)
+
 // ContainerInfo stores information about containers
 type ContainerInfo struct {
 	Name            string            `json:"name"`
@@ -16,9 +20,16 @@ type ContainerInfo struct {
 	IP              string            `json:"ip_address"`
 }
 
+// IDMappings specifies the ID mappings used for containers.
+type IDMappings struct {
+	Uids []idtools.IDMap `json:"uids"`
+	Gids []idtools.IDMap `json:"gids"`
+}
+
 // CrioInfo stores information about the crio daemon
 type CrioInfo struct {
-	StorageDriver string `json:"storage_driver"`
-	StorageRoot   string `json:"storage_root"`
-	CgroupDriver  string `json:"cgroup_driver"`
+	StorageDriver     string     `json:"storage_driver"`
+	StorageRoot       string     `json:"storage_root"`
+	CgroupDriver      string     `json:"cgroup_driver"`
+	DefaultIDMappings IDMappings `json:"default_id_mappings"`
 }


### PR DESCRIPTION
add information about the ID mappings used for the containers.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

**- What I did**
Added information about the UIDs/GIDs mappings to the /info endpoint

**- How I did it**
Added a new field to the JSON output

**- How to verify it**
echo -e "GET /info HTTP/1.1\r\nHost: crio\r\n" | sudo socat - UNIX-CONNECT:/PATH/TO/crio.sock

**- Description for the changelog**
nothing, it is a followup for https://github.com/kubernetes-incubator/cri-o/pull/1562