### PR TITLE
CRI-O Integration testing with userns enabled

### DIFF
--- a/contrib/test/integration/README.md
+++ b/contrib/test/integration/README.md
@@ -8,11 +8,11 @@ for both RHEL and Fedora hosts. Two entry-point playbooks exist:
 
 When running the `main.yml` playbook, multiple tags are present:
 
- - `setup`: run all tasks to set up the system for testing.
- - `e2e`: build CRI-O from source and run Kubernetes end-to-end tests.
- - `node-e2e`: build CRI-O from source and run Kubernetes 'node' end-to-end tests.
- - `integration`: build CRI-O from source and run the local integration suite.
--  `userns`: An option for use along with the `integration` tag.  Enables user-namespace testing mode.
+ - `setup`: Run all tasks to set up the system for testing.
+ - `e2e`: Build CRI-O from source and run Kubernetes end-to-end tests.
+ - `node-e2e`: Build CRI-O from source and run Kubernetes 'node' end-to-end tests.
+ - `integration`: Build CRI-O from source and run the local integration suite twice.
+                  First normally, then again with user-namespace support enabled.
 
 The playbooks assume the following things about your system:
 

--- a/contrib/test/integration/README.md
+++ b/contrib/test/integration/README.md
@@ -12,6 +12,7 @@ When running the `main.yml` playbook, multiple tags are present:
  - `e2e`: build CRI-O from source and run Kubernetes end-to-end tests.
  - `node-e2e`: build CRI-O from source and run Kubernetes 'node' end-to-end tests.
  - `integration`: build CRI-O from source and run the local integration suite.
+-  `userns`: Same as `integration`, except with usernamespaces enabled.
 
 The playbooks assume the following things about your system:
 

--- a/contrib/test/integration/README.md
+++ b/contrib/test/integration/README.md
@@ -12,7 +12,7 @@ When running the `main.yml` playbook, multiple tags are present:
  - `e2e`: build CRI-O from source and run Kubernetes end-to-end tests.
  - `node-e2e`: build CRI-O from source and run Kubernetes 'node' end-to-end tests.
  - `integration`: build CRI-O from source and run the local integration suite.
--  `userns`: Same as `integration`, except with usernamespaces enabled.
+-  `userns`: An option for use along with the `integration` tag.  Enables user-namespace testing mode.
 
 The playbooks assume the following things about your system:
 

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -60,24 +60,16 @@
   remote_user: root
   vars_files:
     - "{{ playbook_dir }}/vars.yml"
+  tags:
+    - integration
   tasks:
     - name: clone build and install cri-tools
       include: "build/cri-tools.yml"
       vars:
         force_clone: True
         cri_tools_git_version: "9da2549287cbbdbfa045b3246ab34ffea703dce4"
-      tags:
-        - integration
-    - name: Usernamespace integration testing needs updated environment variables
-      set_fact:
-        # Keys/Values in userns_int_test_env update int_test_env (from vars.yml)
-        int_test_env: '{{ int_test_env | combine(userns_int_test_env) }}'
-      tags:
-        - userns
     - name: run cri-o integration tests
       include: test.yml
-      tags:
-        - integration
 
 - hosts: all
   remote_user: root

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -41,6 +41,7 @@
     - "{{ playbook_dir }}/vars.yml"
   tags:
     - integration
+    - userns
     - e2e
     - node-e2e
     - critest

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -60,16 +60,24 @@
   remote_user: root
   vars_files:
     - "{{ playbook_dir }}/vars.yml"
-  tags:
-    - integration
   tasks:
     - name: clone build and install cri-tools
       include: "build/cri-tools.yml"
       vars:
         force_clone: True
         cri_tools_git_version: "9da2549287cbbdbfa045b3246ab34ffea703dce4"
+      tags:
+        - integration
+    - name: Usernamespace integration testing needs updated environment variables
+      set_fact:
+        # Keys/Values in userns_int_test_env update int_test_env (from vars.yml)
+        int_test_env: '{{ int_test_env | combine(userns_int_test_env) }}'
+      tags:
+        - userns
     - name: run cri-o integration tests
       include: test.yml
