### PR TITLE
[release 1.10] network: Fix manage NetworkNS lifecycle

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -372,12 +372,13 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 
 	privileged := isTrue(m.Annotations[annotations.PrivilegedRuntime])
 	trusted := isTrue(m.Annotations[annotations.TrustedSandbox])
+	hostNetwork := isTrue(m.Annotations[annotations.HostNetwork])
 	nsOpts := pb.NamespaceOption{}
 	if err := json.Unmarshal([]byte(m.Annotations[annotations.NamespaceOptions]), &nsOpts); err != nil {
 		return err
 	}
 
-	sb, err := sandbox.New(id, m.Annotations[annotations.Namespace], name, m.Annotations[annotations.KubeName], filepath.Dir(m.Annotations[annotations.LogPath]), labels, kubeAnnotations, processLabel, mountLabel, &metadata, m.Annotations[annotations.ShmPath], m.Annotations[annotations.CgroupParent], privileged, trusted, m.Annotations[annotations.ResolvPath], m.Annotations[annotations.HostName], portMappings)
+	sb, err := sandbox.New(id, m.Annotations[annotations.Namespace], name, m.Annotations[annotations.KubeName], filepath.Dir(m.Annotations[annotations.LogPath]), labels, kubeAnnotations, processLabel, mountLabel, &metadata, m.Annotations[annotations.ShmPath], m.Annotations[annotations.CgroupParent], privileged, trusted, m.Annotations[annotations.ResolvPath], m.Annotations[annotations.HostName], portMappings, hostNetwork)
 	if err != nil {
 		return err
 	}

--- a/lib/sandbox/sandbox.go
+++ b/lib/sandbox/sandbox.go
@@ -190,7 +190,7 @@ var (
 // New creates and populates a new pod sandbox
 // New sandboxes have no containers, no infra container, and no network namespaces associated with them
 // An infra container must be attached before the sandbox is added to the state
-func New(id, namespace, name, kubeName, logDir string, labels, annotations map[string]string, processLabel, mountLabel string, metadata *pb.PodSandboxMetadata, shmPath, cgroupParent string, privileged, trusted bool, resolvPath, hostname string, portMappings []*hostport.PortMapping) (*Sandbox, error) {
+func New(id, namespace, name, kubeName, logDir string, labels, annotations map[string]string, processLabel, mountLabel string, metadata *pb.PodSandboxMetadata, shmPath, cgroupParent string, privileged, trusted bool, resolvPath, hostname string, portMappings []*hostport.PortMapping, hostNetwork bool) (*Sandbox, error) {
 	sb := new(Sandbox)
 	sb.id = id
 	sb.namespace = namespace
@@ -211,6 +211,7 @@ func New(id, namespace, name, kubeName, logDir string, labels, annotations map[s
 	sb.hostname = hostname
 	sb.portMappings = portMappings
 	sb.created = time.Now()
+	sb.hostNetwork = hostNetwork
 
 	return sb, nil
 }
@@ -329,7 +330,7 @@ func (s *Sandbox) Trusted() bool {
 
 // HostNetwork returns whether the sandbox runs in the host network namespace
 func (s *Sandbox) HostNetwork() bool {
-	return s.NamespaceOptions().GetNetwork() == pb.NamespaceMode_NODE
+	return s.hostNetwork
 }
 
 // ResolvPath returns the resolv path for the sandbox

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -96,6 +96,9 @@ const (
 
 	// Volumes is the volumes annotatoin
 	Volumes = "io.kubernetes.cri-o.Volumes"
+
+	// HostNetwork indicates whether the host network namespace is used or not
+	HostNetwork = "io.kubernetes.cri-o.HostNetwork"
 )
 
 // ContainerType values

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -378,6 +378,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	g.AddAnnotation(annotations.HostName, hostname)
 	g.AddAnnotation(annotations.NamespaceOptions, string(nsOptsJSON))
 	g.AddAnnotation(annotations.KubeName, kubeName)
+	g.AddAnnotation(annotations.HostNetwork, fmt.Sprintf("%v", hostNetwork))
 	if podContainer.Config.Config.StopSignal != "" {
 		// this key is defined in image-spec conversion document at https://github.com/opencontainers/image-spec/pull/492/files#diff-8aafbe2c3690162540381b8cdb157112R57
 		g.AddAnnotation("org.opencontainers.image.stopSignal", podContainer.Config.Config.StopSignal)
@@ -416,7 +417,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 	g.AddAnnotation(annotations.CgroupParent, cgroupParent)
 
-	sb, err := sandbox.New(id, namespace, name, kubeName, logDir, labels, kubeAnnotations, processLabel, mountLabel, metadata, shmPath, cgroupParent, privileged, trusted, resolvPath, hostname, portMappings)
+	sb, err := sandbox.New(id, namespace, name, kubeName, logDir, labels, kubeAnnotations, processLabel, mountLabel, metadata, shmPath, cgroupParent, privileged, trusted, resolvPath, hostname, portMappings, hostNetwork)
 	if err != nil {
 		return nil, err
 	}

--- a/server/sandbox_status_test.go
+++ b/server/sandbox_status_test.go
@@ -46,7 +46,7 @@ func newTestContainerServerOrFailNow(t *testing.T) (cs *lib.ContainerServer, dir
 func newTestSandboxOrFailNow(t *testing.T) (string, *sandbox.Sandbox) {
 	id := fmt.Sprintf("id-for-sandbox-%d", rand.Int())
 
-	sb, err := sandbox.New(id, "", "", "", "", nil, nil, "", "", nil, "", "", false, false, "", "", nil)
+	sb, err := sandbox.New(id, "", "", "", "", nil, nil, "", "", nil, "", "", false, false, "", "", nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is a port to the release-1.10 branch. Original PR was 
https://github.com/kubernetes-incubator/cri-o/pull/1524

After port ManageNetworkNSLifecycle from 1.9 branch the logic
was modified to not save the host network state from the sandbox.

This commit restore the logic to save if the sandbox host network. It saves
if the sandbox is using network host-namespace. Then when a container is
created LoadSandbox will check for the annotation to know if the sandbox
where the container is created was using host NetworkNS.
was modified to not save the hostnetwork state from the sandbox.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
