### PR TITLE
cherry-pick commit 73b6901403 ("Fix AppArmor build")

### DIFF
--- a/pkg/apparmor/apparmor_supported.go
+++ b/pkg/apparmor/apparmor_supported.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"path"
 	"strings"
+	"text/template"
 
-	"github.com/docker/docker/pkg/templates"
 	"github.com/opencontainers/runc/libcontainer/apparmor"
 )
 
@@ -108,7 +108,7 @@ func IsLoaded(name string) (bool, error) {
 
 // generateDefault creates an apparmor profile from ProfileData.
 func (p *profileData) generateDefault(out io.Writer) error {
-	compiled, err := templates.NewParse("apparmor_profile", baseTemplate)
+	compiled, err := template.New("apparmor_profile").Parse(baseTemplate)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix AppArmor builds by using text/template as the previously referenced
on from docker/docker doesn't exist.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>