### PR TITLE
server: fix race between container create and cadvisor asking for info

### DIFF
--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -779,6 +779,13 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, fmt.Errorf("failed to write runtime configuration for pod sandbox %s(%s): %v", sb.Name(), id, err)
 	}
 
+	s.addInfraContainer(container)
+	defer func() {
+		if err != nil {
+			s.removeInfraContainer(container)
+		}
+	}()
+
 	if err = s.createContainer(container, nil, sb.CgroupParent()); err != nil {
 		return nil, err
 	}
@@ -786,8 +793,6 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	if err = s.Runtime().StartContainer(container); err != nil {
 		return nil, err
 	}
-
-	s.addInfraContainer(container)
 
 	s.ContainerStateToDisk(container)
 


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

same as #1616 but for master

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
