### PR TITLE
Remove "--log-level debug" from service file

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -162,7 +162,7 @@ Description=OCI-based implementation of Kubernetes Container Runtime Interface
 Documentation=https://github.com/kubernetes-incubator/cri-o
 
 [Service]
-ExecStart=/usr/local/bin/crio --log-level debug
+ExecStart=/usr/local/bin/crio
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
The tutorial shows how to create the crio service file
but it has --log-level debug, which is wrong. Should pick
up the log-level from the crio.conf file.

Signed-off-by: umohnani8 <umohnani@redhat.com>