### PR TITLE
make key names plural in hooks configuration

### DIFF
--- a/lib/hooks.go
+++ b/lib/hooks.go
@@ -22,9 +22,9 @@ const (
 // HookParams is the structure returned from read the hooks configuration
 type HookParams struct {
 	Hook          string   `json:"hook"`
-	Stage         []string `json:"stage"`
-	Cmds          []string `json:"cmd"`
-	Annotations   []string `json:"annotation"`
+	Stages        []string `json:"stages"`
+	Cmds          []string `json:"cmds"`
+	Annotations   []string `json:"annotations"`
 	HasBindMounts bool     `json:"hasbindmounts"`
 	Arguments     []string `json:"arguments"`
 }
@@ -62,10 +62,10 @@ func readHook(hookPath string) (HookParams, error) {
 			return hook, errors.Wrapf(err, "invalid cmd regular expression %q defined in hook config %q", cmd, hookPath)
 		}
 	}
-	if len(hook.Stage) == 0 {
+	if len(hook.Stages) == 0 {
 		logrus.Warnf("No stage defined in hook config %q, hook will never run", hookPath)
 	} else {
-		for _, stage := range hook.Stage {
+		for _, stage := range hook.Stages {
 			if !validStage[stage] {
 				return hook, errors.Wrapf(err, "unknown stage %q defined in hook config %q", stage, hookPath)
 			}

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -242,7 +242,7 @@ func buildOCIProcessArgs(containerKubeConfig *pb.ContainerConfig, imageOCIConfig
 // addOCIHook look for hooks programs installed in hooksDirPath and add them to spec
 func addOCIHook(specgen *generate.Generator, hook lib.HookParams) error {
 	logrus.Debugf("AddOCIHook %s", hook.Hook)
-	for _, stage := range hook.Stage {
+	for _, stage := range hook.Stages {
 		h := rspec.Hook{
 			Path: hook.Hook,
 			Args: append([]string{hook.Hook}, hook.Arguments...),

--- a/test/hooks/checkhook.json
+++ b/test/hooks/checkhook.json
@@ -1,5 +1,5 @@
 {
-    "cmd" : [".*"],
+    "cmds" : [".*"],
     "hook" : "HOOKSDIR/checkhook.sh",
-    "stage" : [ "prestart" ]
+    "stages" : [ "prestart" ]
 }


### PR DESCRIPTION
**- What I did**
Renamed hook configuration keys: stage->stages, cmd->cmds,
annotation->annotations to be consistent with their description
in hooks.md

**- How I did it**
By changing keys and values in HookParams struct in lib/hooks.go

**- How to verify it**
Put plurals into the hook config and run workload.

**- Description for the changelog**
make key names plural in hooks configuration
