### PR TITLE
.travis.yml: One stage for integration tests (userns and otherwise)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,9 @@ jobs:
       script:
         - make integration
       go: "1.10.x"
-    - stage: Integration Test with User namespaces enabled
-      script:
-        - TEST_USERNS=1 make integration
+    - script:
+        - make integration
+      env: TEST_USERNS=1
       go: "1.10.x"
   allow_failures:
     - os: osx


### PR DESCRIPTION
The separate stage is from 4964bd9d (#1578), but using a separate stage meant that Travis serialized these slow (20+ minute) stages.  By flattening into one stage we can run these in parallel (modulo Travis worker availability) and get the Travis results earlier.

I've shifted the `TEST_USERNS` declaration into an `env` property so it shows up in the Travis UI (e.g. [here][1]).

[1]: https://travis-ci.org/kubernetes-incubator/cri-o/builds/388442789