### PR TITLE
[1.11] container_create: Set a minimum memory limit

### DIFF
--- a/test/testdata/container_config.json
+++ b/test/testdata/container_config.json
@@ -47,7 +47,8 @@
 			"cpu_period": 10000,
 			"cpu_quota": 20000,
 			"cpu_shares": 512,
-			"oom_score_adj": 30
+			"oom_score_adj": 30,
+			"memory_limit_in_bytes": 268435456
 		},
 		"security_context": {
 			"namespace_options": {

--- a/test/testdata/container_config_by_imageid.json
+++ b/test/testdata/container_config_by_imageid.json
@@ -48,7 +48,8 @@
 			"cpu_period": 10000,
 			"cpu_quota": 20000,
 			"cpu_shares": 512,
-			"oom_score_adj": 30
+			"oom_score_adj": 30,
+			"memory_limit_in_bytes": 268435456
 		},
 		"security_context": {
 			"namespace_options": {

--- a/test/testdata/container_config_hostport.json
+++ b/test/testdata/container_config_hostport.json
@@ -50,7 +50,8 @@
 			"cpu_period": 10000,
 			"cpu_quota": 20000,
 			"cpu_shares": 512,
-			"oom_score_adj": 30
+			"oom_score_adj": 30,
+			"memory_limit_in_bytes": 268435456
 		},
 		"security_context": {
 			"namespace_options": {

--- a/test/testdata/container_config_logging.json
+++ b/test/testdata/container_config_logging.json
@@ -50,7 +50,8 @@
 			"cpu_period": 10000,
 			"cpu_quota": 20000,
 			"cpu_shares": 512,
-			"oom_score_adj": 30
+			"oom_score_adj": 30,
+			"memory_limit_in_bytes": 268435456
 		},
 		"security_context": {
 			"namespace_options": {

--- a/test/testdata/container_config_resolvconf.json
+++ b/test/testdata/container_config_resolvconf.json
@@ -49,7 +49,8 @@
 			"cpu_period": 10000,
 			"cpu_quota": 20000,
 			"cpu_shares": 512,
-			"oom_score_adj": 30
+			"oom_score_adj": 30,
+			"memory_limit_in_bytes": 268435456
 		},
 		"security_context": {
 			"namespace_options": {

--- a/test/testdata/container_config_resolvconf_ro.json
+++ b/test/testdata/container_config_resolvconf_ro.json
@@ -49,7 +49,8 @@
 			"cpu_period": 10000,
 			"cpu_quota": 20000,
 			"cpu_shares": 512,
-			"oom_score_adj": 30
+			"oom_score_adj": 30,
+			"memory_limit_in_bytes": 268435456
 		},
 		"security_context": {
 			"namespace_options": {

--- a/test/testdata/container_config_seccomp.json
+++ b/test/testdata/container_config_seccomp.json
@@ -48,7 +48,8 @@
 			"cpu_period": 10000,
 			"cpu_quota": 20000,
 			"cpu_shares": 512,
-			"oom_score_adj": 30
+			"oom_score_adj": 30,
+			"memory_limit_in_bytes": 268435456
 		},
 		"security_context": {
 			"namespace_options": {

--- a/test/testdata/container_config_sleep.json
+++ b/test/testdata/container_config_sleep.json
@@ -48,7 +48,8 @@
 			"cpu_period": 10000,
 			"cpu_quota": 20000,
 			"cpu_shares": 512,
-			"oom_score_adj": 30
+			"oom_score_adj": 30,
+			"memory_limit_in_bytes": 268435456
 		},
 		"security_context": {
 			"namespace_options": {

--- a/test/testdata/container_redis_default_mounts.json
+++ b/test/testdata/container_redis_default_mounts.json
@@ -54,7 +54,8 @@
 			"cpu_period": 10000,
 			"cpu_quota": 20000,
 			"cpu_shares": 512,
-			"oom_score_adj": 30
+			"oom_score_adj": 30,
+			"memory_limit_in_bytes": 268435456
 		},
 		"security_context": {
 			"namespace_options": {

--- a/test/testdata/container_redis_device.json
+++ b/test/testdata/container_redis_device.json
@@ -55,7 +55,8 @@
 			"cpu_period": 10000,
 			"cpu_quota": 20000,
 			"cpu_shares": 512,
-			"oom_score_adj": 30
+			"oom_score_adj": 30,
+			"memory_limit_in_bytes": 268435456
 		},
 		"security_context": {
 			"namespace_options": {

--- a/test/testdata/container_sleep.json
+++ b/test/testdata/container_sleep.json
@@ -36,7 +36,8 @@
 			"cpu_period": 10000,
 			"cpu_quota": 20000,
 			"cpu_shares": 512,
-			"oom_score_adj": 30
+			"oom_score_adj": 30,
+			"memory_limit_in_bytes": 268435456
 		}
 	}
 }

--- a/test/testdata/template_container_config.json
+++ b/test/testdata/template_container_config.json
@@ -45,7 +45,8 @@
 			"cpu_period": 10000,
 			"cpu_quota": 20000,
 			"cpu_shares": 512,
-			"oom_score_adj": 30
+			"oom_score_adj": 30,
+			"memory_limit_in_bytes": 268435456
 		},
 		"security_context": {
 			"readonly_rootfs": false,


### PR DESCRIPTION
We set a minimum limit of 4MB. Lower values could result
in container failing to start.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

