### PR TITLE
test: Update to k8s release-1.11 for e2e tests

### DIFF
--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -118,7 +118,7 @@
       include: "build/kubernetes.yml"
       vars:
           force_clone: True
-          k8s_git_version: "release-1.10"
+          k8s_git_version: "release-1.11"
           k8s_github_fork: "kubernetes"
           crio_socket: "/var/run/crio/crio.sock"
     - name: run k8s e2e tests


### PR DESCRIPTION
release-1.11 should work with crio 1.10 and help with the flak

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

