### PR TITLE
.travis.yml: Add missing $ to OSTree guard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 install:
   - make install.tools
   - >
-    if [ "{TRAVIS_OS_NAME}" = linux ]; then
+    if [ "${TRAVIS_OS_NAME}" = linux ]; then
       OSTREE_VERSION=v2017.9;
       git clone https://github.com/ostreedev/ostree ${TRAVIS_BUILD_DIR}/ostree &&
       (


### PR DESCRIPTION
I'd missed this in f06674b9 (#1428).  Without the `$`, OSTree was never being compiled, even on Linux.