### PR TITLE
server/container_create: mask /proc/{acpi,keys}

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -907,7 +907,9 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		if containerConfig.GetLinux().GetSecurityContext() != nil &&
 			!containerConfig.GetLinux().GetSecurityContext().Privileged {
 			for _, mp := range []string{
+				"/proc/acpi",
 				"/proc/kcore",
+				"/proc/keys",
 				"/proc/latency_stats",
 				"/proc/timer_list",
 				"/proc/timer_stats",


### PR DESCRIPTION
server/container_create: mask /proc/{acpi,keys}

Signed-off-by: Antonio Murdaca <runcom@redhat.com>
Cherry-picked-by: Valentin Rothberg <vrothberg@suse.com>

Cherry-pick of commit 2bf6b3ced6d3b544aa6609de7712a897eecc2152.
Cc: @runcom 