### PR TITLE
4294967295 does not fit in an int on 32 bit systems

### DIFF
--- a/server/inspect.go
+++ b/server/inspect.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 
 	cimage "github.com/containers/image/types"
@@ -16,11 +17,16 @@ import (
 )
 
 func (s *Server) getIDMappingsInfo() types.IDMappings {
+	max := int64(int(^uint(0) >> 1))
+	if max > math.MaxUint32 {
+		max = math.MaxUint32
+	}
+
 	if s.defaultIDMappings == nil {
 		fullMapping := idtools.IDMap{
 			ContainerID: 0,
 			HostID:      0,
-			Size:        4294967295,
+			Size:        int(max),
 		}
 		return types.IDMappings{
 			Uids: []idtools.IDMap{fullMapping},


### PR DESCRIPTION
Currently cri-o will not build on 32 bit systems.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
