### PR TITLE
oci: update privilege/trust handling

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -106,12 +106,6 @@ func (r *Runtime) Name() string {
 // this will return either the trusted or untrusted runtime path.
 func (r *Runtime) Path(c *Container) string {
 	if !c.trusted {
-		// We have an explicitly untrusted container.
-		if c.privileged {
-			logrus.Warnf("Running an untrusted but privileged container")
-			return r.trustedPath
-		}
-
 		if r.untrustedPath != "" {
 			return r.untrustedPath
 		}


### PR DESCRIPTION


**- What I did**

Submitted this PR which removes the "if priv" clause when we are handling a container which is marked with an untrusted annotation.

**- How I did it**

vi
:109
d6d
esc
:wq

**- How to verify it**

Started a k8s cluster with CRIO running with this patch applied.  Started a privileged and untrusted container and verified that it used my untrusted-runtime (kata).  Verified all of the VM's device nodes are available to the container.

**- Description for the changelog**

Prior to this patch, the trusted runtime (ie, runc) was used if the
 container was privileged, even if the workload was explicitly marked
 untrusted and an untrusted runtime (kata, for example) was provided.
    
This patch will follow the explicit annotation, since there are cases where
privileged container is desired with kata containers.
    
When the default trust level is untrusted, privileged containers will still 
make use of the default runtime unless the untrusted annotation is provided
for the workload. This is necessary to make sure core kube-system privileged
containers continue to function properly.

Fixes: #1662
