### PR TITLE
Add dynamic TLS Configuration for the streaming server

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -46,6 +46,22 @@ stream_address = "{{ .StreamAddress }}"
 # stream_port is the port on which the stream server will listen
 stream_port = "{{ .StreamPort }}"
 
+# stream_enable_tls enables encrypted tls transport of the stream server
+stream_enable_tls = {{ .StreamEnableTLS }}
+
+# stream_tls_cert is the x509 certificate file path used to serve the encrypted stream.
+# This file can change, and CRIO will automatically pick up the changes within 5 minutes.
+stream_tls_cert = "{{ .StreamTLSCert }}"
+
+# stream_tls_key is the key file path used to serve the encrypted stream.
+# This file can change, and CRIO will automatically pick up the changes within 5 minutes.
+stream_tls_key = "{{ .StreamTLSKey }}"
+
+# stream_tls_ca is the x509 CA(s) file used to verify and authenticate client
+# communication with the tls encrypted stream.
+# This file can change, and CRIO will automatically pick up the changes within 5 minutes.
+stream_tls_ca = "{{ .StreamTLSCA }}"
+
 # file_locking is whether file-based locking will be used instead of
 # in-memory locking
 file_locking = {{ .FileLocking }}

--- a/server/config.go
+++ b/server/config.go
@@ -30,6 +30,19 @@ type APIConfig struct {
 
 	// StreamPort is the port on which the stream server will listen.
 	StreamPort string `toml:"stream_port"`
+
+	// StreamEnableTLS enables encrypted tls transport of the stream server
+	StreamEnableTLS bool `toml:"stream_enable_tls"`
+
+	// StreamTLSCert is the x509 certificate file path used to serve the encrypted stream
+	StreamTLSCert string `toml:"stream_tls_cert"`
+
+	// StreamTLSKey is the key file path used to serve the encrypted stream
+	StreamTLSKey string `toml:"stream_tls_key"`
+
+	// StreamTLSCA is the x509 CA(s) file used to verify and authenticate client
+	// communication with the tls encrypted stream
+	StreamTLSCA string `toml:"stream_tls_ca"`
 }
 
 // tomlConfig is another way of looking at a Config, which is


### PR DESCRIPTION
Signed-off-by: Nathan Sweet <nathanjsweet@gmail.com>

fixes: #1582 

**- What I did**
Add Dyanmic TLS Configuration for the streaming server. Optional CA verification is added, though kubernetes doesn't seem to be requesting the streaming server with a client cert, the option is there to add it.

**- How I did it**
I simply added a TLSConfig object to stream server config object, that implements GetConfigForClient method.
**- How to verify it**
Start crio, add the `tls_streaming`, `tls_cert`, and `tls_key` options, using the kubelet cert and key for testing. The kube-apiserver also needs to have the CA set that also signed these certs.
**- Description for the changelog**
Added TLS Encryption to the streaming server
