### PR TITLE
[release-1.10] Port lvm_cleanup from master branch

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -318,10 +318,20 @@ function restart_crio() {
 	fi
 }
 
+function cleanup_lvm() {
+	if [ "$LVM_DEVICE" != "" ]; then
+		lvm lvremove -y storage/thinpool
+		lvm vgremove -y storage
+		lvm pvremove -y $LVM_DEVICE
+	fi
+}
+
+
 function cleanup_test() {
 	cleanup_ctrs
 	cleanup_pods
 	stop_crio
+	cleanup_lvm
 	rm -rf "$TESTDIR"
 }
 


### PR DESCRIPTION
lvm_cleanup function is used for testing CRI-O
with devicemapper driver.
This should fix the errors on the Kata Containers CI.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
