### PR TITLE
server: Size = max int32 in inspect.go

### DIFF
--- a/server/inspect.go
+++ b/server/inspect.go
@@ -20,7 +20,7 @@ func (s *Server) getIDMappingsInfo() types.IDMappings {
 		fullMapping := idtools.IDMap{
 			ContainerID: 0,
 			HostID:      0,
-			Size:        4294967295,
+			Size:        2147483647,
 		}
 		return types.IDMappings{
 			Uids: []idtools.IDMap{fullMapping},


### PR DESCRIPTION
fails to build on 32-bit systems otherwise as const overflows int.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@runcom @mrunalp @giuseppe PTAL.

See [prior build failure](https://koji.fedoraproject.org/koji/getfile?taskID=28041528&volume=DEFAULT&name=build.log&offset=-4000)

(or perhaps Size should be a uint in containers/storage???)