### PR TITLE
server: Don't make additional copy of config.json

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -322,7 +322,7 @@ func (c *ContainerServer) Update() error {
 
 // LoadSandbox loads a sandbox from the disk into the sandbox store
 func (c *ContainerServer) LoadSandbox(id string) error {
-	config, err := c.store.FromContainerDirectory(id, "config.json")
+	config, err := c.store.FromContainerRunDirectory(id, "config.json")
 	if err != nil {
 		return err
 	}
@@ -410,11 +410,6 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		return err
 	}
 
-	sandboxDir, err := c.store.ContainerDirectory(id)
-	if err != nil {
-		return err
-	}
-
 	cname, err := c.ReserveContainerName(m.Annotations[annotations.ContainerID], m.Annotations[annotations.ContainerName])
 	if err != nil {
 		return err
@@ -430,7 +425,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		return err
 	}
 
-	scontainer, err := oci.NewContainer(m.Annotations[annotations.ContainerID], cname, sandboxPath, m.Annotations[annotations.LogPath], sb.NetNs().Path(), labels, m.Annotations, kubeAnnotations, "", "", "", nil, id, false, false, false, privileged, trusted, sandboxDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
+	scontainer, err := oci.NewContainer(m.Annotations[annotations.ContainerID], cname, sandboxPath, m.Annotations[annotations.LogPath], sb.NetNs().Path(), labels, m.Annotations, kubeAnnotations, "", "", "", nil, id, false, false, false, privileged, trusted, sandboxPath, created, m.Annotations["org.opencontainers.image.stopSignal"])
 	if err != nil {
 		return err
 	}
@@ -480,7 +475,7 @@ func configNetNsPath(spec rspec.Spec) (string, error) {
 
 // LoadContainer loads a container from the disk into the container store
 func (c *ContainerServer) LoadContainer(id string) error {
-	config, err := c.store.FromContainerDirectory(id, "config.json")
+	config, err := c.store.FromContainerRunDirectory(id, "config.json")
 	if err != nil {
 		return err
 	}
@@ -522,11 +517,6 @@ func (c *ContainerServer) LoadContainer(id string) error {
 		return err
 	}
 
-	containerDir, err := c.store.ContainerDirectory(id)
-	if err != nil {
-		return err
-	}
-
 	img, ok := m.Annotations[annotations.Image]
 	if !ok {
 		img = ""
@@ -552,7 +542,7 @@ func (c *ContainerServer) LoadContainer(id string) error {
 		return err
 	}
 
-	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], sb.NetNs().Path(), labels, m.Annotations, kubeAnnotations, img, imgName, imgRef, &metadata, sb.ID(), tty, stdin, stdinOnce, sb.Privileged(), sb.Trusted(), containerDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
+	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], sb.NetNs().Path(), labels, m.Annotations, kubeAnnotations, img, imgName, imgRef, &metadata, sb.ID(), tty, stdin, stdinOnce, sb.Privileged(), sb.Trusted(), containerPath, created, m.Annotations["org.opencontainers.image.stopSignal"])
 	if err != nil {
 		return err
 	}

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1392,7 +1392,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 
 	crioAnnotations := specgen.Spec().Annotations
 
-	container, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, sb.NetNs().Path(), labels, crioAnnotations, kubeAnnotations, image, imageName, imageRef, metadata, sb.ID(), containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.Privileged(), sb.Trusted(), containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
+	container, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, sb.NetNs().Path(), labels, crioAnnotations, kubeAnnotations, image, imageName, imageRef, metadata, sb.ID(), containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.Privileged(), sb.Trusted(), containerInfo.RunDir, created, containerImageConfig.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}
@@ -1431,9 +1431,6 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	}
 
 	saveOptions := generate.ExportOptions{}
-	if err = specgen.SaveToFile(filepath.Join(containerInfo.Dir, "config.json"), saveOptions); err != nil {
-		return nil, err
-	}
 	if err = specgen.SaveToFile(filepath.Join(containerInfo.RunDir, "config.json"), saveOptions); err != nil {
 		return nil, err
 	}

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -689,7 +689,7 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	g.AddAnnotation(annotations.HostnamePath, hostnamePath)
 	sb.AddHostnamePath(hostnamePath)
 
-	container, err := oci.NewContainer(id, containerName, podContainer.RunDir, logPath, sb.NetNs().Path(), labels, g.Spec().Annotations, kubeAnnotations, "", "", "", nil, id, false, false, false, sb.Privileged(), sb.Trusted(), podContainer.Dir, created, podContainer.Config.Config.StopSignal)
+	container, err := oci.NewContainer(id, containerName, podContainer.RunDir, logPath, sb.NetNs().Path(), labels, g.Spec().Annotations, kubeAnnotations, "", "", "", nil, id, false, false, false, sb.Privileged(), sb.Trusted(), podContainer.RunDir, created, podContainer.Config.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Keep only one copy of config.json under /run
and store the container state there as well.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>



**- What I did**
Removed extra copy of config.json

**- How I did it**
Removed the call to save it under /var/lib/containers

**- How to verify it**
There is only one copy of config.json on disk for the container. Tests pass.

**- Description for the changelog**
`Save only copy of config.json`
