### PR TITLE
Add jq package needed for artifacts processing

### DIFF
--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -54,6 +54,10 @@
   post_tasks:
     - name: Swap is disused and disabled as required for kubernetes
       include: "disable_swap.yml"
+    - name: The docker daemon is NOT running during testing
+      systemd:
+        name: docker
+        state: stopped
 
 - hosts: all
   remote_user: root
@@ -118,3 +122,16 @@
           crio_socket: "/var/run/crio/crio.sock"
     - name: run k8s e2e tests
       include: e2e.yml
+
+# N/B: This is done after all testing, so it doesn't get in the way.
+- hosts: all
+  remote_user: root
+  vars_files:
+    - "{{ playbook_dir }}/vars.yml"
+  tags:
+    - always
+  tasks:
+    - name: The docker daemon must be running to post GCE results
+      systemd:
+        name: docker
+        state: started

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -54,10 +54,6 @@
   post_tasks:
     - name: Swap is disused and disabled as required for kubernetes
       include: "disable_swap.yml"
-    - name: The docker daemon is NOT running during testing
-      systemd:
-        name: docker
-        state: stopped
 
 - hosts: all
   remote_user: root
@@ -131,7 +127,4 @@
   tags:
     - always
   tasks:
-    - name: The docker daemon must be running to post GCE results
-      systemd:
-        name: docker
-        state: started
+    - include: results.yml

--- a/contrib/test/integration/results.yml
+++ b/contrib/test/integration/results.yml
@@ -1,62 +1,19 @@
 ---
 # vim-syntax: ansible
 
-- hosts: '{{ hosts | default("all") }}'
-  vars_files:
-    - "{{ playbook_dir }}/vars.yml"
-  vars:
-    _result_filepaths: []  # do not use
-    _dstfnbuff: []  # do not use
-  tasks:
-    - name: The crio_integration_filepath is required
-      tags:
-          - integration
-      set_fact:
-       _result_filepaths: "{{ _result_filepaths + [crio_integration_filepath] }}"
+- name: Enable EPEL repository for 'jq' on RHEL/CentOS
+  package:
+    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    state: present
+  when: ansible_distribution in ['RedHat', 'CentOS']
 
-    - name: The crio_node_e2e_filepath is required
-      tags:
-          - e2e
-      set_fact:
-       _result_filepaths: "{{ _result_filepaths + [crio_node_e2e_filepath] }}"
+- name: Docker and jq are required for uploading results
+  package:
+    name: "docker,jq"
+    state: present
 
-    - name: Verify expectations
-      assert:
-        that:
-          - 'result_dest_basedir | default(False, True)'
-          - '_result_filepaths | default(False, True)'
-          - '_dstfnbuff == []'
-          - 'results_fetched is undefined'
+- name: The docker daemon is running for result uploading container use
+  systemd:
+    name: docker
+    state: started
 
-    - name: Results directory exists
-      file:
-          path: "{{ result_dest_basedir }}"
-          state: directory
-      delegate_to: localhost
-
-    - name: destination file paths are buffered for overwrite-checking and jUnit conversion
-      set_fact:
-          _dstfnbuff: >
-              {{ _dstfnbuff |
-                 union( [result_dest_basedir ~ "/" ~ inventory_hostname ~ "/" ~ item | basename] ) }}
-      with_items: '{{ _result_filepaths }}'
-
-    - name: Overwriting existing results assumed very very bad
-      fail:
-          msg: "Cowardly refusing to overwrite {{ item }}"
-      when: item | exists
-      delegate_to: localhost
-      with_items: '{{ _dstfnbuff }}'
-
-    # fetch module doesn't support directories
-    - name: Retrieve results from all hosts
-      synchronize:
-          checksum: True  # Don't rely on date/time being in sync
-          archive: False  # Don't bother with permissions or times
-          copy_links: True  # We want files, not links to files
-          recursive: True
-          mode: pull
-          dest: '{{ result_dest_basedir }}/{{ inventory_hostname }}/'  # must end in /
-          src: '{{ item }}'
-      register: results_fetched
-      with_items: '{{ _result_filepaths }}'

--- a/contrib/test/integration/system.yml
+++ b/contrib/test/integration/system.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: Enable EPEL repository for 'jq' on RHEL/CentOS
+  package:
+    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    state: present
+  when: ansible_distribution in ['RedHat', 'CentOS']
+
 - name: Make sure we have all required packages
   package:
     name: "{{ item }}"
@@ -20,6 +26,7 @@
     - hostname
     - iproute
     - iptables
+    - jq
     - krb5-workstation
     - libassuan-devel
     - libffi-devel

--- a/contrib/test/integration/system.yml
+++ b/contrib/test/integration/system.yml
@@ -15,6 +15,7 @@
     - container-selinux
     - curl
     - device-mapper-devel
+    - docker
     - expect
     - findutils
     - gcc

--- a/contrib/test/integration/system.yml
+++ b/contrib/test/integration/system.yml
@@ -1,11 +1,5 @@
 ---
 
-- name: Enable EPEL repository for 'jq' on RHEL/CentOS
-  package:
-    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    state: present
-  when: ansible_distribution in ['RedHat', 'CentOS']
-
 - name: Make sure we have all required packages
   package:
     name: "{{ item }}"
@@ -15,7 +9,6 @@
     - container-selinux
     - curl
     - device-mapper-devel
-    - docker
     - expect
     - findutils
     - gcc
@@ -27,7 +20,6 @@
     - hostname
     - iproute
     - iptables
-    - jq
     - krb5-workstation
     - libassuan-devel
     - libffi-devel


### PR DESCRIPTION
**- What I did**

Add 'jq' package.

**- How I did it**

Added it here so it gets built into the AMI's as per @stevekuznetsov 

>  runcom, mrunalp, cevich looks like you need `jq` on your AMIs to push the artifacts

**- How to verify it**

With ``/test ami`` (regular tests won't do it), then check Origin CI logs for error posting to GCE.