### PR TITLE
conmon: do not use an empty env when running the exit command

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -1240,7 +1240,7 @@ static void do_exit_command()
 			args[n_args + 1] = opt_exit_args[n_args];
 	args[n_args + 1] = NULL;
 
-	execve(opt_exit_command, args, NULL);
+	execv(opt_exit_command, args);
 
 	/* Should not happen, but better be safe. */
 	_exit(EXIT_FAILURE);


### PR DESCRIPTION
**- What I did**

fixed an error where the exit command was launched with an empty environment

**- How I did it**

leaving the original env from conmon

**- How to verify it**
https://github.com/projectatomic/libpod/pull/942 works

**- Description for the changelog**

the exit command launched by conmon has a valid environment