### PR TITLE
oci: Define a minimal timeout for WaitContainerStateStopped()

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -193,6 +193,10 @@ uid_mappings = "{{ .UIDMappings }}"
 # ranges are separed by comma.
 gid_mappings = "{{ .GIDMappings }}"
 
+# ctr_stop_timeout specifies the time to wait before to generate an error
+# because the container state is still tagged as "running".
+ctr_stop_timeout = {{ .CtrStopTimeout }}
+
 [crio.image]
 
 # default_transport is the prefix we try prepending to an image name if the

--- a/lib/config.go
+++ b/lib/config.go
@@ -212,6 +212,10 @@ type RuntimeConfig struct {
 	// LogLevel determines the verbosity of the logs based on the level it is set to.
 	// Options are fatal, panic, error (default), warn, info, and debug.
 	LogLevel string `toml:"log_level"`
+
+	// CtrStopTimeout specifies the time to wait before to generate an
+	// error because the container state is still tagged as "running".
+	CtrStopTimeout int64 `toml:"ctr_stop_timeout"`
 }
 
 // ImageConfig represents the "crio.image" TOML config table.

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -129,7 +129,7 @@ func New(ctx context.Context, config *Config) (*ContainerServer, error) {
 		return nil, err
 	}
 
-	runtime, err := oci.New(config.Runtime, config.RuntimeUntrustedWorkload, config.DefaultWorkloadTrust, config.Conmon, config.ConmonEnv, config.CgroupManager, config.ContainerExitsDir, config.ContainerAttachSocketDir, config.LogSizeMax, config.NoPivot)
+	runtime, err := oci.New(config.Runtime, config.RuntimeUntrustedWorkload, config.DefaultWorkloadTrust, config.Conmon, config.ConmonEnv, config.CgroupManager, config.ContainerExitsDir, config.ContainerAttachSocketDir, config.LogSizeMax, config.NoPivot, config.CtrStopTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/stop.go
+++ b/lib/stop.go
@@ -25,7 +25,7 @@ func (c *ContainerServer) ContainerStop(ctx context.Context, container string, t
 			if err := c.runtime.StopContainer(ctx, ctr, timeout); err != nil {
 				return "", errors.Wrapf(err, "failed to stop container %s", ctrID)
 			}
-			if err := c.runtime.WaitContainerStateStopped(ctx, ctr, timeout); err != nil {
+			if err := c.runtime.WaitContainerStateStopped(ctx, ctr); err != nil {
 				return "", errors.Wrapf(err, "failed to get container 'stopped' status %s", ctrID)
 			}
 			if err := c.storageRuntimeServer.StopContainer(ctrID); err != nil {

--- a/lib/testdata/config.toml
+++ b/lib/testdata/config.toml
@@ -17,6 +17,7 @@
     hooks_dir_path = "/usr/share/containers/oci/hooks.d"
     pids_limit = 2048
     container_exits_dir = "/var/run/podman/exits"
+    ctr_stop_timeout = 10
   [crio.image]
     default_transport = "docker://"
     pause_image = "kubernetes/pause"

--- a/server/fixtures/crio.conf
+++ b/server/fixtures/crio.conf
@@ -22,6 +22,7 @@ seccomp_profile = "/etc/crio/seccomp.json"
 apparmor_profile = "crio-default"
 cgroup_manager = "cgroupfs"
 pids_limit = 1024
+ctr_stop_timeout = 10
 
 [crio.image]
 default_transport = "docker://"

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -53,7 +53,7 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 					// Assume container is already stopped
 					logrus.Warnf("failed to stop container %s: %v", c.Name(), err)
 				}
-				if err := s.Runtime().WaitContainerStateStopped(ctx, c, timeout); err != nil {
+				if err := s.Runtime().WaitContainerStateStopped(ctx, c); err != nil {
 					return nil, fmt.Errorf("failed to get container 'stopped' status %s in pod sandbox %s: %v", c.Name(), sb.ID(), err)
 				}
 			}

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -63,7 +63,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 			if err := s.Runtime().StopContainer(ctx, c, timeout); err != nil {
 				return nil, fmt.Errorf("failed to stop container %s in pod sandbox %s: %v", c.Name(), sb.ID(), err)
 			}
-			if err := s.Runtime().WaitContainerStateStopped(ctx, c, timeout); err != nil {
+			if err := s.Runtime().WaitContainerStateStopped(ctx, c); err != nil {
 				return nil, fmt.Errorf("failed to get container 'stopped' status %s in pod sandbox %s: %v", c.Name(), sb.ID(), err)
 			}
 			if err := s.StorageRuntimeServer().StopContainer(c.ID()); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {
@@ -82,7 +82,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 		if err := s.Runtime().StopContainer(ctx, podInfraContainer, timeout); err != nil {
 			return nil, fmt.Errorf("failed to stop infra container %s in pod sandbox %s: %v", podInfraContainer.Name(), sb.ID(), err)
 		}
-		if err := s.Runtime().WaitContainerStateStopped(ctx, podInfraContainer, timeout); err != nil {
+		if err := s.Runtime().WaitContainerStateStopped(ctx, podInfraContainer); err != nil {
 			return nil, fmt.Errorf("failed to get infra container 'stopped' status %s in pod sandbox %s: %v", podInfraContainer.Name(), sb.ID(), err)
 		}
 	}


### PR DESCRIPTION
A minimal timeout is required when waiting for the container
termination since runtimes like Kata Containers might take more
time than standard runc.

This commit introduces a minimal timeout value that will ensure
a proper amount of time will be waited before to issue a timeout.

Fixes #1695

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>