### PR TITLE
[release-1.10] conmon: fix incorrect log line on a log refresh

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -232,6 +232,7 @@ static ssize_t writev_buffer_flush (int fd, writev_buffer_t *buf)
 		while (res > 0) {
 			size_t from_this = MIN((size_t)res, iov->iov_len);
 			iov->iov_len -= from_this;
+			iov->iov_base += from_this;
 			res -= from_this;
 
 			if (iov->iov_len == 0) {

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -395,6 +395,9 @@ static int write_k8s_log(int fd, stdpipe_t pipe, const char *buf, ssize_t buflen
 		if ((opt_log_size_max > 0) && (bytes_written + bytes_to_be_written) > opt_log_size_max) {
 			bytes_written = 0;
 
+			if (writev_buffer_flush(fd, &bufv) < 0) {
+				nwarn("failed to flush buffer to log");
+			}
 			reopen_log_file();
 
 			/* Reassign to the new log file fd */


### PR DESCRIPTION
backport of https://github.com/kubernetes-incubator/cri-o/pull/1606