### PR TITLE
[release-1.9] server: fix race between container create and cadvisor asking for info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,8 @@ jobs:
       script:
         - make integration
       go: 1.8.x
+  allow_failures:
+    - go: tip
 
 notifications:
   irc: "chat.freenode.net#cri-o"

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -592,14 +592,25 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 		}
 	}()
 
-	if err = s.Runtime().CreateContainer(container, sb.CgroupParent()); err != nil {
-		return nil, err
-	}
-
 	s.addContainer(container)
+	defer func() {
+		if err != nil {
+			s.removeContainer(container)
+		}
+	}()
 
 	if err = s.CtrIDIndex().Add(containerID); err != nil {
-		s.removeContainer(container)
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			if err2 := s.CtrIDIndex().Delete(containerID); err2 != nil {
+				logrus.Warnf("couldn't delete ctr id %s from idIndex", containerID)
+			}
+		}
+	}()
+
+	if err = s.Runtime().CreateContainer(container, sb.CgroupParent()); err != nil {
 		return nil, err
 	}
 

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -533,11 +533,16 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, fmt.Errorf("failed to write runtime configuration for pod sandbox %s(%s): %v", sb.Name(), id, err)
 	}
 
+	s.addInfraContainer(container)
+	defer func() {
+		if err != nil {
+			s.removeInfraContainer(container)
+		}
+	}()
+
 	if err = s.runContainer(container, sb.CgroupParent()); err != nil {
 		return nil, err
 	}
-
-	s.addInfraContainer(container)
 
 	s.ContainerStateToDisk(container)
 


### PR DESCRIPTION
We create (and run) the containers before adding their info in memory.
Cadvisor queries our /containers/{id} info endpoint as soon as cgroups
show up on the system. That means there's a race between cgroups
creation and info available in memory in CRI-O.
Fix this race by putting containers info in memory prior to actually
creawting the containers with the runtime.
Tested on kube 1.10, I'm not able to reproduce the following error in
kubelet.log:

Failed to process watch event {EventType:0
Name:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod5b7ccb19_6f87_11e8_86dd_0eb037b2774e.slice/crio-e6ccc38071c3b403accd153c11775f7fd933305f31b551d4b6c6597692ce777d.scope
WatchSource:0}: invalid character 'c' looking for beginning of value

The "invalid character 'c' looking for beginning of value" is just
json.Decode failing when we don't find the container in the CRI-O
memory store and just return "can't find ..." (hence, the 'c' above).

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
