### PR TITLE
[release-1.10] tests: remove more sleeps from ctr.bats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq update; fi
   - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq install btrfs-tools libdevmapper-dev libgpgme11-dev libapparmor-dev libseccomp-dev; fi
   - if [ "${TRAVIS_OS_NAME}" = linux ]; then sudo apt-get -qq install autoconf automake bison e2fslibs-dev libfuse-dev libtool liblzma-dev gettext; fi
+  - if [ "${TRAVIS_OS_NAME}" = osx ]; then brew update && brew install gpgme; fi
 
 install:
   - make install.tools

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -310,7 +310,7 @@ func (c *ContainerServer) Update() error {
 		if err = c.LoadSandbox(sandboxID); err != nil {
 			logrus.Warnf("could not load new pod sandbox %s: %v, ignoring", sandboxID, err)
 		} else {
-			logrus.Debugf("loaded new pod sandbox %s", sandboxID, err)
+			logrus.Debugf("loaded new pod sandbox %s: %v", sandboxID, err)
 		}
 	}
 	for containerID := range newPodContainers {
@@ -318,7 +318,7 @@ func (c *ContainerServer) Update() error {
 		if err = c.LoadContainer(containerID); err != nil {
 			logrus.Warnf("could not load new sandbox container %s: %v, ignoring", containerID, err)
 		} else {
-			logrus.Debugf("loaded new pod container %s", containerID, err)
+			logrus.Debugf("loaded new pod container %s: %v", containerID, err)
 		}
 	}
 	return nil

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -423,7 +423,7 @@ func buildOCIProcessArgs(containerKubeConfig *pb.ContainerConfig, imageOCIConfig
 
 // addOCIHook look for hooks programs installed in hooksDirPath and add them to spec
 func addOCIHook(specgen *generate.Generator, hook lib.HookParams) error {
-	logrus.Debugf("AddOCIHook", hook)
+	logrus.Debugf("AddOCIHook %s", hook.Hook)
 	for _, stage := range hook.Stage {
 		h := rspec.Hook{
 			Path: hook.Hook,
@@ -747,7 +747,7 @@ func (s *Server) setupOCIHooks(specgen *generate.Generator, sb *sandbox.Sandbox,
 		return nil
 	}
 	for _, hook := range s.Hooks() {
-		logrus.Debugf("SetupOCIHooks", hook)
+		logrus.Debugf("SetupOCIHooks: %s", hook.Hook)
 		if hook.HasBindMounts && len(mounts) > 0 {
 			if err := addHook(hook); err != nil {
 				return err

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -37,7 +37,7 @@ func (s *Server) filterContainerList(filter *pb.ContainerFilter, origCtrList []*
 		if err != nil {
 			// If we don't find a container ID with a filter, it should not
 			// be considered an error.  Log a warning and return an empty struct
-			logrus.Warn("unable to find container ID %s", filter.Id)
+			logrus.Warnf("unable to find container ID %s", filter.Id)
 			return []*oci.Container{}
 		}
 		c := s.ContainerServer.GetContainer(id)

--- a/server/container_stats_list.go
+++ b/server/container_stats_list.go
@@ -36,7 +36,7 @@ func (s *Server) ListContainerStats(ctx context.Context, req *pb.ListContainerSt
 	for _, container := range ctrList {
 		stats, err := s.GetContainerStats(container, &lib.ContainerStats{})
 		if err != nil {
-			logrus.Warn("unable to get stats for container %s", container.ID())
+			logrus.Warnf("unable to get stats for container %s", container.ID())
 			continue
 		}
 		response := buildContainerStats(stats, container)

--- a/server/sandbox_list.go
+++ b/server/sandbox_list.go
@@ -53,7 +53,7 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxReque
 				// Not finding an ID in a filtered list should not be considered
 				// and error; it might have been deleted when stop was done.
 				// Log and return an empty struct.
-				logrus.Warn("unable to find pod %s with filter", filter.Id)
+				logrus.Warnf("unable to find pod %s with filter", filter.Id)
 				return &pb.ListPodSandboxResponse{}, nil
 			}
 			sb := s.getSandbox(id)

--- a/server/server.go
+++ b/server/server.go
@@ -436,7 +436,7 @@ func (s *Server) StartExitMonitor() {
 						logrus.Debugf("container exited and found: %v", containerID)
 						err := s.Runtime().UpdateStatus(c)
 						if err != nil {
-							logrus.Warnf("Failed to update container status %s: %v", c, err)
+							logrus.Warnf("Failed to update container status %s: %v", containerID, err)
 						} else {
 							s.ContainerStateToDisk(c)
 						}
@@ -447,7 +447,7 @@ func (s *Server) StartExitMonitor() {
 							logrus.Debugf("sandbox exited and found: %v", containerID)
 							err := s.Runtime().UpdateStatus(c)
 							if err != nil {
-								logrus.Warnf("Failed to update sandbox infra container status %s: %v", c, err)
+								logrus.Warnf("Failed to update sandbox infra container status %s: %v", c.ID(), err)
 							} else {
 								s.ContainerStateToDisk(c)
 							}

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -28,7 +28,8 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run sleep 5
+	wait_until_exit "$ctr_id"
+	[ "$status" -eq 0 ]
 	run crictl inspect --output yaml "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
@@ -54,7 +55,8 @@ function teardown() {
 	run crictl start "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
-	run sleep 5
+	EXPECTED_EXIT_STATUS=1 wait_until_exit "$ctr_id"
+	[ "$status" -eq 0 ]
 	run crictl inspect --output yaml "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -488,7 +488,7 @@ function wait_until_exit() {
 		echo "$output"
 		[ "$status" -eq 0 ]
 		if [[ "$output" =~ "State: CONTAINER_EXITED" ]]; then
-			[[ "$output" =~ "Exit Code: 0" ]]
+			[[ "$output" =~ "Exit Code: ${EXPECTED_EXIT_STATUS:-0}" ]]
 			return 0
 		fi
 		sleep 1


### PR DESCRIPTION
Change wait_until_exit function to now also
receive the expected exit status, this way we
can wait for containers that we know will fail.
Which is the case of test #3 of ctr.bats.

Also change sleeps use wait_until_exit on test #2
and #3.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
