### PR TITLE
oci: update privilege/trust handling

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -109,12 +109,6 @@ func (r *Runtime) Name() string {
 // this will return either the trusted or untrusted runtime path.
 func (r *Runtime) Path(c *Container) string {
 	if !c.trusted {
-		// We have an explicitly untrusted container.
-		if c.privileged {
-			logrus.Warnf("Running an untrusted but privileged container")
-			return r.trustedPath
-		}
-
 		if r.untrustedPath != "" {
 			return r.untrustedPath
 		}


### PR DESCRIPTION
Prior to this patch, the trusted runtime (ie, runc) was used if the
container was privileged, even if the workload was explicitly marked
untrusted and an untrusted runtime (kata, for example) was provided.

This patch will follow the explicit annotation, since there are cases where
privileged container is desired with kata containers.

When the default trust level is untrusted, privileged containers will still
make use of the default runtime unless the untrusted annotation is provided
for the workload. This is necessary to make sure core kube-system privileged
containers continue to function properly.

Fixes: #1662

Signed-off-by: Eric Ernst <eric.ernst@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
