### PR TITLE
[1.10] Use release-1.11 branch of k8s for e2e tests

### DIFF
--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -118,7 +118,7 @@
       include: "build/kubernetes.yml"
       vars:
           force_clone: True
-          k8s_git_version: "release-1.10"
+          k8s_git_version: "release-1.11"
           k8s_github_fork: "kubernetes"
           crio_socket: "/var/run/crio/crio.sock"
     - name: run k8s e2e tests


### PR DESCRIPTION
The e2e RHEL test is very flaky on the release 1.10 branch.
using k8s release 1.11 branch instead.

Signed-off-by: umohnani8 <umohnani@redhat.com>