### PR TITLE
[1.10] Add log-level option to conmon and crio.conf

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -118,6 +118,10 @@ pids_limit = {{ .PidsLimit }}
 # Negative values indicate that no limit is imposed.
 log_size_max = {{ .LogSizeMax }}
 
+# log_level changes the verbosity of the logs printed.
+# Options are: error (default), fatal, panic, warn, info, and debug
+log_level = "{{ .LogLevel }}"
+
 # The "crio.image" table contains settings pertaining to the
 # management of OCI images.
 [crio.image]

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -144,6 +144,9 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("image-volumes") {
 		config.ImageVolumes = lib.ImageVolumesType(ctx.GlobalString("image-volumes"))
 	}
+	if ctx.GlobalIsSet("log-level") {
+		config.LogLevel = ctx.GlobalString("log-level")
+	}
 	return nil
 }
 
@@ -229,9 +232,9 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "log-level",
-			Usage: "log messages above specified level: debug, info (default), warn, error, fatal or panic",
+			Value: "error",
+			Usage: "log messages above specified level: debug, info, warn, error (default), fatal or panic",
 		},
-
 		cli.StringFlag{
 			Name:  "pause-command",
 			Usage: "name of the pause command in the pause image",
@@ -375,14 +378,11 @@ func main() {
 
 		logrus.SetFormatter(cf)
 
-		if loglevel := c.GlobalString("log-level"); loglevel != "" {
-			level, err := logrus.ParseLevel(loglevel)
-			if err != nil {
-				return err
-			}
-
-			logrus.SetLevel(level)
+		level, err := logrus.ParseLevel(config.LogLevel)
+		if err != nil {
+			return err
 		}
+		logrus.SetLevel(level)
 
 		if path := c.GlobalString("log"); path != "" {
 			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0666)

--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -56,29 +56,53 @@
 		exit(EXIT_FAILURE);                                           \
 	} while (0)
 
-#define nwarn(s)                                             \
-	do {                                                 \
-		fprintf(stderr, "[conmon:w]: %s\n", s);      \
-		syslog(LOG_INFO, "conmon <nwarn>: %s\n", s); \
-	} while (0)
+#define nwarn(s)                                                     \
+	if (parse_level(opt_log_level) >= WARN_LEVEL) {                                     \
+		do {                                                 \
+			fprintf(stderr, "[conmon:w]: %s\n", s);      \
+			syslog(LOG_INFO, "conmon <nwarn>: %s\n", s); \
+		} while (0);                                         \
+	}
 
-#define nwarnf(fmt, ...)                                                       \
-	do {                                                                   \
-		fprintf(stderr, "[conmon:w]: " fmt "\n", ##__VA_ARGS__);       \
-		syslog(LOG_INFO, "conmon <nwarn>: " fmt " \n", ##__VA_ARGS__); \
-	} while (0)
+#define nwarnf(fmt, ...)                                                               \
+	if (parse_level(opt_log_level) >= WARN_LEVEL) {                                                       \
+		do {                                                                   \
+			fprintf(stderr, "[conmon:w]: " fmt "\n", ##__VA_ARGS__);       \
+			syslog(LOG_INFO, "conmon <nwarn>: " fmt " \n", ##__VA_ARGS__); \
+		} while (0);                                                           \
+	}
 
-#define ninfo(s)                                             \
-	do {                                                 \
-		fprintf(stderr, "[conmon:i]: %s\n", s);      \
-		syslog(LOG_INFO, "conmon <ninfo>: %s\n", s); \
-	} while (0)
+#define ninfo(s)                                                     \
+	if (parse_level(opt_log_level) >= INFO_LEVEL) {                                     \
+		do {                                                 \
+			fprintf(stderr, "[conmon:i]: %s\n", s);      \
+			syslog(LOG_INFO, "conmon <ninfo>: %s\n", s); \
+		} while (0);                                         \
+	}
 
-#define ninfof(fmt, ...)                                                       \
-	do {                                                                   \
-		fprintf(stderr, "[conmon:i]: " fmt "\n", ##__VA_ARGS__);       \
-		syslog(LOG_INFO, "conmon <ninfo>: " fmt " \n", ##__VA_ARGS__); \
-	} while (0)
+#define ninfof(fmt, ...)                                                               \
+	if (parse_level(opt_log_level) >= INFO_LEVEL) {                                                       \
+		do {                                                                   \
+			fprintf(stderr, "[conmon:i]: " fmt "\n", ##__VA_ARGS__);       \
+			syslog(LOG_INFO, "conmon <ninfo>: " fmt " \n", ##__VA_ARGS__); \
+		} while (0);                                                           \
+	}
+
+#define ndebug(s)                                                     \
+	if (parse_level(opt_log_level) >= DEBUG_LEVEL) {                                      \
+		do {                                                  \
+			fprintf(stderr, "[conmon:d]: %s\n", s);       \
+			syslog(LOG_INFO, "conmon <ndebug>: %s\n", s); \
+		} while (0);                                          \
+	}
+
+#define ndebugf(fmt, ...)                                                               \
+	if (parse_level(opt_log_level) >= DEBUG_LEVEL) {                                                        \
+		do {                                                                    \
+			fprintf(stderr, "[conmon:d]: " fmt "\n", ##__VA_ARGS__);        \
+			syslog(LOG_INFO, "conmon <ndebug>: " fmt " \n", ##__VA_ARGS__); \
+		} while (0);                                                            \
+	}
 
 #define _cleanup_(x) __attribute__((cleanup(x)))
 
@@ -146,6 +170,7 @@ static bool opt_no_new_keyring = false;
 static char *opt_exit_command = NULL;
 static gchar **opt_exit_args = NULL;
 static bool opt_replace_listen_pid = false;
+static char *opt_log_level = NULL;
 static GOptionEntry opt_entries[] =
 {
   { "terminal", 't', 0, G_OPTION_ARG_NONE, &opt_terminal, "Terminal", NULL },
@@ -171,8 +196,32 @@ static GOptionEntry opt_entries[] =
   { "log-size-max", 0, 0, G_OPTION_ARG_INT64, &opt_log_size_max, "Maximum size of log file", NULL },
   { "socket-dir-path", 0, 0, G_OPTION_ARG_STRING, &opt_socket_path, "Location of container attach sockets", NULL },
   { "version", 0, 0, G_OPTION_ARG_NONE, &opt_version, "Print the version and exit", NULL },
+  { "log-level", 0, 0, G_OPTION_ARG_STRING, &opt_log_level, "Print debug logs based on log level", NULL },
   { NULL }
 };
+
+/* Different levels of logging */
+typedef enum{
+	EXIT_LEVEL,
+	WARN_LEVEL,
+	INFO_LEVEL,
+	DEBUG_LEVEL,
+} log_level_t;
+
+/* Parse_level parses the string value of the --log_level flag to its matching enum */
+static log_level_t parse_level(char *level_name) {
+	if (!strcmp(level_name, "error") || !strcmp(level_name, "fatal") || !strcmp(level_name, "panic")) {
+		return EXIT_LEVEL;
+	} else if (!strcmp(level_name, "warn") || !strcmp(level_name, "warning")) {
+		return WARN_LEVEL;
+	} else if (!strcmp(level_name, "info")) {
+		return INFO_LEVEL;
+	} else if (!strcmp(level_name, "debug")) {
+		return DEBUG_LEVEL;
+	} else {
+		nexitf("No such log level %s", level_name);
+	}
+}
 
 /* strlen("1997-03-25T13:20:42.999999999+01:00 stdout ") + 1 */
 #define TSBUFLEN 44
@@ -1585,7 +1634,7 @@ int main(int argc, char *argv[])
 	}
 
 	container_pid = atoi(contents);
-	ninfof("container PID: %d", container_pid);
+	ndebugf("container PID: %d", container_pid);
 
 	g_hash_table_insert (pid_to_handler, (pid_t *) &container_pid, container_exit_cb);
 

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -84,7 +84,7 @@ crio [GLOBAL OPTIONS] config [OPTIONS]
 
 **--log-format**="": Set the format used by logs ('text' (default), or 'json') (default: "text")
 
-**--log-level**="": log crio messages above specified level: debug, info (default), warn, error, fatal or panic
+**--log-level**="": log crio messages above specified level: debug, info, warn, error (default), fatal or panic
 
 **--log-size-max**="": Maximum log size in bytes for a container (default: -1 (no limit)). If it is positive, it must be >= 8192 (to match/exceed conmon read buffer).
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -84,6 +84,10 @@ Example:
   If it is positive, it must be >= 8192 (to match/exceed conmon read buffer).
   The file is truncated and re-opened so the limit is never exceeded.
 
+**log_level**=""
+  Changes the verbosity of the logs based on the level it is set to.
+  Options are fatal, panic, error (default), warn, info, and debug.
+
 **pids_limit**=""
   Maximum number of processes allowed in a container (default: 1024)
 
@@ -107,6 +111,10 @@ Example:
 
 **default_mounts**=[]
   List of mount points, in the form host:container, to be mounted in every container
+
+**read_only**==*true*|*false*
+  Run every container in read-only mode. Automatically mount tmpfs on `/run`, `/tmp` and `/var/tmp`.
+  Setup images to run in read-only. (default: false)
 
 ## CRIO.IMAGE TABLE
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -168,6 +168,10 @@ type RuntimeConfig struct {
 	// ManageNetworkNSLifecycle determines whether we pin and remove network namespace
 	// and manage its lifecycle
 	ManageNetworkNSLifecycle bool `toml:"manage_network_ns_lifecycle"`
+
+	// LogLevel determines the verbosity of the logs based on the level it is set to.
+	// Options are fatal, panic, error (default), warn, info, and debug.
+	LogLevel string `toml:"log_level"`
 }
 
 // ImageConfig represents the "crio.image" TOML config table.
@@ -295,6 +299,7 @@ func DefaultConfig() *Config {
 			ContainerExitsDir: containerExitsDir,
 			HooksDirPath:      DefaultHooksDirPath,
 			LogSizeMax:        DefaultLogSizeMax,
+			LogLevel:          "error",
 		},
 		ImageConfig: ImageConfig{
 			DefaultTransport:    defaultTransport,

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -183,6 +183,7 @@ func (r *Runtime) CreateContainer(c *Container, cgroupParent string) (err error)
 	args = append(args, "-l", c.logPath)
 	args = append(args, "--exit-dir", r.containerExitsDir)
 	args = append(args, "--socket-dir-path", ContainerAttachSocketDir)
+	args = append(args, "--log-level", logrus.GetLevel().String())
 	if r.logSizeMax >= 0 {
 		args = append(args, "--log-size-max", fmt.Sprintf("%v", r.logSizeMax))
 	}
@@ -443,6 +444,7 @@ func (r *Runtime) ExecSync(c *Container, command []string, timeout int64) (resp 
 	}
 	args = append(args, "-l", logPath)
 	args = append(args, "--socket-dir-path", ContainerAttachSocketDir)
+	args = append(args, "--log-level", logrus.GetLevel().String())
 
 	processFile, err := PrepareProcessExec(c, command, c.terminal)
 	if err != nil {

--- a/tutorial.md
+++ b/tutorial.md
@@ -155,6 +155,16 @@ Edit `/etc/crio/crio.conf` and verify that the registries option has valid value
 registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'docker.io']
 ```
 
+#### Optional - Modify verbosity of logs in /etc/crio/crio.conf
+
+Can modify the `log_level` field in `/etc/crio/crio.conf` to change the verbosity of
+the logs.
+Options are fatal, panic, error (default), warn, info, and debug.
+
+```
+log_level = "info"
+```
+
 #### Start the crio system daemon
 
 ```
@@ -163,7 +173,7 @@ Description=OCI-based implementation of Kubernetes Container Runtime Interface
 Documentation=https://github.com/kubernetes-incubator/cri-o
 
 [Service]
-ExecStart=/usr/local/bin/crio --log-level debug
+ExecStart=/usr/local/bin/crio
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
conmon now has a --log-level flag that changes
the verbosity of the logs based on the value it
is set to. From logrus, panic(0), fatal(1), error(2) tells
conmon to print all pexit and nexit logs (this
is the default). warn(3) adds the nwarn logs, info(4)
adds the ninfo logs, and finally debug(5) adds the ndebug
logs as well.

Adds a log_level field in the crio.conf that can have the
following options: panic, fatal, error, warn, info, and debug.
Changes default from info to error.

Signed-off-by: umohnani8 <umohnani@redhat.com>