### PR TITLE
tests: remove more sleeps from ctr.bats

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -28,7 +28,8 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run sleep 5
+	wait_until_exit "$ctr_id"
+	[ "$status" -eq 0 ]
 	run crictl inspect --output yaml "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -54,7 +55,8 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run sleep 5
+	EXPECTED_EXIT_STATUS=1 wait_until_exit "$ctr_id"
+	[ "$status" -eq 0 ]
 	run crictl inspect --output yaml "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -510,7 +510,7 @@ function wait_until_exit() {
 		echo "$output"
 		[ "$status" -eq 0 ]
 		if [[ "$output" =~ "State: CONTAINER_EXITED" ]]; then
-			[[ "$output" =~ "Exit Code: 0" ]]
+			[[ "$output" =~ "Exit Code: ${EXPECTED_EXIT_STATUS:-0}" ]]
 			return 0
 		fi
 		sleep 1


### PR DESCRIPTION
Change wait_until_exit function to now also
receive the expected exit status, this way we
can wait for containers that we know will fail.
Which is the case of test #3 of ctr.bats.

Also change sleeps use wait_until_exit on test #2
and #3.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
