### PR TITLE
network name is required in cni/99-loopback.conf

### DIFF
--- a/contrib/cni/99-loopback.conf
+++ b/contrib/cni/99-loopback.conf
@@ -1,4 +1,5 @@
 {
     "cniVersion": "0.3.0",
+    "name": "lo",
     "type": "loopback"
 }

--- a/tutorial.md
+++ b/tutorial.md
@@ -284,6 +284,7 @@ EOF'
 sudo sh -c 'cat >/etc/cni/net.d/99-loopback.conf <<-EOF
 {
     "cniVersion": "0.2.0",
+    "name": "lo",
     "type": "loopback"
 }
 EOF'


### PR DESCRIPTION
When ip netns add, the network name is required.
Please refer to https://github.com/containernetworking/cni#576