### PR TITLE
tests: Add timeout before stop container.

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -180,10 +180,7 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run crictl stop "$ctr_id"
-	echo "$output"
-	# Ignore errors on stop.
-	run crictl inspect "$ctr_id"
+	run wait_until_exit "$ctr_id"
 	[ "$status" -eq 0 ]
 	run crictl rm "$ctr_id"
 	echo "$output"
@@ -227,10 +224,7 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run crictl stop "$ctr_id"
-	echo "$output"
-	# Ignore errors on stop.
-	run crictl inspect "$ctr_id"
+	run wait_until_exit "$ctr_id"
 	[ "$status" -eq 0 ]
 	run crictl rm "$ctr_id"
 	echo "$output"
@@ -272,8 +266,7 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	sleep 6
-	run crictl inspect "$ctr_id"
+	run wait_until_exit "$ctr_id"
 	[ "$status" -eq 0 ]
 	run crictl rm "$ctr_id"
 	echo "$output"
@@ -316,10 +309,7 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run crictl stop "$ctr_id"
-	echo "$output"
-	# Ignore errors on stop.
-	run crictl inspect "$ctr_id"
+	run wait_until_exit "$ctr_id"
 	[ "$status" -eq 0 ]
 	run crictl rm "$ctr_id"
 	echo "$output"
@@ -948,20 +938,8 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	# Wait for container to exit
-	attempt=0
-	while [ $attempt -le 100 ]; do
-		attempt=$((attempt+1))
-		run crictl inspect "$ctr_id" --output table
-		echo "$output"
-		[ "$status" -eq 0 ]
-		if [[ "$output" =~ "State: CONTAINER_EXITED" ]]; then
-			[[ "$output" =~ "Exit Code: 0" ]]
-			break
-		fi
-		sleep 1
-	done
-
+	run wait_until_exit "$ctr_id"
+	[ "$status" -eq 0 ]
 	run crictl create "$pod_id" "$TESTDATA"/container_config_resolvconf_ro.json "$TESTDATA"/sandbox_config.json
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -969,19 +947,8 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	# Wait for container to exit
-	attempt=0
-	while [ $attempt -le 100 ]; do
-		attempt=$((attempt+1))
-		run crictl inspect "$ctr_id" --output table
-		echo "$output"
-		[ "$status" -eq 0 ]
-		if [[ "$output" =~ "State: CONTAINER_EXITED" ]]; then
-			break
-		fi
-		sleep 1
-	done
-
+	run wait_until_exit "$ctr_id"
+	[ "$status" -eq 0 ]
 	cleanup_ctrs
 	cleanup_pods
 	stop_crio

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -499,3 +499,21 @@ function cleanup_network_conf() {
 function temp_sandbox_conf() {
 	sed -e s/\"namespace\":.*/\"namespace\":\ \"$1\",/g "$TESTDATA"/sandbox_config.json > $TESTDIR/sandbox_config_$1.json
 }
+
+function wait_until_exit() {
+	ctr_id=$1
+	# Wait for container to exit
+	attempt=0
+	while [ $attempt -le 100 ]; do
+		attempt=$((attempt+1))
+		run crictl inspect "$ctr_id" --output table
+		echo "$output"
+		[ "$status" -eq 0 ]
+		if [[ "$output" =~ "State: CONTAINER_EXITED" ]]; then
+			[[ "$output" =~ "Exit Code: 0" ]]
+			return 0
+		fi
+		sleep 1
+	done
+	return 1
+}


### PR DESCRIPTION
Starting a container and then stoping it right away can
be racy in some slow environments.
Add a sleep of 5 seconds to let the process finish correctly
before stoping the container.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
