### PR TITLE
conmon: fix segfault when --log-level is not specified

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -237,6 +237,8 @@ typedef enum {
 /* Parse_level parses the string value of the --log_level flag to its matching enum */
 static log_level_t parse_level(char *level_name)
 {
+	if (level_name == NULL)
+		return WARN_LEVEL;
 	if (!strcmp(level_name, "error") || !strcmp(level_name, "fatal") || !strcmp(level_name, "panic")) {
 		return EXIT_LEVEL;
 	} else if (!strcmp(level_name, "warn") || !strcmp(level_name, "warning")) {


### PR DESCRIPTION
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

fix crash in conmon

**- How I did it**

add a check when --log-level is not specified

**- How to verify it**

conmon without --log-level works as before
