### PR TITLE
[1.11] Reduce amount of logs being printed by default

### DIFF
--- a/cmd/crio/selinux_unsupported.go
+++ b/cmd/crio/selinux_unsupported.go
@@ -5,5 +5,5 @@ package main
 import "github.com/sirupsen/logrus"
 
 func disableSELinux() {
-	logrus.Infof("there is no selinux to disable")
+	logrus.Debugf("there is no selinux to disable")
 }

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -1044,7 +1044,9 @@ static void runtime_exit_cb(G_GNUC_UNUSED GPid pid, int status, G_GNUC_UNUSED gp
 
 static void container_exit_cb(G_GNUC_UNUSED GPid pid, int status, G_GNUC_UNUSED gpointer user_data)
 {
-	ninfof("container %d exited with status %d", pid, get_exit_status(status));
+	if (get_exit_status(status) != 0) {
+		ninfof("container %d exited with status %d", pid, get_exit_status(status));
+	}
 	container_status = status;
 	container_pid = -1;
 	g_main_loop_quit(main_loop);
@@ -1573,7 +1575,6 @@ int main(int argc, char *argv[])
 	if (signal(SIGCHLD, on_sigchld) == SIG_ERR)
 		pexit("Failed to set handler for SIGCHLD");
 
-	ninfof("about to waitpid: %d", create_pid);
 	if (csname != NULL) {
 		guint terminal_watch = g_unix_fd_add(console_socket_fd, G_IO_IN, terminal_accept_cb, csname);
 		/* Process any SIGCHLD we may have missed before the signal handler was in place.  */
@@ -1657,13 +1658,13 @@ int main(int argc, char *argv[])
 
 	g_main_loop_run(main_loop);
 
-	/* Drain stdout and stderr */
-	if (masterfd_stdout != -1) {
+	/* Drain stdout and stderr only if a timeout doesn't occur */
+	if (masterfd_stdout != -1 && !timed_out) {
 		g_unix_set_fd_nonblocking(masterfd_stdout, TRUE, NULL);
 		while (read_stdio(masterfd_stdout, STDOUT_PIPE, NULL))
 			;
 	}
-	if (masterfd_stderr != -1) {
+	if (masterfd_stderr != -1 && !timed_out) {
 		g_unix_set_fd_nonblocking(masterfd_stderr, TRUE, NULL);
 		while (read_stdio(masterfd_stderr, STDERR_PIPE, NULL))
 			;

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -478,7 +478,7 @@ func (r *Runtime) ExecSync(c *Container, command []string, timeout int64) (resp 
 		}
 	}
 
-	logrus.Infof("Received container exit code: %v, message: %s", ec.ExitCode, ec.Message)
+	logrus.Debugf("Received container exit code: %v, message: %s", ec.ExitCode, ec.Message)
 
 	if ec.ExitCode == -1 {
 		return nil, ExecSyncError{

--- a/oci/oci_linux.go
+++ b/oci/oci_linux.go
@@ -17,7 +17,7 @@ import (
 func (r *Runtime) createContainerPlatform(c *Container, cgroupParent string, pid int) error {
 	// Move conmon to specified cgroup
 	if r.cgroupManager == SystemdCgroupsManager {
-		logrus.Infof("Running conmon under slice %s and unitName %s", cgroupParent, createUnitName("crio-conmon", c.id))
+		logrus.Debugf("Running conmon under slice %s and unitName %s", cgroupParent, createUnitName("crio-conmon", c.id))
 		if err := utils.RunUnderSystemdScope(pid, cgroupParent, createUnitName("crio-conmon", c.id)); err != nil {
 			logrus.Warnf("Failed to add conmon to systemd sandbox cgroup: %v", err)
 		}

--- a/pkg/storage/runtime.go
+++ b/pkg/storage/runtime.go
@@ -278,13 +278,13 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 		if err != nil {
 			if err2 := r.storageImageServer.GetStore().DeleteContainer(container.ID); err2 != nil {
 				if metadata.Pod {
-					logrus.Infof("%v deleting partially-created pod sandbox %q", err2, container.ID)
+					logrus.Debugf("%v deleting partially-created pod sandbox %q", err2, container.ID)
 				} else {
-					logrus.Infof("%v deleting partially-created container %q", err2, container.ID)
+					logrus.Debugf("%v deleting partially-created container %q", err2, container.ID)
 				}
 				return
 			}
-			logrus.Infof("deleted partially-created container %q", container.ID)
+			logrus.Debugf("deleted partially-created container %q", container.ID)
 		}
 	}()
 

--- a/server/container_attach.go
+++ b/server/container_attach.go
@@ -66,10 +66,10 @@ func (ss streamService) Attach(containerID string, inputStream io.Reader, output
 	defer controlFile.Close()
 
 	kubecontainer.HandleResizing(resize, func(size remotecommand.TerminalSize) {
-		logrus.Infof("Got a resize event: %+v", size)
+		logrus.Debugf("Got a resize event: %+v", size)
 		_, err := fmt.Fprintf(controlFile, "%d %d %d\n", 1, size.Height, size.Width)
 		if err != nil {
-			logrus.Infof("Failed to write to control file to resize terminal: %v", err)
+			logrus.Debugf("Failed to write to control file to resize terminal: %v", err)
 		}
 	})
 
@@ -125,7 +125,7 @@ func redirectResponseToOutputStreams(outputStream, errorStream io.Writer, conn i
 			} else if buf[0] == AttachPipeStderr {
 				dst = errorStream
 			} else {
-				logrus.Infof("Got unexpected attach type %+d", buf[0])
+				logrus.Debugf("Got unexpected attach type %+d", buf[0])
 			}
 
 			if dst != nil {

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -348,7 +348,7 @@ func addDevices(sb *sandbox.Sandbox, containerConfig *pb.ContainerConfig, specge
 				// mount the internal devices recursively
 				filepath.Walk(path, func(dpath string, f os.FileInfo, e error) error {
 					if e != nil {
-						logrus.Infof("addDevice walk: %v", e)
+						logrus.Debugf("addDevice walk: %v", e)
 					}
 					childDevice, e := devices.DeviceFromPath(dpath, device.Permissions)
 					if e != nil {

--- a/server/container_reopen_log.go
+++ b/server/container_reopen_log.go
@@ -82,7 +82,7 @@ func (s *Server) ReopenContainerLog(ctx context.Context, req *pb.ReopenContainer
 	}
 
 	if _, err = fmt.Fprintf(controlFile, "%d %d %d\n", 2, 0, 0); err != nil {
-		logrus.Infof("Failed to write to control file to reopen log file: %v", err)
+		logrus.Debugf("Failed to write to control file to reopen log file: %v", err)
 	}
 
 	select {


### PR DESCRIPTION
Changed the Info logs to Debug logs so that it is only
logged if an error occurs or if the log-level is set to debug.
In conmon, only log container status if it is non-zero and removed
the "about to waitpid" logs.
Also only drain stdout and stderr if a timeout does not occur.

Signed-off-by: umohnani8 <umohnani@redhat.com>