### PR TITLE
Fix manpage to correctly state default storage driver

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -122,7 +122,7 @@ crio [GLOBAL OPTIONS] config [OPTIONS]
 
 **--signature-policy**="": Path to the signature policy json file (default: "", to use the system-wide default)
 
-**--storage-driver**: OCI storage driver (default: "devicemapper")
+**--storage-driver**: OCI storage driver (default: "overlay")
 
 **--storage-opt**: OCI storage driver option (no default)
 


### PR DESCRIPTION
Signed-off-by: Klaas Demter <Klaas-@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
change default storage driver to point to correct driver

**- How I did it**
simple doc change

**- How to verify it**
check diff

**- Description for the changelog**
fix manpage to point to correct default storage driver
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
