### PR TITLE
Make logging to syslog optional

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -172,6 +172,9 @@ func (r *Runtime) CreateContainer(c *Container, cgroupParent string) (err error)
 	if r.cgroupManager == SystemdCgroupsManager {
 		args = append(args, "-s")
 	}
+	if r.cgroupManager == CgroupfsCgroupsManager {
+		args = append(args, "--syslog")
+	}
 	args = append(args, "-c", c.id)
 	args = append(args, "-u", c.id)
 	args = append(args, "-r", r.Path(c))


### PR DESCRIPTION
Fixes #1604 

@runcom @rhatdan @giuseppe PTAL

**- What I did**
Made logging to syslog optional.

**- How I did it**
Added a --syslog flag to conmon.

**- How to verify it**
We don't see double logging while using systemd cgroups.

**- Description for the changelog**
Add a --syslog flag to conmon.