+      tags:
+        - integration
 
 - hosts: all
   remote_user: root

--- a/contrib/test/integration/test.yml
+++ b/contrib/test/integration/test.yml
@@ -7,11 +7,6 @@
     regexp: ' go test \"\$'
     state: present
 
-- name: set extra storage options
-  set_fact:
-    extra_storage_opts: " --storage-opt overlay.override_kernel_check=1"
-  when: ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS'
-
 - name: Usernamespace integration testing uses updated environment variables
   set_fact:
     # Keys/Values in userns_int_test_env update int_test_env (from vars.yml)

--- a/contrib/test/integration/test.yml
+++ b/contrib/test/integration/test.yml
@@ -12,6 +12,14 @@
     extra_storage_opts: " --storage-opt overlay.override_kernel_check=1"
   when: ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS'
 
+- name: Usernamespace integration testing uses updated environment variables
+  set_fact:
+    # Keys/Values in userns_int_test_env update int_test_env (from vars.yml)
+    int_test_env: '{{ int_test_env | combine(userns_int_test_env) }}'
+  tags:
+    - integration
+    - userns
+
 - name: ensure directory exists for e2e reports
   file:
     path: "{{ artifacts }}"
@@ -24,9 +32,10 @@
       when: not integration_selinux_enabled
 
     - name: run integration tests
-      shell: "CGROUP_MANAGER=cgroupfs STORAGE_OPTIONS='--storage-driver=overlay{{ extra_storage_opts | default('') }}' make localintegration >& {{ artifacts }}/testout.txt"
+      shell: "{{ int_test_cmd }}"
       args:
         chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o"
+      environment: '{{ int_test_env }}'  # from vars.yml
       async: '{{ 60 * 30 }}'  # seconds
       poll: 30
 

--- a/contrib/test/integration/test.yml
+++ b/contrib/test/integration/test.yml
@@ -19,10 +19,18 @@
       when: not integration_selinux_enabled
 
     - name: run integration tests
-      shell: "{{ int_test_cmd }}"
+      shell: "make localintegration >& {{ crio_integration_filepath }}"
       args:
         chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o"
       environment: '{{ int_test_env }}'  # from vars.yml and main.yml
+      async: '{{ 60 * 30 }}'  # seconds
+      poll: 30
+
+    - name: run integration tests with userNS enabled + alternate results file
+      shell: "make localintegration >& {{ crio_integration_userns_filepath }}"
+      args:
+        chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o"
+      environment: '{{ int_test_env | combine(userns_int_test_env) }} '
       async: '{{ 60 * 30 }}'  # seconds
       poll: 30
 

--- a/contrib/test/integration/test.yml
+++ b/contrib/test/integration/test.yml
@@ -7,14 +7,6 @@
     regexp: ' go test \"\$'
     state: present
 
-- name: Usernamespace integration testing uses updated environment variables
-  set_fact:
-    # Keys/Values in userns_int_test_env update int_test_env (from vars.yml)
-    int_test_env: '{{ int_test_env | combine(userns_int_test_env) }}'
-  tags:
-    - integration
-    - userns
-
 - name: ensure directory exists for e2e reports
   file:
     path: "{{ artifacts }}"
@@ -30,7 +22,7 @@
       shell: "{{ int_test_cmd }}"
       args:
         chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o"
-      environment: '{{ int_test_env }}'  # from vars.yml
+      environment: '{{ int_test_env }}'  # from vars.yml and main.yml
       async: '{{ 60 * 30 }}'  # seconds
       poll: 30
 

--- a/contrib/test/integration/vars.yml
+++ b/contrib/test/integration/vars.yml
@@ -8,14 +8,12 @@ node_e2e_selinux_enabled: False
 # For results.yml Paths use rsync 'source' conventions
 artifacts: "/tmp/artifacts"  # Base-directory for collection
 crio_integration_filepath: "{{ artifacts }}/testout.txt"
+crio_integration_userns_filepath: "{{ artifacts }}/testout_userns.txt"
 crio_node_e2e_filepath: "{{ artifacts }}/junit_01.xml"
 result_dest_basedir: '{{ lookup("env","WORKSPACE") |
                          default(playbook_dir, True) }}/artifacts'
 
