### PR TITLE
Image Volumes should be bind mounted as private

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -159,7 +159,8 @@ func addImageVolumes(rootfs string, s *Server, containerInfo *storage.ContainerI
 			mounts = append(mounts, rspec.Mount{
 				Source:      src,
 				Destination: dest,
-				Options:     []string{"rw"},
+				Type:        "bind",
+				Options:     []string{"private", "bind", "rw"},
 			})
 
 		case lib.ImageVolumesIgnore:


### PR DESCRIPTION
We found an issue with mounting of user images inside of a
Image Volume.  The mount point was leaked to the host, since
the default for mountpoint is shared, this can cause container
cleanup to fail.  We should default to private.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
