### PR TITLE
server: ignore server closed error

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -386,7 +386,7 @@ func New(ctx context.Context, config *Config) (*Server, error) {
 	s.stream.streamServerCloseCh = make(chan struct{})
 	go func() {
 		defer close(s.stream.streamServerCloseCh)
-		if err := s.stream.streamServer.Start(true); err != nil {
+		if err := s.stream.streamServer.Start(true); err != nil && err != http.ErrServerClosed {
 			logrus.Errorf("Failed to start streaming server: %v", err)
 		}
 	}()


### PR DESCRIPTION
no harm in ignoring this error, it comes from the underlying kube
stream server and we have no power on it as we don't own the listener
(containerd/cri also ignores it)

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
