### PR TITLE
conmon: fix incorrect log line on a log refresh

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -239,6 +239,7 @@ static ssize_t writev_buffer_flush(int fd, writev_buffer_t *buf)
 		while (res > 0) {
 			size_t from_this = MIN((size_t)res, iov->iov_len);
 			iov->iov_len -= from_this;
+			iov->iov_base += from_this;
 			res -= from_this;
 
 			if (iov->iov_len == 0) {

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -399,6 +399,9 @@ static int write_k8s_log(int fd, stdpipe_t pipe, const char *buf, ssize_t buflen
 		if ((opt_log_size_max > 0) && (bytes_written + bytes_to_be_written) > opt_log_size_max) {
 			bytes_written = 0;
 
+			if (writev_buffer_flush(fd, &bufv) < 0) {
+				nwarn("failed to flush buffer to log");
+			}
 			reopen_log_file();
 
 			/* Reassign to the new log file fd */


### PR DESCRIPTION
**- How I did it**
flushing the current data before reopening the log file

**- How to verify it**
every log file starts with a proper k8s timestamp on the first line https://bugzilla.redhat.com/show_bug.cgi?id=1588410

**- Description for the changelog**
conmon doesn't write invalid log lines when the log file is refreshed