-# The shell command to execute the integration tests
-int_test_cmd: "make localintegration >& {{ crio_integration_filepath }}"
-
-# Environment variables to set when executing int_test_cmd
+# Environment variables to set when executing integration tests
 int_test_env:
     CGROUP_MANAGER: "cgroupfs"
     STORAGE_OPTIONS: >
@@ -24,6 +22,6 @@ int_test_env:
             --storage-opt overlay.override_kernel_check=1
         {% endif %}
 
-# Additional environment variables for int_test_cmd with usernamespaces
+# Additional environment variables for integration tests w/ userNS enabled
 userns_int_test_env:
     TEST_USERNS: "1"  # Consumed by test/test_runner.sh, by way of Makefile

--- a/contrib/test/integration/vars.yml
+++ b/contrib/test/integration/vars.yml
@@ -11,3 +11,15 @@ crio_integration_filepath: "{{ artifacts }}/testout.txt"
 crio_node_e2e_filepath: "{{ artifacts }}/junit_01.xml"
 result_dest_basedir: '{{ lookup("env","WORKSPACE") |
                          default(playbook_dir, True) }}/artifacts'
+
+# The shell command to execute the integration tests
+int_test_cmd: "make localintegration >& {{ crio_integration_filepath }}"
+
+# Environment variables to set when executing int_test_cmd
+int_test_env:
+    CGROUP_MANAGER: "cgroupfs"
+    STORAGE_OPTIONS: "STORAGE_OPTIONS=--storage-driver=overlay{{ extra_storage_opts | default('') }}"
+
+# Additional environment variables for int_test_cmd with usernamespaces
+userns_int_test_env:
+    TEST_USERNS: "1"

--- a/contrib/test/integration/vars.yml
+++ b/contrib/test/integration/vars.yml
@@ -18,7 +18,11 @@ int_test_cmd: "make localintegration >& {{ crio_integration_filepath }}"
 # Environment variables to set when executing int_test_cmd
 int_test_env:
     CGROUP_MANAGER: "cgroupfs"
-    STORAGE_OPTIONS: "STORAGE_OPTIONS=--storage-driver=overlay{{ extra_storage_opts | default('') }}"
+    STORAGE_OPTIONS: >
+        --storage-driver=overlay
+        {% if ansible_distribution in ['RedHat', 'CentOS'] %}
+            --storage-opt overlay.override_kernel_check=1
+        {% endif %}
 
 # Additional environment variables for int_test_cmd with usernamespaces
 userns_int_test_env:

--- a/contrib/test/integration/vars.yml
+++ b/contrib/test/integration/vars.yml
@@ -26,4 +26,4 @@ int_test_env:
 
 # Additional environment variables for int_test_cmd with usernamespaces
 userns_int_test_env:
-    TEST_USERNS: "1"
+    TEST_USERNS: "1"  # Consumed by test/test_runner.sh, by way of Makefile


### PR DESCRIPTION
**- What I did**

* Added a new tag to enables running the integration tests with usernamespaces.
* Updated the README.md regarding the new ``userns`` tag.
* Improved the [POLA](https://en.wikipedia.org/wiki/Principle_of_least_astonishment)-ness of the integration test command-line and environment variables.
* Minor: Removed two unnecessary and disused files.

**- How I did it**

Leverage the ``environment`` task argument for passing in a dictionary of environment variables to be used.  Define the test-command, and two sets of environment variables in the ``vars.yml`` file.  When the ``userns`` tag is specified in addition to the ``integration`` tag, the two env. var. dictionaries will be combined, enabling usernamespace testing by the test command.

Utilize some jinja2 template logic to simplify the ``--storage-driver`` and ``--storage-opt`` values for RHEL/CentOS vs Fedora testing.  This allows all definitions to exist in one place, without secondary, conditional mangling.

**- How to verify it**

A special/custom OriginCI testing job will be necessary to test these changes.  There is no other method available in this repo., to affect the runtime tags used by the ansible-playbook command.