### PR TITLE
server/container_create: error out if capability is unknown

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -377,9 +377,7 @@ func setupCapabilities(specgen *generate.Generator, capabilities *pb.Capability)
 		capPrefixed := toCAPPrefixed(cap)
 		// Validate capability
 		if !inStringSlice(getOCICapabilitiesList(), capPrefixed) {
-			// invalid capability, logging and moving on to next capability in list.
-			logrus.Warnf("invalid capability %q, skipping...", cap)
-			continue
+			return fmt.Errorf("unknown capability %q to add", capPrefixed)
 		}
 		if err := specgen.AddProcessCapabilityBounding(capPrefixed); err != nil {
 			return err


### PR DESCRIPTION
We were just logging the fact that the capability provided by kube was
invalid. We need to error out (according to this bz as well
https://bugzilla.redhat.com/show_bug.cgi?id=1608814). I'm going to add
a test in the critest suite, not here as the capability is coming from
the kube pod definition.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
