### PR TITLE
server/container_create: Mask /proc/keys

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -1044,6 +1044,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 			for _, mp := range []string{
 				"/proc/acpi",
 				"/proc/kcore",
+				"/proc/keys",
 				"/proc/latency_stats",
 				"/proc/timer_list",
 				"/proc/timer_stats",


### PR DESCRIPTION
[From Justin Cormack][1]:

> This leaks information about keyrings on the host.  Keyrings are not namespaced.

CC @runcom.

[1]: https://github.com/moby/moby/pull/36368#issue-170520321